### PR TITLE
Switch to CMSSW_10_2_X (C++17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # KLUBAnalysis
 
-repo for the h->tautau/h->hh analysis within the LLR framework
+Repo for the h->hh->bbtautau analysis within the LLR framework
 
-## Instructions for 2018 Analysis 
+## Instructions for Run2 Legacy Analysis
 ```
-cmsrel CMSSW_9_0_0
-cd CMSSW_9_0_0/src
+cmsrel CMSSW_10_2_16
+cd CMSSW_10_2_16/src
 cmsenv
 
 git clone https://github.com/bvormwald/HHKinFit2
 git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
 cd HiggsAnalysis/CombinedLimit
-git checkout 94x
+git checkout v8.0.1
 cd -
 
 scram b -j8
@@ -23,17 +23,15 @@ source setup.sh
 ./compile.sh
 cd ..
 
-git clone git@github.com:francescobrivio/KLUBAnalysis.git
+git clone git@github.com:LLRCMS/KLUBAnalysis.git
 cd KLUBAnalysis
-git checkout VBF2018_mib
+git checkout VBF_legacy
 
-mkdir interface/exceptions
 cd interface/exceptions
 ln -ns ../../../HHKinFit2/interface/exceptions/HHInvMConstraintException.h
 ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyRangeException.h
 ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyConstraintException.h
 cd -
-
 
 source scripts/setup.sh
 make
@@ -159,6 +157,15 @@ make exe
 ```
 </details>
 
++## How To
+Please refer to:
+```
+https://codimd.web.cern.ch/s/HJM-lQ2AX#
+```
+
+### (Old) How To:
+<details>
+
 ## SyncNtupleProducer
 Specify the options (channels, samples, etc.), in:
 ```
@@ -262,3 +269,4 @@ The MVA info is then added to the SKIM tree with:
 ```
 ./bin/addTMVA.exe config/addTMVA.cfg 
 ```
+</details>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KLUBAnalysis
 
-Repo for the h->hh->bbtautau analysis within the LLR framework
+Repo for the hh->bbtautau analysis within the LLR framework
 
 ## Instructions for Run2 Legacy Analysis
 ```
@@ -157,7 +157,7 @@ make exe
 ```
 </details>
 
-+## How To
+## How To
 Please refer to:
 ```
 https://codimd.web.cern.ch/s/HJM-lQ2AX#

--- a/interface/ConfigFileLine.h
+++ b/interface/ConfigFileLine.h
@@ -13,13 +13,13 @@
 #include <string>
 #include <list>
 
-using namespace std;
+//using namespace std;
 
 class ConfigFileLine {
  public:
 
   //! Constructor with name of the option and a single option value (no list!)
-  ConfigFileLine(const string &option, const string &value="");
+  ConfigFileLine(const std::string &option, const std::string &value="");
 
   //! Destructor: Does currently nothing
   virtual ~ConfigFileLine();
@@ -31,7 +31,7 @@ class ConfigFileLine {
   void appendList(const ConfigFileLine &other);
 
   //! Check whether name of option is "name"
-  bool isOption(const string &name) const{
+  bool isOption(const std::string &name) const{
     return name==option;
   }
 
@@ -41,38 +41,38 @@ class ConfigFileLine {
   }
 
   //! Return the list of configuration values
-  list<string> getValues() const{
+  std::list<std::string> getValues() const{
     // This operation is somewhat time-consuming!
     return values;
   }
 
   //! Sets the list of configuration values
-  void setValues(const list<string> &v){
+  void setValues(const std::list<std::string> &v){
     values=v;
   }
 
   //! Get option name
-  const string &getOptionName() const{
+  const std::string &getOptionName() const{
     return option;
   }
 
   //! Sets the scope by prepending "scope":: to the option name
-  void setScope(const string &scope);
+  void setScope(const std::string &scope);
   
   //! Print the contents of the rule to stdout
   void print() const;
 
   //! stream operator
-  friend ostream & operator<< (ostream & out, const ConfigFileLine & line) ;
+  friend std::ostream & operator<< (std::ostream & out, const ConfigFileLine & line) ;
 
  private:
 
-  string option;                //!< The name of the option
-  list<string> values;     //!< The list of option values
+  std::string option;                //!< The name of the option
+  std::list<std::string> values;     //!< The list of option values
 
   //! For convinience a ValueIterator type is defined which walks along
   //! the list of option strings
-  typedef list<string>::const_iterator ValueIterator;
+  typedef std::list<std::string>::const_iterator ValueIterator;
 
 };
 

--- a/interface/ConfigParser.h
+++ b/interface/ConfigParser.h
@@ -18,7 +18,7 @@
 #include <stdexcept>
 #include <vector>
 
-using namespace std;
+//using namespace std;
 
 class ConfigParser {
  public:
@@ -44,55 +44,52 @@ class ConfigParser {
   bool deleteLine(const char *name, const char *scope=0);
 
   // Override an option
-  bool overrideOption(const char *name, list<string> &values,
+  bool overrideOption(const char *name, std::list<std::string> &values,
 		      const char *scope = 0);
 
   // Is this option defined?
   bool isDefined(const char *name) const;
 
   // Read Integer Option
-  int readIntOption(const char *name) const throw(const char *);
+  int readIntOption(const char *name);
 
   // Read Double Option
-  double readDoubleOption(const char *name) const throw(const char *);
+  double readDoubleOption(const char *name);
 
   // Read Float Option
-  float readFloatOption(const char *name) const throw(const char *);
+  float readFloatOption(const char *name);
 
   // Read bool Option
-  const bool readBoolOption(const char *name) const throw(const char *);
+  const bool readBoolOption(const char *name);
   
   // Read Integer Option
-  const char *readStringOption(const char *name) const throw(const char *);
+  const char *readStringOption(const char *name);
   
   // Read Integer List Option
-  vector<int> readIntListOption(const char *name) const throw(const char *);
+  std::vector<int> readIntListOption(const char *name);
 
   // Read Double List Option
-  vector<double> readDoubleListOption(const char *name) 
-    const throw(const char *);
+  std::vector<double> readDoubleListOption(const char *name);
 
   // Read Double List Option
-  vector<float> readFloatListOption(const char *name) 
-    const throw(const char *);
+  std::vector<float> readFloatListOption(const char *name);
   
   // Read String List Option
-  vector<string> readStringListOption(const char *name)
-    const throw(const char *);
+  std::vector<std::string> readStringListOption(const char *name);
 
   // Print all options
   void print() const;
 
   //! stream operator
-  friend ostream & operator<< (ostream & out, const ConfigParser & conf) ;
+  friend std::ostream & operator<< (std::ostream & out, const ConfigParser & conf) ;
 
  private:
 
-  list<ConfigFileLine *> configLines; //!< A list of configuration file lines
+  std::list<ConfigFileLine *> configLines; //!< A list of configuration file lines
   
   //! For convinience a ValueIterator type is defined which walks along
   //! the list of option strings
-  typedef list<ConfigFileLine *>::const_iterator LineIterator;
+  typedef std::list<ConfigFileLine *>::const_iterator LineIterator;
 
 };
 

--- a/interface/analysisUtils.h
+++ b/interface/analysisUtils.h
@@ -29,8 +29,8 @@
 #include "plotContainer.h"
 
 
-vector<pair <TString, TCut> > 
-addSelection (vector<pair <TString, TCut> > m_cuts, string cut, string tag) ;
+std::vector<std::pair <TString, TCut> >
+addSelection (std::vector<std::pair <TString, TCut> > m_cuts, std::string cut, std::string tag) ;
 
 std::pair<int, int> leptonsType (int pairType) ;
 /*
@@ -42,32 +42,32 @@ true = is isolated
 bool isIsolated (int leptonType, float threshold, float isoDeposits, float pT) ; 
 
 void
-addHistos (vector<sample> & samples, HistoManager * manager,
-           vector<string> & variablesList,
-           vector<pair <TString, TCut> > & selections,
+addHistos (std::vector<mysample> & samples, HistoManager * manager,
+           std::vector<std::string> & variablesList,
+           std::vector<std::pair <TString, TCut> > & selections,
            bool isSignal,
            bool isData = false) ;
 
 // implicitly empty 2D list is used --> no 2D filling
 counters
-fillHistos (vector<sample> & samples, 
+fillHistos (std::vector<mysample> & samples,
             plotContainer & plots,
-            vector<string> & variablesList,
-            vector<pair <TString, TCut> > & selections,
+            std::vector<std::string> & variablesList,
+            std::vector<std::pair <TString, TCut> > & selections,
             float lumi,
-            const vector<float> & scale,
+            const std::vector<float> & scale,
             bool isData = false,
             bool isSignal = false,
             int maxEvts = -1, TFile* fOut = 0) ;
 
 counters
-fillHistos (vector<sample> & samples, 
+fillHistos (std::vector<mysample> & samples,
             plotContainer & plots,
-            vector<string> & variablesList,
-            vector<pair<string,string>> & variables2DList,
-            vector<pair <TString, TCut> > & selections,
+            std::vector<std::string> & variablesList,
+            std::vector<std::pair<std::string,std::string>> & variables2DList,
+            std::vector<std::pair <TString, TCut> > & selections,
             float lumi,
-            const vector<float> & scale,
+            const std::vector<float> & scale,
             bool isData = false,
             bool isSignal = false,
             int maxEvts = -1, TFile* fOut = 0) ;
@@ -76,17 +76,17 @@ fillHistos (vector<sample> & samples,
 //counters
 //makeCounter (plotContainer & plots, float initEff = 1.0, float initTotNum = 0.0) ; 
 
-vector<THStack *> 
-stackHistos (vector<sample> & samples, HistoManager * manager, 
-            vector<string> & variablesList,
-            vector<pair <TString, TCut> > & selections,
-            const string & tag) ;
+std::vector<THStack *>
+stackHistos (std::vector<mysample> & samples, HistoManager * manager,
+            std::vector<std::string> & variablesList,
+            std::vector<std::pair <TString, TCut> > & selections,
+            const std::string & tag) ;
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 // utilities to draw data/background plot + legend + ratioplot, return vector of ROOT objects allocated on the heap
 std::vector<TObject*> makeStackPlot (plotContainer& dataPlots, plotContainer& bkgPlots, plotContainer& sigPlots,
-                                      string varName, string selName,
-                                      TCanvas* canvas, std::vector <pair <string, string> > & addInLegend, std::vector <pair <string, string> >& axisTitles,
+                                      std::string varName, std::string selName,
+                                      TCanvas* canvas, std::vector <std::pair <std::string, std::string> > & addInLegend, std::vector <std::pair <std::string, std::string> >& axisTitles,
                                       bool LogY = false, bool makeRatioPlot = true, bool drawLegend = true, bool doShapes = false, bool forceNonNegMin = false, bool drawGrassForData = false,
                                       bool drawSignal = true, bool drawData = true, bool drawMC = true) ;
 

--- a/interface/histoUtils.h
+++ b/interface/histoUtils.h
@@ -27,7 +27,7 @@
 #include "HistoManager.h"
 #include "plotContainer.h"
 
-using namespace std ;
+//using namespace std ;
 
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----                                                                                                
 
@@ -72,7 +72,7 @@ void copyTitles (TH1F * histogram, THStack * hstack) ;
 float findNonNullMinimum (TH1F * histo) ;
 
 //mirror an histogram h1 wrt to h2
-TH1F* mirrorHistogram(string name, TH1F* h1, TH1F*h2) ;
+TH1F* mirrorHistogram(std::string name, TH1F* h1, TH1F*h2) ;
 
 // re-roll unrolled 2D distributions and return a TH2F.                                                                                                                    
 // templated on RooFit objects, works for RooHist and RooCurve,                                                                                                                 
@@ -90,7 +90,7 @@ TH2F * roll ( T * original,    // thing to be re-rolled
    
   if (nBinsY * nBinsX != nBinsOriginal)
     {
-      cerr << " problems in number of bins" << endl ;
+      std::cerr << " problems in number of bins" << std::endl ;
       exit (1) ;
     }
   TString name = "roll_" ;
@@ -111,8 +111,8 @@ TH2F * roll ( T * original,    // thing to be re-rolled
 }
  
 // xmin ymin xmax ymax
-vector<float> getExtremes (THStack * hstack, bool islog = false, bool nostack = false) ;
-vector<float> getExtremes (std::vector<TH1F*>& histos, bool islog = false) ;
+std::vector<float> getExtremes (THStack * hstack, bool islog = false, bool nostack = false) ;
+std::vector<float> getExtremes (std::vector<TH1F*>& histos, bool islog = false) ;
 
 float min3 (float uno, float due, float tre) ;
 float max3 (float uno, float due, float tre) ;

--- a/interface/plotContainer.h
+++ b/interface/plotContainer.h
@@ -25,59 +25,59 @@
 #include "histoUtils.h"
 #include "ConfigParser.h"
 
-typedef map<string, TH1F *> samples_coll ;
-typedef map<string, samples_coll > cuts_coll ;
-typedef map<string, cuts_coll > vars_coll ;
+typedef std::map<std::string, TH1F *> samples_coll ;
+typedef std::map<std::string, samples_coll > cuts_coll ;
+typedef std::map<std::string, cuts_coll > vars_coll ;
 
-typedef map<string, TH2F *> samples_2D_coll ;
-typedef map<string, samples_2D_coll > cuts_2D_coll ;
-typedef map<string, cuts_2D_coll > vars_2D_coll ;
+typedef std::map<std::string, TH2F *> samples_2D_coll ;
+typedef std::map<std::string, samples_2D_coll > cuts_2D_coll ;
+typedef std::map<std::string, cuts_2D_coll > vars_2D_coll ;
 
 struct plotContainer 
 {
-  plotContainer (string name) ;
-  plotContainer (string name, vector<string> varList,
-                 vector<pair <TString, TCut> > cutList, vector<string> sampleList, int histosType) ;  
-  plotContainer (string name, vector<string> varList, vector<pair<string,string>> varList2D,
-                 vector<pair <TString, TCut> > cutList, vector<string> sampleList, int histosType) ;
+  plotContainer (std::string name) ;
+  plotContainer (std::string name, std::vector<std::string> varList,
+                 std::vector<std::pair <TString, TCut> > cutList, std::vector<std::string> sampleList, int histosType) ;
+  plotContainer (std::string name, std::vector<std::string> varList, std::vector<std::pair<std::string,std::string>> varList2D,
+                 std::vector<std::pair <TString, TCut> > cutList, std::vector<std::string> sampleList, int histosType) ;
 
-  void init (vector<string> varList, vector<pair <TString, TCut> > cutList, 
-             vector<string> sampleList, int histosType) ;
-  void MergeHistograms(vector<string> mergesampleList, TString mergedName);
-  void createHistos (vector<string> varList, vector<pair<string,string>> varList2D,
-                     vector<pair <TString, TCut> > cutList, vector<string> sampleList) ;      
+  void init (std::vector<std::string> varList, std::vector<std::pair <TString, TCut> > cutList,
+             std::vector<std::string> sampleList, int histosType) ;
+  void MergeHistograms(std::vector<std::string> mergesampleList, TString mergedName);
+  void createHistos (std::vector<std::string> varList, std::vector<std::pair<std::string,std::string>> varList2D,
+                     std::vector<std::pair <TString, TCut> > cutList, std::vector<std::string> sampleList) ;
   
   //int addHisto (string varName, string cutName, string sampleName) ; // not implemented yet
-  int addSample (string sampleName, const plotContainer & original) ;
-  TH1F * getHisto (string varName, string cutName, string sampleName) ;
-  TH2F * get2DHisto (string var1Name, string var2Name, string cutName, string sampleName) ;
-  map<string, TH1F *> & getStackSet (string varName, string cutName) ;
-  THStack * makeStack (string varName, string cutName) ;
-  THStack * make2DStack (pair <string,string> var2DName, string cutName) ;
+  int addSample (std::string sampleName, const plotContainer & original) ;
+  TH1F * getHisto (std::string varName, std::string cutName, std::string sampleName) ;
+  TH2F * get2DHisto (std::string var1Name, std::string var2Name, std::string cutName, std::string sampleName) ;
+  std::map<std::string, TH1F *> & getStackSet (std::string varName, std::string cutName) ;
+  THStack * makeStack (std::string varName, std::string cutName) ;
+  THStack * make2DStack (std::pair <std::string,std::string> var2DName, std::string cutName) ;
   void AddOverAndUnderFlow () ;
-  TH1F * createNewHisto (string name, string title, 
+  TH1F * createNewHisto (std::string name, std::string title,
                          int nbinsx, double xlow, double xup,
                          int color, int histoType,
                          TString titleX, TString titleY) ;
-  TH1F * createNewHisto (string name, string title, 
+  TH1F * createNewHisto (std::string name, std::string title,
                          int nbinsx, float binning [],
                          int color, int histoType,
                          TString titleX, TString titleY) ;
-  TH2F * createNew2DHisto (string name, string title, 
+  TH2F * createNew2DHisto (std::string name, std::string title,
                          int nbinsx, double xlow, double xup,
                          int nbinsy, double ylow, double yup,
                          int color, int histoType,
                          TString titleX, TString titleY) ;
   void scale (float scaleFactor) ;
-  void scale (vector<string> & variablesList, vector<pair <TString, TCut> > & selections, vector<vector<float>> scaleFactorVector) ;
-  void scale2D (vector<pair<string,string>> & variables2DList, vector<pair <TString, TCut> > & selections, vector<vector<float>> scaleFactorVector) ;
+  void scale (std::vector<std::string> & variablesList, std::vector<std::pair <TString, TCut> > & selections, std::vector<std::vector<float>> scaleFactorVector) ;
+  void scale2D (std::vector<std::pair<std::string,std::string>> & variables2DList, std::vector<std::pair <TString, TCut> > & selections, std::vector<std::vector<float>> scaleFactorVector) ;
 
   void setFillColor (int color) ;
   void save (TFile * fOut) ;
   void setHistosProperties (TH1 * h, int histoType, int color) ;
   void setHistosProperties (int histoType, int color) ;
 
-  string m_name ;
+  std::string m_name ;
   unsigned int m_Nvar ;    // 1D plots
   unsigned int m_N2Dvar ;  // 2D plots ("2D variable")
   unsigned int m_Ncut ;    // same for 1D and 2D

--- a/interface/utils.h
+++ b/interface/utils.h
@@ -30,12 +30,12 @@
 #include "TObject.h"
 #include "plotContainer.h"
 
-struct sample
+struct mysample
 {
-  sample (TString sampleName,
-          TString theSampleFileName, 
-          TString readingOption = "READ",
-          TString treeName = "HTauTauTree") ;
+  mysample (TString sampleName,
+            TString theSampleFileName,
+            TString readingOption = "READ",
+            TString treeName = "HTauTauTree") ;
   float calcEfficiency () ;
   TString sampleName ;
   TString sampleFileName ;
@@ -49,16 +49,16 @@ struct sample
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-void addTo (vector<float> & total, vector<float> & addition) ;
+void addTo (std::vector<float> & total, std::vector<float> & addition) ;
 
 struct counters 
 {
-  vector<vector<float> > counters ; // [sample][selection]
-  vector<float> initEfficiencies ; // [sample]
+  std::vector<std::vector<float> > counters ; // [sample][selection]
+  std::vector<float> initEfficiencies ; // [sample]
 
-  vector<float> getTotalCountsPerCut ()
+  std::vector<float> getTotalCountsPerCut ()
     {
-      vector<float> total (counters.at(0).size (), 0.) ;
+      std::vector<float> total (counters.at(0).size (), 0.) ;
       // loop on the samples
       for (unsigned int i = 0 ; i < counters.size () ; ++i) 
         addTo (total, counters.at (i)) ;
@@ -68,14 +68,14 @@ struct counters
 } ;
 
 
-int readSamples (vector<sample> & samples, vector<string> & samplesList, 
+int readSamples (std::vector<mysample> & samples, std::vector<std::string> & samplesList,
                  TString readOption = "READ") ;
-int readSamples (vector<sample> & samples, vector<string> & samplesList, const unique_ptr<CfgParser> & lConfigParser, 
+int readSamples (std::vector<mysample> & samples, std::vector<std::string> & samplesList, const std::unique_ptr<CfgParser> & lConfigParser,
                  TString readOption = "READ") ;
 
-vector<pair<TString, TCut> > readCutsFile (string filename) ;
-vector<pair <TString, TCut> > readCutsFile (vector<string> activeSelections, string filename) ;
-vector<pair <string, string> > readVarNamesFile (vector<string> varList, string filename) ;
+std::vector<std::pair<TString, TCut> > readCutsFile (std::string filename) ;
+std::vector<std::pair <TString, TCut> > readCutsFile (std::vector<std::string> activeSelections, std::string filename) ;
+std::vector<std::pair <std::string, std::string> > readVarNamesFile (std::vector<std::string> varList, std::string filename) ;
 
 
 
@@ -93,14 +93,14 @@ std::vector<std::string> split(const std::string &s, char delim) ;
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 // utilities to draw tables of yields
 
-void printTableTitle (std::ostream& out, vector<string> & sample, unsigned int NSpacesColZero = 16, unsigned int NSpacesColumns = 10) ;
-void printTableTitle (std::ostream& out, vector<sample> & sample, unsigned int NSpacesColZero = 16, unsigned int NSpacesColumns = 10) ;
-void printTableTitle (std::ostream& out, vector<sample> & sample, vector<string> & DataDrivenBkgsName, unsigned int NSpacesColZero = 16, unsigned int NSpacesColumns = 10) ; // adding e.g. QCD that has not a coutner structure
+void printTableTitle (std::ostream& out, std::vector<std::string> & sample, unsigned int NSpacesColZero = 16, unsigned int NSpacesColumns = 10) ;
+void printTableTitle (std::ostream& out, std::vector<mysample> & sample, unsigned int NSpacesColZero = 16, unsigned int NSpacesColumns = 10) ;
+void printTableTitle (std::ostream& out, std::vector<mysample> & sample, std::vector<std::string> & DataDrivenBkgsName, unsigned int NSpacesColZero = 16, unsigned int NSpacesColumns = 10) ; // adding e.g. QCD that has not a coutner structure
 
-void printTableBody  (std::ostream& out, vector<pair <TString, TCut> > & selections, counters & count, vector<sample> & samples, unsigned int NSpacesColZero = 16, unsigned int NSpacesColumns = 10, unsigned int precision = 1) ;
-void printTableBody  (std::ostream& out, vector<pair <TString, TCut> > & selections, counters & count, vector<sample> & samples, vector<vector<float>> & DataDrivenSamplesYields, unsigned int NSpacesColZero = 16, unsigned int NSpacesColumns = 10, unsigned int precision = 1) ;
+void printTableBody  (std::ostream& out, std::vector<std::pair <TString, TCut> > & selections, counters & count, std::vector<mysample> & samples, unsigned int NSpacesColZero = 16, unsigned int NSpacesColumns = 10, unsigned int precision = 1) ;
+void printTableBody  (std::ostream& out, std::vector<std::pair <TString, TCut> > & selections, counters & count, std::vector<mysample> & samples, std::vector<std::vector<float>> & DataDrivenSamplesYields, unsigned int NSpacesColZero = 16, unsigned int NSpacesColumns = 10, unsigned int precision = 1) ;
 
-void printTableBodyEff  (std::ostream& out, vector<pair <TString, TCut> > & selections, counters & count, vector<sample> & samples, unsigned int NSpacesColZero = 16, unsigned int NSpacesColumns = 10, unsigned int precision = 1) ;
+void printTableBodyEff  (std::ostream& out, std::vector<std::pair <TString, TCut> > & selections, counters & count, std::vector<mysample> & samples, unsigned int NSpacesColZero = 16, unsigned int NSpacesColumns = 10, unsigned int precision = 1) ;
 
 
 // title + body, flush to file or std cout

--- a/src/ConfigParser.cc
+++ b/src/ConfigParser.cc
@@ -113,8 +113,8 @@ bool ConfigParser::isDefined(const char *name) const
   return false;
 }
 //! Read integer option
-int ConfigParser::readIntOption(const char *name) const
-  throw(const char *){
+int ConfigParser::readIntOption(const char *name)
+{
   string s(name);
   LineIterator I=configLines.begin();
   while (I != configLines.end()) {
@@ -132,8 +132,8 @@ int ConfigParser::readIntOption(const char *name) const
   throw "ConfigParser::readIntOption: No such option provided!";
 }
 //! Read double option
-double ConfigParser::readDoubleOption(const char *name) const
-  throw(const char *){
+double ConfigParser::readDoubleOption(const char *name)
+{
   string s(name);
   LineIterator I=configLines.begin();
   while (I != configLines.end()) {
@@ -151,8 +151,8 @@ double ConfigParser::readDoubleOption(const char *name) const
   throw "ConfigParser::readDoubleOption: No such option provided!";
 }
 //! Read float option
-float ConfigParser::readFloatOption(const char *name) const
-  throw(const char *){
+float ConfigParser::readFloatOption(const char *name)
+{
   string s(name);
   LineIterator I=configLines.begin();
   while (I != configLines.end()) {
@@ -170,8 +170,8 @@ float ConfigParser::readFloatOption(const char *name) const
   throw "ConfigParser::readFloatOption: No such option provided!";
 }
 //! Read double list option
-const char *ConfigParser::readStringOption(const char *name) const
-  throw(const char *){
+const char *ConfigParser::readStringOption(const char *name)
+{
   string s(name);
   LineIterator I=configLines.begin();
   while (I != configLines.end()) {
@@ -189,16 +189,16 @@ const char *ConfigParser::readStringOption(const char *name) const
   throw "ConfigParser::readStringOption: No such option provided!";
 }
 //! Read bool option
-const bool ConfigParser::readBoolOption(const char *name) const
-  throw(const char *){
+const bool ConfigParser::readBoolOption(const char *name)
+{
   return (string(readStringOption(name))=="true") ? true : false;
   cerr << "ConfigParser::readBoolOption: No \""
 	    << name << "\" option provided!\n" ;
   throw "ConfigParser::readBoolOption: No such option provided!";
 }
 //! Read integer list option
-vector<int> ConfigParser::readIntListOption(const char *name) const
-  throw(const char *){
+vector<int> ConfigParser::readIntListOption(const char *name)
+{
   string s(name);
   LineIterator I=configLines.begin();
   while (I != configLines.end()) {
@@ -220,8 +220,8 @@ vector<int> ConfigParser::readIntListOption(const char *name) const
   throw "ConfigParser::readIntListOption: No such option provided!";
 }
 //! Read double list option
-vector<double> ConfigParser::readDoubleListOption(const char *name) const
-  throw(const char *){
+vector<double> ConfigParser::readDoubleListOption(const char *name)
+{
   string s(name);
   LineIterator I=configLines.begin();
   while (I != configLines.end()) {
@@ -244,8 +244,8 @@ vector<double> ConfigParser::readDoubleListOption(const char *name) const
 }
 
 //! Read float list option
-vector<float> ConfigParser::readFloatListOption(const char *name) const
-  throw(const char *){
+vector<float> ConfigParser::readFloatListOption(const char *name)
+{
   string s(name);
   LineIterator I=configLines.begin();
   while (I != configLines.end()) {
@@ -267,8 +267,8 @@ vector<float> ConfigParser::readFloatListOption(const char *name) const
   throw "ConfigParser::readFloatListOption: No such option provided!";
 }
 //! Read string list option
-vector<string> ConfigParser::readStringListOption(const char *name) const
-  throw(const char *){
+vector<string> ConfigParser::readStringListOption(const char *name)
+{
   string s(name);
   LineIterator I=configLines.begin();
   while (I != configLines.end()) {

--- a/src/analysisUtils.cc
+++ b/src/analysisUtils.cc
@@ -1,13 +1,13 @@
 #include "analysisUtils.h"
 #include <algorithm>
 
-using namespace std ;
+//using namespace std ;
 
 
-vector<pair <TString, TCut> >
-addSelection (vector<pair <TString, TCut> > m_cuts, string cut, string tag)
+std::vector<std::pair <TString, TCut> >
+addSelection (std::vector<std::pair <TString, TCut> > m_cuts, std::string cut, std::string tag)
 {
-  vector<pair <TString, TCut> > output = m_cuts ;
+  std::vector<std::pair <TString, TCut> > output = m_cuts ;
   for (unsigned int i = 0 ; i < output.size () ; ++i)
     {
       output.at (i).first = TString (tag.c_str ()) + output.at (i).first ;
@@ -22,15 +22,15 @@ addSelection (vector<pair <TString, TCut> > m_cuts, string cut, string tag)
 
 std::pair<int, int> leptonsType (int pairType)
 {
-  if (pairType == 0) return pair<int,int> (0, 2) ;
-  if (pairType == 1) return pair<int,int> (1, 2) ;
-  if (pairType == 2) return pair<int,int> (2, 2) ;
-  if (pairType == 3) return pair<int,int> (0, 0) ;
-  if (pairType == 4) return pair<int,int> (1, 1) ;
-  if (pairType == 5) return pair<int,int> (1, 0) ; // FIXME are they ordered per flavour?
-  if (pairType == 6) return pair<int,int> (1, 1) ;
-  if (pairType == 7) return pair<int,int> (0, 0) ;
-  return pair<int,int> (-1, -1) ;
+  if (pairType == 0) return std::pair<int,int> (0, 2) ;
+  if (pairType == 1) return std::pair<int,int> (1, 2) ;
+  if (pairType == 2) return std::pair<int,int> (2, 2) ;
+  if (pairType == 3) return std::pair<int,int> (0, 0) ;
+  if (pairType == 4) return std::pair<int,int> (1, 1) ;
+  if (pairType == 5) return std::pair<int,int> (1, 0) ; // FIXME are they ordered per flavour?
+  if (pairType == 6) return std::pair<int,int> (1, 1) ;
+  if (pairType == 7) return std::pair<int,int> (0, 0) ;
+  return std::pair<int,int> (-1, -1) ;
 }
 
 
@@ -49,10 +49,10 @@ bool isIsolated (int leptonType, float threshold, float isoDeposits, float pT)
 
 
 void
-addHistos (vector<sample> & samples, 
+addHistos (std::vector<mysample> & samples,
            HistoManager * manager,
-           vector<string> & variablesList,
-           vector<pair <TString, TCut> > & selections,
+           std::vector<std::string> & variablesList,
+           std::vector<std::pair <TString, TCut> > & selections,
            bool isSignal,
            bool isData)
 {
@@ -74,13 +74,13 @@ addHistos (vector<sample> & samples,
                               selections.at (k).first.Data ()
                               ) ;
               // remove not alphanumeric symbols from the var name
-              string varID = variablesList.at (i) ;
+              std::string varID = variablesList.at (i) ;
               varID.erase (std::remove_if (varID.begin (), varID.end (), isNOTalnum ()), varID.end ()) ;
               // get histo nbins and range
               int hcolor = gConfigParser->isDefined (TString ("colors::") + samples.at (j).sampleName.Data ())
                           ? gConfigParser->readIntOption (TString ("colors::") + samples.at (j).sampleName.Data ())
                           : 1;
-              vector <float> limits = 
+              std::vector <float> limits =
                 gConfigParser->readFloatListOption (TString ("histos::") 
                     + varID.c_str ()) ;
               manager->AddNewHisto (histoName.Data (),histoName.Data (),
@@ -100,17 +100,17 @@ addHistos (vector<sample> & samples,
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 counters
-fillHistos (vector<sample> & samples, 
+fillHistos (std::vector<mysample> & samples,
             plotContainer & plots,
-            vector<string> & variablesList,
-            vector<pair <TString, TCut> > & selections,
+            std::vector<std::string> & variablesList,
+            std::vector<std::pair <TString, TCut> > & selections,
             float lumi,
-            const vector<float> & scale,
+            const std::vector<float> & scale,
             bool isData,
             bool isSignal,
             int maxEvts, TFile* fOut)
 {
-    vector<pair<string,string>> variables2DList (0);
+    std::vector<std::pair<std::string,std::string>> variables2DList (0);
     return fillHistos (
             samples, 
             plots,
@@ -127,13 +127,13 @@ fillHistos (vector<sample> & samples,
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 counters
-fillHistos (vector<sample> & samples, 
+fillHistos (std::vector<mysample> & samples,
             plotContainer & plots,
-            vector<string> & variablesList,
-            vector<pair<string,string>> & variables2DList,
-            vector<pair <TString, TCut> > & selections,
+            std::vector<std::string> & variablesList,
+            std::vector<std::pair<std::string,std::string>> & variables2DList,
+            std::vector<std::pair <TString, TCut> > & selections,
             float lumi,
-            const vector<float> & scale,
+            const std::vector<float> & scale,
             bool isData,
             bool isSignal,
             int maxEvts, TFile* fOut)
@@ -149,16 +149,16 @@ fillHistos (vector<sample> & samples,
       double eff = samples.at (iSample).eff ;
       localCounter.initEfficiencies.push_back (eff) ;
 
-      localCounter.counters.push_back (vector<float> (selections.size () + 1, 0.)) ;
+      localCounter.counters.push_back (std::vector<float> (selections.size () + 1, 0.)) ;
       
       TTree *tree = samples.at (iSample).sampleTree ;
       TTreeFormula * TTF[selections.size ()] ;
       
       // specifies the type of bTagreweight weight in the selection. 0: no weight; 1: bTagL, 2: bTagM, 3: bTagT
-      vector<int> selBTagWeight (selections.size());
+      std::vector<int> selBTagWeight (selections.size());
       
       // specifies the type of top pt reweight in the selection. 0: nominal; 1: UP, 2: DOWN
-      vector<int> selTopRewType (selections.size());
+      std::vector<int> selTopRewType (selections.size());
       for (unsigned int isel = 0 ; isel < selections.size () ; ++isel)
         {
           TString fname ; fname.Form ("ttf%d",isel) ;
@@ -231,24 +231,24 @@ fillHistos (vector<sample> & samples,
       float scaling = 1. / samples.at (iSample).eff_den ;
       if (scale.size () > 0) scaling *= scale.at (iSample) ;
 
-      cout << "Opening sample: "
+      std::cout << "Opening sample: "
            << samples.at (iSample).sampleName
            << "\t with initial weighted events\t" << samples.at (iSample).eff_den
-           << endl ;
+           << std::endl ;
 
 
       // find how many variables needed for 2D are not in the list of the 1D vars
-      vector<string> allvars (variablesList);
-      vector<pair<int,int>> var2Didxmap; // this maps each entry of 2Dvarlist to allvars to be more efficient in retrieving values
+      std::vector<std::string> allvars (variablesList);
+      std::vector<std::pair<int,int>> var2Didxmap; // this maps each entry of 2Dvarlist to allvars to be more efficient in retrieving values
 
-      std::vector<string>::iterator it;
+      std::vector<std::string>::iterator it;
       for (unsigned int ivar = 0; ivar < variables2DList.size(); ivar++)
       {
         int ind1 = -1;
         int ind2 = -1;
 
         // var 1 (x)
-        string var1 = variables2DList.at(ivar).first;
+        std::string var1 = variables2DList.at(ivar).first;
         it = find (allvars.begin(), allvars.end(), var1);
         if ( it == allvars.end() )
         {
@@ -259,7 +259,7 @@ fillHistos (vector<sample> & samples,
           ind1 = distance (allvars.begin(), it);
 
         // var 2 (y)
-        string var2 = variables2DList.at(ivar).second;
+        std::string var2 = variables2DList.at(ivar).second;
         it = find (allvars.begin(), allvars.end(), var2);
         if ( it == allvars.end() )
         {
@@ -270,13 +270,13 @@ fillHistos (vector<sample> & samples,
           ind2 = distance (allvars.begin(), it);
 
         // save indexes
-        var2Didxmap.push_back (make_pair(ind1, ind2));
+        var2Didxmap.push_back (std::make_pair(ind1, ind2));
       }
 
       // set tbranch addresses for 1D histos
-      vector<float> address (allvars.size(), 0.) ;
-      vector<int> addressInt (allvars.size(), 0.) ;
-      vector<int> indexInt ;
+      std::vector<float> address (allvars.size(), 0.) ;
+      std::vector<int> addressInt (allvars.size(), 0.) ;
+      std::vector<int> indexInt ;
       for (unsigned int iv = 0 ; iv < allvars.size () ; ++iv)
       {
         if(allvars.at(iv)=="njets" || allvars.at(iv)=="npu" || allvars.at(iv)=="npv" || allvars.at(iv)=="dau1_MVAiso" || allvars.at(iv)=="dau2_MVAiso" || allvars.at(iv)=="lheNOutPartons")
@@ -291,7 +291,7 @@ fillHistos (vector<sample> & samples,
       int nEvts = tree->GetEntries();
       if (maxEvts > 0)
       {
-        nEvts = min(nEvts, maxEvts);
+        nEvts = std::min(nEvts, maxEvts);
         scaling *= (1.*tree->GetEntries() / nEvts); // scales if nEvts != entries in the tree
       }
 
@@ -492,17 +492,17 @@ makeCounter (plotContainer & plots, float initEff = 1.0, float initTotNum = 0.0)
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 
-vector<THStack *> 
-stackHistos (vector<sample> & samples, HistoManager * manager, 
-             vector<string> & variablesList,
-             vector<pair <TString, TCut> > & selections,
-             const string & tag)
+std::vector<THStack *>
+stackHistos (std::vector<mysample> & samples, HistoManager * manager,
+             std::vector<std::string> & variablesList,
+             std::vector<std::pair <TString, TCut> > & selections,
+             const std::string & tag)
 {
   int nVars = variablesList.size () ;
   int nSel = selections.size () ;
   TString outputName, histoName ;
   
-  vector <THStack *> hstack (nVars*nSel) ; //one stack for variable
+  std::vector <THStack *> hstack (nVars*nSel) ; //one stack for variable
 
   for (int isel = 0 ; isel < nSel ; ++isel)
     {
@@ -533,8 +533,8 @@ stackHistos (vector<sample> & samples, HistoManager * manager,
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---0
 std::vector<TObject*> makeStackPlot (plotContainer& dataPlots, plotContainer& bkgPlots, plotContainer& sigPlots,
-                                      string varName, string selName,
-                                      TCanvas* canvas, std::vector <pair <string, string> >& addInLegend, std::vector <pair <string, string> >& axisTitles,
+                                      std::string varName, std::string selName,
+                                      TCanvas* canvas, std::vector <std::pair <std::string, std::string> >& addInLegend, std::vector <std::pair <std::string, std::string> >& axisTitles,
                                       bool LogY, bool makeRatioPlot, bool drawLegend, bool doShapes, bool forceNonNegMin, bool drawGrassForData,
                                       bool drawSignal, bool drawData, bool drawMC)
 {
@@ -553,7 +553,7 @@ std::vector<TObject*> makeStackPlot (plotContainer& dataPlots, plotContainer& bk
   if (LogY)                    forceNonNegMin = false; // the min finder already thinsk about it if LOG
   if (! (drawSignal || drawData || drawMC) )
   {
-    cout << " ** analysisUtils::makeStackPlot: qualcosa lo devi pur disegnare, enabling MC+data+sig" << endl;
+    std::cout << " ** analysisUtils::makeStackPlot: qualcosa lo devi pur disegnare, enabling MC+data+sig" << std::endl;
     drawSignal = drawData = drawMC = true;
   }  
   //if (doShapes) drawSignal = true; // FIXME: enable shapes with bkgr only
@@ -567,16 +567,16 @@ std::vector<TObject*> makeStackPlot (plotContainer& dataPlots, plotContainer& bk
   THStack * bkg_stack =  (drawMC     ? bkgPlots.makeStack ( varName, selName )  : 0);
   THStack * DATA_stack = (drawData   ? dataPlots.makeStack ( varName, selName ) : 0);
 
-  vector<float> extremes_bkg; 
-  vector<float> extremes_sig; 
-  vector<float> extremes_DATA;
+  std::vector<float> extremes_bkg;
+  std::vector<float> extremes_sig;
+  std::vector<float> extremes_DATA;
   
   if (drawMC)     extremes_bkg = getExtremes (bkg_stack, LogY) ;
   if (drawSignal) extremes_sig = getExtremes (sig_stack, LogY) ;
   if (drawData)   extremes_DATA = getExtremes (DATA_stack, LogY) ;
   
   // fill all vectors with dummy values to avoid many other "if" everywhere
-  vector<float> vZeroes (4, 0.);
+  std::vector<float> vZeroes (4, 0.);
   if (extremes_bkg.size() == 0) extremes_bkg.insert (extremes_bkg.begin(),    vZeroes.begin(), vZeroes.end());
   if (extremes_sig.size() == 0) extremes_sig.insert (extremes_sig.begin(),    vZeroes.begin(), vZeroes.end());
   if (extremes_DATA.size() == 0) extremes_DATA.insert (extremes_DATA.begin(), vZeroes.begin(), vZeroes.end());
@@ -670,7 +670,7 @@ std::vector<TObject*> makeStackPlot (plotContainer& dataPlots, plotContainer& bk
     allocatedStuff.push_back(hstack_bkg_norm);
 
     hstack_sig_norm = normaliseStack (sig_stack, true) ;
-    vector<float> extremes_sig_norm = getExtremes (hstack_sig_norm, LogY, true) ;
+    std::vector<float> extremes_sig_norm = getExtremes (hstack_sig_norm, LogY, true) ;
 
     //hstack_data_norm = normaliseStack (DATA_stack) ;
     //hshape_data = (TH1F*) hstack_data_norm->GetStack () ->Last() ;
@@ -725,10 +725,10 @@ std::vector<TObject*> makeStackPlot (plotContainer& dataPlots, plotContainer& bk
   // frame->GetXaxis()->SetTickSize(0);
 
   TString xTitle = frame->GetXaxis()->GetTitle();
-  string xTitlestr (xTitle.Data());
+  std::string xTitlestr (xTitle.Data());
   auto it = std::find_if(axisTitles.begin(), 
                    axisTitles.end(), 
-                  [&xTitlestr](const pair<string, string>& p)
+                  [&xTitlestr](const std::pair<std::string, std::string>& p)
                   { return p.first == xTitlestr; });
 
   if (it != axisTitles.end()) xTitle = (it->second).c_str();
@@ -818,45 +818,45 @@ std::vector<TObject*> makeStackPlot (plotContainer& dataPlots, plotContainer& bk
     allocatedStuff.push_back(leg);
 
     // sample names -- bkg
-    for (map<string, TH1F *>::iterator iSample = bkgPlots.m_histos[varName][selName].begin () ;
+    for (std::map<std::string, TH1F *>::iterator iSample = bkgPlots.m_histos[varName][selName].begin () ;
         iSample != bkgPlots.m_histos[varName][selName].end () && drawMC; ++iSample)
     {
-      string samplename = iSample->first ;
-      string thisname = "EMPTY";
+      std::string samplename = iSample->first ;
+      std::string thisname = "EMPTY";
 
       auto it = std::find_if(addInLegend.begin(), 
                        addInLegend.end(), 
-                      [&samplename](const pair<string, string>& p)
+                      [&samplename](const std::pair<std::string, std::string>& p)
                       { return p.first == samplename; });
 
       if (it != addInLegend.end()) thisname = it->second;
       else thisname = samplename;
       
-      if (thisname != string ("NODRAW") ) leg->AddEntry (iSample->second, thisname.c_str(), "f") ;
+      if (thisname != std::string ("NODRAW") ) leg->AddEntry (iSample->second, thisname.c_str(), "f") ;
     }    
 
     // sample names -- signal
-    for (map<string, TH1F *>::iterator iSample = sigPlots.m_histos[varName][selName].begin () ;
+    for (std::map<std::string, TH1F *>::iterator iSample = sigPlots.m_histos[varName][selName].begin () ;
         iSample != sigPlots.m_histos[varName][selName].end () && drawSignal; ++iSample)
     {
-      string samplename = iSample->first ;
-      string thisname = "EMPTY";
+      std::string samplename = iSample->first ;
+      std::string thisname = "EMPTY";
 
       auto it = std::find_if(addInLegend.begin(), 
                        addInLegend.end(), 
-                      [&samplename](const pair<string, string>& p)
+                      [&samplename](const std::pair<std::string, std::string>& p)
                       { return p.first == samplename; });
 
       if (it != addInLegend.end()) thisname = it->second;
       else thisname = samplename;      
-      if (thisname != string ("NODRAW") ) leg->AddEntry (iSample->second, thisname.c_str(), "l") ;
+      if (thisname != std::string ("NODRAW") ) leg->AddEntry (iSample->second, thisname.c_str(), "l") ;
 
     }
 
     if (drawData)
     {
       //TH1F* dataHisto = dataPlots.getHisto(varName, selName, addInLegend.at(i).first );      
-      map<string, TH1F *>::iterator iData = dataPlots.m_histos[varName][selName].begin() ;  // all data have the same format!
+      std::map<std::string, TH1F *>::iterator iData = dataPlots.m_histos[varName][selName].begin() ;  // all data have the same format!
       leg->AddEntry (iData->second, "data", "lep") ;
     }        
     leg->Draw();
@@ -1006,8 +1006,8 @@ std::vector<TObject*> makeStackPlot (plotContainer& dataPlots, plotContainer& bk
   // now plot lumi!
   float lumi_num = gConfigParser->readFloatOption ("general::lumi");
   lumi_num = lumi_num/1000.; // is in pb-1
-  stringstream stream;
-  stream << fixed << setprecision(1) << lumi_num;
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(1) << lumi_num;
   TString lumi = stream.str().c_str();
   lumi += " fb^{-1} (13 TeV)";
 

--- a/src/histoUtils.cc
+++ b/src/histoUtils.cc
@@ -37,11 +37,11 @@ void addOverFlow (TH1F * input) {
   if(input->GetDefaultSumw2())
     dummy->Sumw2 () ;
 
-  string name = input->GetName () ;
+  std::string name = input->GetName () ;
   input->SetName ("trash") ;
   dummy->GetXaxis()->SetTitle(input->GetXaxis()->GetTitle());
   dummy->SetName (name.c_str ()) ;
-  swap (*input, *dummy) ;
+  std::swap (*input, *dummy) ;
   return ;
 
 }
@@ -119,10 +119,10 @@ void setAsymmetricErrorsTo2DHisto (TH2F * input) { // set the error in each bin 
                                                                                               
 TH1F *  getHistoOfErrors (TH1F * input, int isLog) {
 
-  string name = "err_" ;
+  std::string name = "err_" ;
   name += input->GetName () ;
   if(isLog) name +="_log";
-  string title = "errors of " ;
+  std::string title = "errors of " ;
   title += input->GetTitle () ;
   TH1F * dummy = new TH1F (
 			   name.c_str (),
@@ -147,7 +147,7 @@ TH1F *  getHistoOfErrors (TH1F * input, int isLog) {
 TH1F* unRollingHistogram (TH2F* histo, int errorType){
 
   TH1F* dummy = new TH1F("dummy","",(histo->GetNbinsX())*(histo->GetNbinsY()),0,histo->GetNbinsX()*histo->GetNbinsY());
-  dummy->SetName((string(histo->GetName())+"_dummy").c_str());
+  dummy->SetName((std::string(histo->GetName())+"_dummy").c_str());
   dummy->Sumw2();
 
   // copy all the entries (basic structure inside the matrix)                                                                                                                  
@@ -202,7 +202,7 @@ TH1F* unRollingHistogram (TH2F* histo, int errorType){
                                                                                              
 THStack * stackMe (TH1F * histo)
 {
-  string name = histo->GetName () ;
+  std::string name = histo->GetName () ;
   name += "_st" ;
   THStack * dummy = new THStack (name.c_str (), "") ;
   dummy->Add (histo) ;
@@ -213,7 +213,7 @@ THStack * stackMe (TH1F * histo)
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----  
 
                                                                                                  
-TH1F* mirrorHistogram(string name, TH1F* h1, TH1F*h2)
+TH1F* mirrorHistogram(std::string name, TH1F* h1, TH1F*h2)
 {
   TH1F* dummy = (TH1F*) h1->Clone(name.c_str());
   dummy->Reset();
@@ -327,7 +327,7 @@ float findNonNullMinimum (TH1F * histo)
 // xmin ymin xmax ymax
 // islog : search only non-null minima
 // nostack: search the max of each histo and not the max of the stack itself
-vector<float> getExtremes (THStack * hstack, bool islog, bool nostack)
+std::vector<float> getExtremes (THStack * hstack, bool islog, bool nostack)
 {
   float ymax = hstack->GetMaximum () ;
   float xmin = ((TH1F*)(hstack->GetStack()->Last()))->GetXaxis()->GetXmin() ; 
@@ -371,7 +371,7 @@ vector<float> getExtremes (THStack * hstack, bool islog, bool nostack)
     else ymax = -999999999999.; // can happen that some histos are empty, return dummy value
   }
 
-  vector<float> extremes (4, 0.) ;
+  std::vector<float> extremes (4, 0.) ;
   extremes.at (0) = xmin ;
   extremes.at (1) = ymin ;
   extremes.at (2) = xmax ;
@@ -385,7 +385,7 @@ vector<float> getExtremes (THStack * hstack, bool islog, bool nostack)
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 // xmin ymin xmax ymax
-vector<float> getExtremes (std::vector<TH1F*>& histos, bool islog)
+std::vector<float> getExtremes (std::vector<TH1F*>& histos, bool islog)
 {
   float xmin = 1. ;
   float xmax = 0. ;
@@ -416,7 +416,7 @@ vector<float> getExtremes (std::vector<TH1F*>& histos, bool islog)
       xmax = histo->GetXaxis ()->GetXmax () ;
     }
   }
-  vector<float> extremes (4, 0.) ;
+  std::vector<float> extremes (4, 0.) ;
   extremes.at (0) = xmin ;
   extremes.at (1) = ymin ;
   extremes.at (2) = xmax ;
@@ -430,7 +430,7 @@ vector<float> getExtremes (std::vector<TH1F*>& histos, bool islog)
 
 float min3 (float uno, float due, float tre)
 {
-  return min (min (uno, due), tre) ;
+  return std::min (std::min (uno, due), tre) ;
 }
 
 
@@ -439,7 +439,7 @@ float min3 (float uno, float due, float tre)
 
 float max3 (float uno, float due, float tre)
 {
-  return max (max (uno, due), tre) ;
+  return std::max (std::max (uno, due), tre) ;
 }
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
@@ -447,9 +447,9 @@ float max3 (float uno, float due, float tre)
 float min3Select (float uno, float due, float tre, bool useUno, bool useDue, bool useTre)
 {
   if (useUno && useDue && useTre) return min3 (uno, due, tre);
-  if (useUno && useDue)           return min (uno, due); 
-  if (useUno && useTre)           return min (uno, tre); 
-  if (useDue && useTre)           return min (due, tre); 
+  if (useUno && useDue)           return std::min (uno, due);
+  if (useUno && useTre)           return std::min (uno, tre);
+  if (useDue && useTre)           return std::min (due, tre);
   if (useUno)                     return uno;
   if (useDue)                     return due;
   if (useTre)                     return tre;
@@ -462,9 +462,9 @@ float min3Select (float uno, float due, float tre, bool useUno, bool useDue, boo
 float max3Select (float uno, float due, float tre, bool useUno, bool useDue, bool useTre)
 {
   if (useUno && useDue && useTre) return max3 (uno, due, tre);
-  if (useUno && useDue)           return max (uno, due); 
-  if (useUno && useTre)           return max (uno, tre); 
-  if (useDue && useTre)           return max (due, tre); 
+  if (useUno && useDue)           return std::max (uno, due);
+  if (useUno && useTre)           return std::max (uno, tre);
+  if (useDue && useTre)           return std::max (due, tre);
   if (useUno)                     return uno;
   if (useDue)                     return due;
   if (useTre)                     return tre;

--- a/src/plotContainer.cc
+++ b/src/plotContainer.cc
@@ -1,7 +1,7 @@
 #include "plotContainer.h"
 
 
-plotContainer::plotContainer (string name) :
+plotContainer::plotContainer (std::string name) :
   m_name   (name),
   m_Nvar   (-1),
   m_N2Dvar (-1) {}
@@ -10,9 +10,9 @@ plotContainer::plotContainer (string name) :
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 
-plotContainer::plotContainer (string name, vector<string> varList, 
-                              vector<pair <TString, TCut> > cutList,
-                              vector<string> sampleList, 
+plotContainer::plotContainer (std::string name, std::vector<std::string> varList,
+                              std::vector<std::pair <TString, TCut> > cutList,
+                              std::vector<std::string> sampleList,
                               int histosType) :
   m_name     (name),
   m_Nvar     (varList.size ()),
@@ -21,13 +21,13 @@ plotContainer::plotContainer (string name, vector<string> varList,
   m_Nsample (sampleList.size ()), 
   m_histosType (histosType)
 {
-  vector<pair<string,string>> varList2D (0); // empty vec
+  std::vector<std::pair<std::string,std::string>> varList2D (0); // empty vec
   createHistos (varList, varList2D, cutList, sampleList) ;
 }
 
 
-plotContainer::plotContainer (string name, vector<string> varList, vector<pair<string,string>> varList2D,
-                vector<pair <TString, TCut> > cutList, vector<string> sampleList, int histosType) :
+plotContainer::plotContainer (std::string name, std::vector<std::string> varList, std::vector<std::pair<std::string,std::string>> varList2D,
+                std::vector<std::pair <TString, TCut> > cutList, std::vector<std::string> sampleList, int histosType) :
   m_name   (name),
   m_Nvar   (varList.size ()),
   m_N2Dvar (varList2D.size()),
@@ -43,32 +43,32 @@ plotContainer::plotContainer (string name, vector<string> varList, vector<pair<s
 
 
 void
-plotContainer::createHistos (vector<string> varList, vector<pair<string,string>> varList2D,
-                             vector<pair <TString, TCut> > cutList,
-                             vector<string> sampleList)
+plotContainer::createHistos (std::vector<std::string> varList, std::vector<std::pair<std::string,std::string>> varList2D,
+                             std::vector<std::pair <TString, TCut> > cutList,
+                             std::vector<std::string> sampleList)
 {
   
   // for 1D plots
   for (unsigned int ivar = 0 ; ivar < m_Nvar ; ++ivar)
     {
-      map<string, map<string, TH1F *> > varDummy ;
+      std::map<std::string, std::map<std::string, TH1F *> > varDummy ;
       for (unsigned int icut = 0 ; icut < m_Ncut ; ++icut)
         {
-          map<string, TH1F *> cutDummy ;
+          std::map<std::string, TH1F *> cutDummy ;
           for (unsigned int isample = 0 ; isample < m_Nsample ; ++isample)
             {
               // remove not alphanumeric symbols from the var name
-              string varID = varList.at (ivar) ;
+              std::string varID = varList.at (ivar) ;
               varID.erase (std::remove_if (varID.begin (), varID.end (), isNOTalnum ()), varID.end ()) ;
               
               bool userBinning = gConfigParser->isDefined (TString ("binning::") + varID.c_str ()) ;
               if (userBinning)
               {
-                vector<float> binning = gConfigParser->readFloatListOption (TString ("binning::") + varID.c_str ()) ;
+                std::vector<float> binning = gConfigParser->readFloatListOption (TString ("binning::") + varID.c_str ()) ;
                 float* bins = new float [binning.size()];
                 for (unsigned int i = 0; i < binning.size(); i++) bins[i] = binning.at(i);
                 
-                string histoName = m_name + "_" 
+                std::string histoName = m_name + "_"
                                    + varList.at (ivar) + "_" 
                                    + cutList.at (icut).first.Data () + "_" 
                                    + sampleList.at (isample) ;     
@@ -93,10 +93,10 @@ plotContainer::createHistos (vector<string> varList, vector<pair<string,string>>
                 : 1;
  
                 // get histo nbins and range
-                vector <float> limits = 
+                std::vector <float> limits =
                   gConfigParser->readFloatListOption (TString ("histos::") 
                       + varID.c_str ()) ;
-                string histoName = m_name + "_" 
+                std::string histoName = m_name + "_"
                                    + varList.at (ivar) + "_" 
                                    + cutList.at (icut).first.Data () + "_" 
                                    + sampleList.at (isample) ;     
@@ -117,31 +117,31 @@ plotContainer::createHistos (vector<string> varList, vector<pair<string,string>>
   // for 2D plots
   for (unsigned int ivar = 0 ; ivar < m_N2Dvar ; ++ivar)
     {
-      map<string, map<string, TH2F *> > varDummy ;
+      std::map<std::string, std::map<std::string, TH2F *> > varDummy ;
       for (unsigned int icut = 0 ; icut < m_Ncut ; ++icut)
         {
-          map<string, TH2F *> cutDummy ;
+          std::map<std::string, TH2F *> cutDummy ;
           for (unsigned int isample = 0 ; isample < m_Nsample ; ++isample)
             {
               // remove not alphanumeric symbols from the var name
-              string varID1 = varList2D.at (ivar).first ;
-              string varID2 = varList2D.at (ivar).second ;
-              string varID1full = varID1;
-              string varID2full = varID2;
+              std::string varID1 = varList2D.at (ivar).first ;
+              std::string varID2 = varList2D.at (ivar).second ;
+              std::string varID1full = varID1;
+              std::string varID2full = varID2;
 
               varID1.erase (std::remove_if (varID1.begin (), varID1.end (), isNOTalnum ()), varID1.end ()) ;
               varID2.erase (std::remove_if (varID2.begin (), varID2.end (), isNOTalnum ()), varID2.end ()) ;
-              string varID = varID1 + varID2; // compone name of string as is seen by this stupid parser
+              std::string varID = varID1 + varID2; // compone name of string as is seen by this stupid parser
 
               int hcolor = gConfigParser->isDefined (TString ("colors::") + TString (sampleList.at (isample).c_str ()))
               ? gConfigParser->readIntOption (TString ("colors::") + TString (sampleList.at (isample).c_str ()))
               : 1;
 
               // get histo nbins and range
-              vector <float> limits = 
+              std::vector <float> limits =
                 gConfigParser->readFloatListOption (TString ("2Dhistos::") 
                     + varID.c_str ()) ;
-              string histoName = m_name + "_" 
+              std::string histoName = m_name + "_"
                                  + varID1full + varID2full + "_" // I skip the : but keep the rest of the var name
                                  + cutList.at (icut).first.Data () + "_" 
                                  + sampleList.at (isample) ;     
@@ -155,7 +155,7 @@ plotContainer::createHistos (vector<string> varList, vector<pair<string,string>>
             }
           varDummy[cutList.at (icut).first.Data ()] = cutDummy ;          
         }
-      string varKeyName = varList2D.at (ivar).first + varList2D.at (ivar).second;
+      std::string varKeyName = varList2D.at (ivar).first + varList2D.at (ivar).second;
       m_2Dhistos[varKeyName] = varDummy ;
     }
 }
@@ -164,9 +164,9 @@ plotContainer::createHistos (vector<string> varList, vector<pair<string,string>>
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 
-void plotContainer::init (vector<string> varList, 
-                          vector<pair <TString, TCut> > cutList, 
-                          vector<string> sampleList, int histosType)
+void plotContainer::init (std::vector<std::string> varList,
+                          std::vector<std::pair <TString, TCut> > cutList,
+                          std::vector<std::string> sampleList, int histosType)
 {
   m_Nvar = varList.size () ;
   m_N2Dvar = 0 ;
@@ -174,7 +174,7 @@ void plotContainer::init (vector<string> varList,
   m_Nsample = sampleList.size () ; 
   m_histosType = histosType ;
   
-  vector<pair<string,string>> varList2D (0);
+  std::vector<std::pair<std::string,std::string>> varList2D (0);
   createHistos (varList, varList2D, cutList, sampleList) ;
 }
 
@@ -182,7 +182,7 @@ void plotContainer::init (vector<string> varList,
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 
-void plotContainer::MergeHistograms(vector<string> mergesampleList, TString mergedName)
+void plotContainer::MergeHistograms(std::vector<std::string> mergesampleList, TString mergedName)
 {
   for (vars_coll::iterator iVar = m_histos.begin () ;
    iVar != m_histos.end () ;++iVar)
@@ -241,24 +241,24 @@ void plotContainer::MergeHistograms(vector<string> mergesampleList, TString merg
 
 
 TH1F * 
-plotContainer::getHisto (string varName, string cutName, string sampleName)
+plotContainer::getHisto (std::string varName, std::string cutName, std::string sampleName)
 {
   if (m_histos.find (varName) == m_histos.end ()) 
     {
-      cerr << "no histograms stored in " << m_name 
-           << " for variable " << varName << endl ;
+      std::cerr << "no histograms stored in " << m_name
+           << " for variable " << varName << std::endl ;
       return 0 ;
     }
   if (m_histos[varName].find (cutName) == m_histos[varName].end ()) 
     {
-      cerr << "no histograms stored in " << m_name 
-           << " for selection " << cutName << endl ;
+      std::cerr << "no histograms stored in " << m_name
+           << " for selection " << cutName << std::endl ;
       return 0 ;
     }  
   if (m_histos[varName][cutName].find (sampleName) == m_histos[varName][cutName].end ()) 
     {
-      cerr << "no histograms stored in " << m_name 
-           << " for sample " << sampleName << endl ;
+      std::cerr << "no histograms stored in " << m_name
+           << " for sample " << sampleName << std::endl ;
       return 0 ;
     }  
   return m_histos[varName][cutName][sampleName] ;
@@ -268,25 +268,25 @@ plotContainer::getHisto (string varName, string cutName, string sampleName)
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 TH2F *
-plotContainer::get2DHisto (string var1Name, string var2Name, string cutName, string sampleName)
+plotContainer::get2DHisto (std::string var1Name, std::string var2Name, std::string cutName, std::string sampleName)
 {
-  string varName = var1Name + var2Name;
+  std::string varName = var1Name + var2Name;
   if (m_2Dhistos.find (varName) == m_2Dhistos.end ()) 
     {
-      cerr << "no histograms stored in " << m_name 
-           << " for variable " << var1Name << ":" << var2Name << endl ;
+      std::cerr << "no histograms stored in " << m_name
+           << " for variable " << var1Name << ":" << var2Name << std::endl ;
       return 0 ;
     }
   if (m_2Dhistos[varName].find (cutName) == m_2Dhistos[varName].end ()) 
     {
-      cerr << "no histograms stored in " << m_name 
-           << " for selection " << cutName << endl ;
+      std::cerr << "no histograms stored in " << m_name
+           << " for selection " << cutName << std::endl ;
       return 0 ;
     }  
   if (m_2Dhistos[varName][cutName].find (sampleName) == m_2Dhistos[varName][cutName].end ()) 
     {
-      cerr << "no histograms stored in " << m_name 
-           << " for sample " << sampleName << endl ;
+      std::cerr << "no histograms stored in " << m_name
+           << " for sample " << sampleName << std::endl ;
       return 0 ;
     }  
   return m_2Dhistos[varName][cutName][sampleName] ;   
@@ -295,17 +295,17 @@ plotContainer::get2DHisto (string var1Name, string var2Name, string cutName, str
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 
-map<string, TH1F *> & 
-plotContainer::getStackSet (string varName, string cutName)
+std::map<std::string, TH1F *> &
+plotContainer::getStackSet (std::string varName, std::string cutName)
 {
   if (m_histos.find (varName) == m_histos.end ()) 
     {
-      cerr << "no histos for " << varName << endl ;
+      std::cerr << "no histos for " << varName << std::endl ;
       exit (1) ;
     }
   if (m_histos[varName].find (cutName) == m_histos[varName].end ())
     {
-      cerr << "no histos for " << varName << ", " << cutName << endl ;
+      std::cerr << "no histos for " << varName << ", " << cutName << std::endl ;
       exit (1) ;
     }
   return m_histos[varName][cutName] ;
@@ -316,14 +316,14 @@ plotContainer::getStackSet (string varName, string cutName)
 
 
 THStack * 
-plotContainer::makeStack (string varName, string cutName)
+plotContainer::makeStack (std::string varName, std::string cutName)
 {
   TString outputName, histoName ;
   outputName.Form ("%s_%s_%s",
     m_name.c_str (), varName.c_str (), cutName.c_str ()) ;
   THStack * stack = new THStack (outputName.Data (), outputName.Data ()) ;
 
-  for (map<string, TH1F *>::iterator iSample = m_histos[varName][cutName].begin () ;
+  for (std::map<std::string, TH1F *>::iterator iSample = m_histos[varName][cutName].begin () ;
        iSample != m_histos[varName][cutName].end () ;
        ++iSample)
     {
@@ -337,14 +337,14 @@ plotContainer::makeStack (string varName, string cutName)
 
 
 THStack * 
-plotContainer::make2DStack (pair<string,string> var2DName, string cutName)
+plotContainer::make2DStack (std::pair<std::string,std::string> var2DName, std::string cutName)
 {
   TString outputName, histoName ;
   outputName.Form ("%s_%s_%s_%s", m_name.c_str (), var2DName.first.c_str (), var2DName.second.c_str (), cutName.c_str ()) ;
   THStack * stack = new THStack (outputName.Data (), outputName.Data ()) ;
-  string varKeyName = var2DName.first + var2DName.second;
+  std::string varKeyName = var2DName.first + var2DName.second;
   
-  for (map<string, TH2F *>::iterator iSample = m_2Dhistos[varKeyName][cutName].begin () ;
+  for (std::map<std::string, TH2F *>::iterator iSample = m_2Dhistos[varKeyName][cutName].begin () ;
        iSample != m_2Dhistos[varKeyName][cutName].end () ;
        ++iSample)
     {
@@ -384,7 +384,7 @@ plotContainer::AddOverAndUnderFlow ()
 
 
 TH1F * 
-plotContainer::createNewHisto (string name, string title, 
+plotContainer::createNewHisto (std::string name, std::string title,
                                int nbinsx, double xlow, double xup,
                                int color, int histoType,
                                TString titleX, TString titleY)
@@ -402,7 +402,7 @@ plotContainer::createNewHisto (string name, string title,
 
 
 TH1F * 
-plotContainer::createNewHisto (string name, string title, 
+plotContainer::createNewHisto (std::string name, std::string title,
                                int nbinsx, float binning[],
                                int color, int histoType,
                                TString titleX, TString titleY)
@@ -420,7 +420,7 @@ plotContainer::createNewHisto (string name, string title,
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 TH2F *
-plotContainer::createNew2DHisto (string name, string title, 
+plotContainer::createNew2DHisto (std::string name, std::string title,
                          int nbinsx, double xlow, double xup,
                          int nbinsy, double ylow, double yup,
                          int color, int histoType,
@@ -520,7 +520,7 @@ plotContainer::scale (float scaleFactor)
 
 
 void 
-plotContainer::scale (vector<string> & variablesList, vector<pair <TString, TCut> > & selections, vector<vector<float>> scaleFactorVector)
+plotContainer::scale (std::vector<std::string> & variablesList, std::vector<std::pair <TString, TCut> > & selections, std::vector<std::vector<float>> scaleFactorVector)
 {
   for (unsigned int ivar = 0; ivar < variablesList.size(); ivar++)
   {
@@ -555,7 +555,7 @@ plotContainer::scale (vector<string> & variablesList, vector<pair <TString, TCut
 
 
 void 
-plotContainer::scale2D (vector<pair<string,string>> & variables2DList, vector<pair <TString, TCut> > & selections, vector<vector<float>> scaleFactorVector)
+plotContainer::scale2D (std::vector<std::pair<std::string,std::string>> & variables2DList, std::vector<std::pair <TString, TCut> > & selections, std::vector<std::vector<float>> scaleFactorVector)
 {
   for (unsigned int ivar = 0; ivar < variables2DList.size(); ivar++)
   {
@@ -615,13 +615,13 @@ plotContainer::setFillColor (int color)
 
 
 int
-plotContainer::addSample (string sampleName, const plotContainer & original) // iHisto = iv + nVars * isel
+plotContainer::addSample (std::string sampleName, const plotContainer & original) // iHisto = iv + nVars * isel
 {
   // shallow check
   if (original.m_Nvar != m_Nvar ||
       original.m_Ncut != m_Ncut) 
     {
-      cerr << "the two plot containers don't match in size\n" ;
+      std::cerr << "the two plot containers don't match in size\n" ;
       exit (1) ;
     }
 
@@ -629,7 +629,7 @@ plotContainer::addSample (string sampleName, const plotContainer & original) // 
   if (original.m_N2Dvar != m_N2Dvar ||
       original.m_Ncut != m_Ncut) 
     {
-      cerr << "the two plot containers 2D don't match in size\n" ;
+      std::cerr << "the two plot containers 2D don't match in size\n" ;
       exit (1) ;
     }
 
@@ -645,11 +645,11 @@ plotContainer::addSample (string sampleName, const plotContainer & original) // 
         {
           if (iCutOrig->second.size () != 1)
             {
-              cerr << "container " << original.m_name
+              std::cerr << "container " << original.m_name
                    << "does not have a single sample\n" ;
               exit (1) ;
             }
-          iCut->second.insert (pair<string, TH1F *> (
+          iCut->second.insert (std::pair<std::string, TH1F *> (
               sampleName,
               iCutOrig->second.begin()->second
             )) ;
@@ -668,11 +668,11 @@ plotContainer::addSample (string sampleName, const plotContainer & original) // 
         {
           if (iCutOrig->second.size () != 1)
             {
-              cerr << "container " << original.m_name
+              std::cerr << "container " << original.m_name
                    << "does not have a single sample\n" ;
               exit (1) ;
             }
-          iCut->second.insert (pair<string, TH2F *> (
+          iCut->second.insert (std::pair<std::string, TH2F *> (
               sampleName,
               iCutOrig->second.begin()->second
             )) ;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -1,9 +1,9 @@
 #include "utils.h"
 
-using namespace std ;
+//using namespace std ;
 
 
-sample::sample (TString theSampleName, TString theSampleFileName, 
+mysample::mysample (TString theSampleName, TString theSampleFileName,
                 TString readingOption, TString treeName) : 
   sampleName (theSampleName),
   sampleFileName (theSampleFileName) 
@@ -18,7 +18,7 @@ sample::sample (TString theSampleName, TString theSampleFileName,
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 
-float sample::calcEfficiency ()
+float mysample::calcEfficiency ()
 {
   TH1F * effHisto = (TH1F *) sampleFile->Get ("h_eff") ;
   if (effHisto->GetBinContent (1) == 0) 
@@ -39,17 +39,17 @@ float sample::calcEfficiency ()
 
 
 int
-readSamples (vector<sample> & samples, vector<string> & samplesList, TString readOption)
+readSamples (std::vector<mysample> & samples, std::vector<std::string> & samplesList, TString readOption)
 {
   for (unsigned int iSample = 0 ; iSample < samplesList.size () ; ++iSample)
     {
       TString sampleFolder = gConfigParser->readStringOption (
           TString ("samples::") + samplesList.at (iSample).c_str ()
         ) ;
-      cout << "reading " << samplesList.at (iSample) << " from : " << sampleFolder << "\n" ; 
-      samples.push_back (sample (samplesList.at (iSample), sampleFolder + "/total.root", readOption)) ; 
+      std::cout << "reading " << samplesList.at (iSample) << " from : " << sampleFolder << "\n" ;
+      samples.push_back (mysample (samplesList.at (iSample), sampleFolder + "/total.root", readOption)) ;
       int done = samples.back ().sampleTree->GetEntries () ;  
-      cout << " --> read " << done << " events\n" ; 
+      std::cout << " --> read " << done << " events\n" ;
     }
   return 0 ;
 }
@@ -58,19 +58,19 @@ readSamples (vector<sample> & samples, vector<string> & samplesList, TString rea
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 int
-readSamples (vector<sample> & samples, vector<string> & samplesList, const unique_ptr<CfgParser> & lConfigParser, TString readOption)
+readSamples (std::vector<mysample> & samples, std::vector<std::string> & samplesList, const std::unique_ptr<CfgParser> & lConfigParser, TString readOption)
 {
   for (unsigned int iSample = 0 ; iSample < samplesList.size () ; ++iSample)
     {
       TString sampleFolder = lConfigParser->readStringOpt (
 							   (TString ("samples::") + samplesList.at (iSample).c_str ()).Data()
 							   ) ;
-      cout << "reading " << samplesList.at (iSample) << " from : " << sampleFolder << "\n" ; 
+      std::cout << "reading " << samplesList.at (iSample) << " from : " << sampleFolder << "\n" ;
       //vector<Sample> sample (new Sample(samplesList.at (iSample) , (sampleFolder + string("/goodfiles.txt")).Data()));
       //#samples.push_back (sample);
-      samples.push_back (sample (samplesList.at (iSample), sampleFolder + "/total.root", readOption)) ; 
+      samples.push_back (mysample (samplesList.at (iSample), sampleFolder + "/total.root", readOption)) ;
       int done = samples.back ().sampleTree->GetEntries () ;  
-      cout << " --> read " << done << " events\n" ; 
+      std::cout << " --> read " << done << " events\n" ;
     }
   return 0 ;
 }
@@ -79,28 +79,28 @@ readSamples (vector<sample> & samples, vector<string> & samplesList, const uniqu
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 
-vector<pair<TString, TCut> >
-readCutsFile (string filename)
+std::vector<std::pair<TString, TCut> >
+readCutsFile (std::string filename)
 {
-  ifstream infile (filename) ;
-  vector<pair<TString, TCut> > selections ;
+  std::ifstream infile (filename) ;
+  std::vector<std::pair<TString, TCut> > selections ;
 
-  string line ;
+  std::string line ;
   while (getline (infile, line))
     {
-      istringstream iss (line) ;
-      string dummy ;
+      std::istringstream iss (line) ;
+      std::string dummy ;
       iss >> dummy ;
       if (dummy.size () < 2) continue ;
       size_t found = dummy.find ("%") ;
-      if (found != string::npos) continue ;
+      if (found != std::string::npos) continue ;
       size_t limit = line.find_first_of ("=") ;
-      if (limit == string::npos) continue ;
+      if (limit == std::string::npos) continue ;
 //       cout << line << endl ;
 //       cout << limit << endl ;
-      string selection = line.substr (limit+1) ;
+      std::string selection = line.substr (limit+1) ;
 //       cout << dummy << "|" << selection << endl ;
-      selections.push_back (pair<TString, TCut> (dummy.c_str (), selection.c_str ())) ;
+      selections.push_back (std::pair<TString, TCut> (dummy.c_str (), selection.c_str ())) ;
     }
   return selections ;  
 }
@@ -109,31 +109,31 @@ readCutsFile (string filename)
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 
-vector<pair <TString, TCut> > 
-readCutsFile (vector<string> activeSelections, string filename)
+std::vector<std::pair <TString, TCut> >
+readCutsFile (std::vector<std::string> activeSelections, std::string filename)
 {
-  ifstream infile (filename) ;
-  vector<pair<TString, TCut> > selections ;
+  std::ifstream infile (filename) ;
+  std::vector<std::pair<TString, TCut> > selections ;
 
-  string line ;
+  std::string line ;
   while (getline (infile, line))
     {
-      istringstream iss (line) ;
-      string dummy ;
+      std::istringstream iss (line) ;
+      std::string dummy ;
       iss >> dummy ;
       if (dummy.size () < 2) continue ;
       size_t found = dummy.find ("#") ;
-      if (found != string::npos) continue ;
+      if (found != std::string::npos) continue ;
       size_t limit = line.find_first_of ("=") ;
-      if (limit == string::npos) continue ;
+      if (limit == std::string::npos) continue ;
 //       cout << line << endl ;
 //       cout << limit << endl ;
-      string selection = line.substr (limit+1) ;
+      std::string selection = line.substr (limit+1) ;
 //       cout << dummy << "|" << selection << endl ;
       if (find (activeSelections.begin (), activeSelections.end (), dummy) 
           == activeSelections.end ())
         continue ;
-      selections.push_back (pair<TString, TCut> (dummy.c_str (), selection.c_str ())) ;
+      selections.push_back (std::pair<TString, TCut> (dummy.c_str (), selection.c_str ())) ;
     }
   return selections ;  
 }
@@ -141,38 +141,38 @@ readCutsFile (vector<string> activeSelections, string filename)
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-vector<pair <string, string> > readVarNamesFile (vector<string> varList, string filename)
+std::vector<std::pair <std::string, std::string> > readVarNamesFile (std::vector<std::string> varList, std::string filename)
 {
-  ifstream infile (filename) ;
-  vector<pair<string, string> > varNames ;
+  std::ifstream infile (filename) ;
+  std::vector<std::pair<std::string, std::string> > varNames ;
 
-  string comments("@@@");
+  std::string comments("@@@");
 
-  string line ;
+  std::string line ;
   while (getline (infile, line))
   {
-      istringstream iss (line) ;
-      string dummy ;
+      std::istringstream iss (line) ;
+      std::string dummy ;
       iss >> dummy ;
       //cout << "PARSE:--" << dummy << endl;
       if (dummy.size () < 2) continue ;
       size_t found = dummy.find (comments) ;
-      if (found != string::npos) continue ;
+      if (found != std::string::npos) continue ;
       size_t limit = line.find_first_of ("=") ;
-      if (limit == string::npos) continue ;    
-      string name = line.substr (limit+1) ;
+      if (limit == std::string::npos) continue ;
+      std::string name = line.substr (limit+1) ;
       if (find (varList.begin (), varList.end (), dummy) 
           == varList.end ())
         continue ;
       // trim tring as whitespace interfere with ROOT positioning
-      size_t first = name.find_first_not_of(string(" \t\f\v\n\r"));
-      size_t last = name.find_last_not_of(string(" \t\f\v\n\r"));
+      size_t first = name.find_first_not_of(std::string(" \t\f\v\n\r"));
+      size_t last = name.find_last_not_of(std::string(" \t\f\v\n\r"));
       name = name.substr(first, (last-first+1));
 
       //name = string(boost::algorithm::trim( name )) ;
       //varNames.push_back (pair<string, string> (dummy, name) ) ;
       //cout << "!" << dummy << "! !" << name << "!" << endl;
-      varNames.push_back(make_pair(dummy, name));
+      varNames.push_back(std::make_pair(dummy, name));
   }
   return varNames;
 }
@@ -204,7 +204,7 @@ std::vector<std::string> split(const std::string &s, char delim)
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 
-void addTo (vector<float> & total, vector<float> & addition)
+void addTo (std::vector<float> & total, std::vector<float> & addition)
 {
   for (unsigned int i = 0 ; i < total.size () ; ++i)
     total.at (i) += addition.at (i) ;
@@ -213,13 +213,13 @@ void addTo (vector<float> & total, vector<float> & addition)
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-void printTableTitle (std::ostream& out, vector<string> & sample, unsigned int NSpacesColZero, unsigned int NSpacesColumns) 
+void printTableTitle (std::ostream& out, std::vector<std::string> & sample, unsigned int NSpacesColZero, unsigned int NSpacesColumns)
 {
   for (unsigned int i = 0 ; i < NSpacesColZero ; ++i) out << " " ;
   out << "| " ;
   for (unsigned int iSample = 0 ; iSample < sample.size () ; ++iSample)
     {
-      string word = sample.at (iSample).substr (0, NSpacesColumns) ;
+      std::string word = sample.at (iSample).substr (0, NSpacesColumns) ;
       out << word ;
       if ( NSpacesColumns < word.size () ) NSpacesColumns = word.size();
       for (unsigned int i = 0 ; i < NSpacesColumns - word.size () ; ++i) out << " " ;
@@ -231,9 +231,9 @@ void printTableTitle (std::ostream& out, vector<string> & sample, unsigned int N
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-void printTableTitle (std::ostream& out, vector<sample> & sample, unsigned int NSpacesColZero, unsigned int NSpacesColumns) 
+void printTableTitle (std::ostream& out, std::vector<mysample> & sample, unsigned int NSpacesColZero, unsigned int NSpacesColumns)
 {
-  vector<string> names ;
+  std::vector<std::string> names ;
   for (unsigned int iSample = 0 ; iSample < sample.size () ; ++iSample)
     names.push_back (sample.at (iSample).sampleName.Data ()) ;
   printTableTitle (out, names, NSpacesColZero, NSpacesColumns) ;
@@ -242,9 +242,9 @@ void printTableTitle (std::ostream& out, vector<sample> & sample, unsigned int N
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-void printTableTitle (std::ostream& out, vector<sample> & sample, vector<string> & DataDrivenBkgsName, unsigned int NSpacesColZero, unsigned int NSpacesColumns)
+void printTableTitle (std::ostream& out, std::vector<mysample> & sample, std::vector<std::string> & DataDrivenBkgsName, unsigned int NSpacesColZero, unsigned int NSpacesColumns)
 {
-  vector<string> names ;
+  std::vector<std::string> names ;
   for (unsigned int iSample = 0 ; iSample < sample.size () ; ++iSample)
     names.push_back (sample.at (iSample).sampleName.Data ()) ;
 
@@ -256,14 +256,14 @@ void printTableTitle (std::ostream& out, vector<sample> & sample, vector<string>
 }
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
-void printTableBody  (std::ostream& out, vector<pair <TString, TCut> > & selections, counters & count, vector<sample> & samples,
+void printTableBody  (std::ostream& out, std::vector<std::pair <TString, TCut> > & selections, counters & count, std::vector<mysample> & samples,
                       unsigned int NSpacesColZero, unsigned int NSpacesColumns, unsigned int precision)
 {
   for (unsigned int iSel = 0 ; iSel < selections.size () ; ++iSel)
   {
     out << selections.at (iSel).first ;
-    if ( NSpacesColZero < string(selections.at (iSel).first.Data ()).size () ) NSpacesColZero = string(selections.at (iSel).first.Data ()).size () ; //guard if name too long
-    for (unsigned int i = 0 ; i < NSpacesColZero - string(selections.at (iSel).first.Data ()).size () ; ++i) out << " " ;
+    if ( NSpacesColZero < std::string(selections.at (iSel).first.Data ()).size () ) NSpacesColZero = std::string(selections.at (iSel).first.Data ()).size () ; //guard if name too long
+    for (unsigned int i = 0 ; i < NSpacesColZero - std::string(selections.at (iSel).first.Data ()).size () ; ++i) out << " " ;
     out << "|" ;
     for (unsigned int iSample = 0 ; iSample < samples.size () ; ++iSample)
       {
@@ -271,7 +271,7 @@ void printTableBody  (std::ostream& out, vector<pair <TString, TCut> > & selecti
         int subtractspace = 0 ;
         if (evtnum > 0) subtractspace = int (log10 (evtnum)) + precision + 1 ;
         for (unsigned int i = 0 ; i < NSpacesColumns - subtractspace ; ++i) out << " " ;
-        out << setprecision (precision) << fixed << evtnum
+        out << std::setprecision (precision) << std::fixed << evtnum
              << " |" ;
       }
     out << "\n" ;
@@ -279,14 +279,14 @@ void printTableBody  (std::ostream& out, vector<pair <TString, TCut> > & selecti
 }
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
-void printTableBody  (std::ostream& out, vector<pair <TString, TCut> > & selections, counters & count, vector<sample> & samples, vector<vector<float>> & DataDrivenSamplesYields,
+void printTableBody  (std::ostream& out, std::vector<std::pair <TString, TCut> > & selections, counters & count, std::vector<mysample> & samples, std::vector<std::vector<float>> & DataDrivenSamplesYields,
                       unsigned int NSpacesColZero, unsigned int NSpacesColumns, unsigned int precision)
 {
   for (unsigned int iSel = 0 ; iSel < selections.size () ; ++iSel)
   {
     out << selections.at (iSel).first ;
-    if ( NSpacesColZero < string(selections.at (iSel).first.Data ()).size () ) NSpacesColZero = string(selections.at (iSel).first.Data ()).size () ; //guard if name too long
-    for (unsigned int i = 0 ; i < NSpacesColZero - string(selections.at (iSel).first.Data ()).size () ; ++i) out << " " ;
+    if ( NSpacesColZero < std::string(selections.at (iSel).first.Data ()).size () ) NSpacesColZero = std::string(selections.at (iSel).first.Data ()).size () ; //guard if name too long
+    for (unsigned int i = 0 ; i < NSpacesColZero - std::string(selections.at (iSel).first.Data ()).size () ; ++i) out << " " ;
     out << "|" ;
     
     for (unsigned int iSample = 0 ; iSample < samples.size () ; ++iSample)
@@ -295,7 +295,7 @@ void printTableBody  (std::ostream& out, vector<pair <TString, TCut> > & selecti
         int subtractspace = 0 ;
         if (evtnum > 0) subtractspace = int (log10 (evtnum)) + precision + 1 ;
         for (unsigned int i = 0 ; i < NSpacesColumns - subtractspace ; ++i) out << " " ;
-        out << setprecision (precision) << fixed << evtnum
+        out << std::setprecision (precision) << std::fixed << evtnum
              << " |" ;
       }
     for (unsigned int iDDSample = 0 ; iDDSample < DataDrivenSamplesYields.size () ; ++iDDSample)
@@ -304,7 +304,7 @@ void printTableBody  (std::ostream& out, vector<pair <TString, TCut> > & selecti
         int subtractspace = 0 ;
         if (evtnum > 0) subtractspace = int (log10 (evtnum)) + precision + 1 ;
         for (unsigned int i = 0 ; i < NSpacesColumns - subtractspace ; ++i) out << " " ;
-        out << setprecision (precision) << fixed << evtnum
+        out << std::setprecision (precision) << std::fixed << evtnum
              << " |" ;
       }
 
@@ -314,14 +314,14 @@ void printTableBody  (std::ostream& out, vector<pair <TString, TCut> > & selecti
 
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
-void printTableBodyEff  (std::ostream& out, vector<pair <TString, TCut> > & selections, counters & count, vector<sample> & samples,
+void printTableBodyEff  (std::ostream& out, std::vector<std::pair <TString, TCut> > & selections, counters & count, std::vector<mysample> & samples,
                       unsigned int NSpacesColZero, unsigned int NSpacesColumns, unsigned int precision)
 {
   for (unsigned int iSel = 0 ; iSel < selections.size () ; ++iSel)
   {
     out << selections.at (iSel).first ;
-    if ( NSpacesColZero < string(selections.at (iSel).first.Data ()).size () ) NSpacesColZero = string(selections.at (iSel).first.Data ()).size () ; //guard if name too long
-    for (unsigned int i = 0 ; i < NSpacesColZero - string(selections.at (iSel).first.Data ()).size () ; ++i) out << " " ;
+    if ( NSpacesColZero < std::string(selections.at (iSel).first.Data ()).size () ) NSpacesColZero = std::string(selections.at (iSel).first.Data ()).size () ; //guard if name too long
+    for (unsigned int i = 0 ; i < NSpacesColZero - std::string(selections.at (iSel).first.Data ()).size () ; ++i) out << " " ;
     out << "|" ;
     for (unsigned int iSample = 0 ; iSample < samples.size () ; ++iSample)
       {
@@ -338,9 +338,9 @@ void printTableBodyEff  (std::ostream& out, vector<pair <TString, TCut> > & sele
         //int subtractspace = 0 ;
         //if (evtnum > 0) subtractspace = int (log10 (evtnum)) + precision + 1 ;
         //for (unsigned int i = 0 ; i < NSpacesColumns - subtractspace ; ++i) out << " " ;
-        out << setprecision (precision) << fixed << totEff;
+        out << std::setprecision (precision) << std::fixed << totEff;
         out << " (";
-        out << setprecision (precision) << fixed << relEff;
+        out << std::setprecision (precision) << std::fixed << relEff;
         out << " %)";
         //out << "INPUT: " << count.counters.at (iSample).at(iSel+1) << " / " << count.counters.at (iSample).at(0);
         out << " |" ;

--- a/test/addTMVA.cpp
+++ b/test/addTMVA.cpp
@@ -28,7 +28,7 @@ using namespace std ;
 
 
 void
-calcTMVA (sample & thisSample, 
+calcTMVA (mysample & thisSample,
           vector<string> & trainingVariables, 
           vector<string> & spectatorVariables, 
           string mvaName, string weightsFile)
@@ -93,7 +93,7 @@ calcTMVA (sample & thisSample,
 
 
 void
-calcTMVA (vector<sample> & samples,
+calcTMVA (vector<mysample> & samples,
           vector<string> & trainingVariables,
           vector<string> & spectatorVariables,            
           string mvaName, string weightsFile)
@@ -138,7 +138,7 @@ int main (int argc, char** argv)
   // get the samples to be analised
   // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
   
-  vector<sample> samples ;
+  vector<mysample> samples ;
   vector<string> samplesList = gConfigParser->readStringListOption ("general::signals") ;
   readSamples (samples, samplesList, "UPDATE") ;
   samplesList.clear () ;

--- a/test/computeQCDratio.cpp
+++ b/test/computeQCDratio.cpp
@@ -126,7 +126,7 @@ int main (int argc, char** argv)
   // .... .... .... .... .... .... .... .... .... .... .... ....
   
   vector<string> sigSamplesList = gConfigParser->readStringListOption ("general::signals") ;
-  vector<sample> sigSamples ;
+  vector<mysample> sigSamples ;
   readSamples (sigSamples, sigSamplesList) ;
 
   vector<float> signalScales ;
@@ -138,11 +138,11 @@ int main (int argc, char** argv)
     }
 
   vector<string> bkgSamplesList = gConfigParser->readStringListOption ("general::backgrounds") ;
-  vector<sample> bkgSamples ;
+  vector<mysample> bkgSamples ;
   readSamples (bkgSamples, bkgSamplesList) ;
 
   vector<string> DATASamplesList = gConfigParser->readStringListOption ("general::data") ;
-  vector<sample> DATASamples ;
+  vector<mysample> DATASamples ;
   readSamples (DATASamples, DATASamplesList) ;
 
 /*

--- a/test/errQCD.cpp
+++ b/test/errQCD.cpp
@@ -60,7 +60,7 @@ int main (int argc, char** argv)
   // .... .... .... .... .... .... .... .... .... .... .... ....
   
   vector<string> sigSamplesList = gConfigParser->readStringListOption ("general::signals") ;
-  vector<sample> sigSamples ;
+  vector<mysample> sigSamples ;
   readSamples (sigSamples, sigSamplesList) ;
 
   vector<float> signalScales ;
@@ -72,11 +72,11 @@ int main (int argc, char** argv)
     }
 
   vector<string> bkgSamplesList = gConfigParser->readStringListOption ("general::backgrounds") ;
-  vector<sample> bkgSamples ;
+  vector<mysample> bkgSamples ;
   readSamples (bkgSamples, bkgSamplesList) ;
 
   vector<string> DATASamplesList = gConfigParser->readStringListOption ("general::data") ;
-  vector<sample> DATASamples ;
+  vector<mysample> DATASamples ;
   readSamples (DATASamples, DATASamplesList) ;
 
 

--- a/test/evalQCD.cpp
+++ b/test/evalQCD.cpp
@@ -163,7 +163,7 @@ int main (int argc, char** argv)
   // .... .... .... .... .... .... .... .... .... .... .... ....
   
   vector<string> sigSamplesList = gConfigParser->readStringListOption ("general::signals") ;
-  vector<sample> sigSamples ;
+  vector<mysample> sigSamples ;
   readSamples (sigSamples, sigSamplesList) ;
 
   vector<float> signalScales (0);
@@ -175,11 +175,11 @@ int main (int argc, char** argv)
   //   }
 
   vector<string> bkgSamplesList = gConfigParser->readStringListOption ("general::backgrounds") ;
-  vector<sample> bkgSamples ;
+  vector<mysample> bkgSamples ;
   readSamples (bkgSamples, bkgSamplesList) ;
 
   vector<string> DATASamplesList = gConfigParser->readStringListOption ("general::data") ;
-  vector<sample> DATASamples ;
+  vector<mysample> DATASamples ;
   readSamples (DATASamples, DATASamplesList) ;
 
 /*

--- a/test/measureBTagEff.cpp
+++ b/test/measureBTagEff.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
 
     // read MC sample
     vector<string> bkgSamplesList = gConfigParser->readStringListOption ("general::backgrounds") ;   
-    vector<sample> samples ;
+    vector<mysample> samples ;
     readSamples (samples, bkgSamplesList) ;
 
     // read list of selections

--- a/test/plot2D.cpp
+++ b/test/plot2D.cpp
@@ -47,7 +47,7 @@ void printTitle (vector<string> & sample, unsigned int NSpacesColZero, unsigned 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
 
-void printTitle (vector<sample> & sample, unsigned int NSpacesColZero, unsigned int NSpacesColumns) 
+void printTitle (vector<mysample> & sample, unsigned int NSpacesColZero, unsigned int NSpacesColumns)
 {
   vector<string> names ;
   for (unsigned int iSample = 0 ; iSample < sample.size () ; ++iSample)
@@ -61,7 +61,7 @@ void printTitle (vector<sample> & sample, unsigned int NSpacesColZero, unsigned 
 
 
 void
-add2DHistos (vector<sample> & samples, HistoManager * manager,
+add2DHistos (vector<mysample> & samples, HistoManager * manager,
              vector<vector<string> > & variablesList,
              vector<pair <TString, TCut> > & selections,
              bool isSignal,
@@ -133,7 +133,7 @@ vector<string> listNeededVars (vector<vector<string> > & variablesList)
 
 
 void
-fill2DHistos (vector<sample> & samples, HistoManager * manager, 
+fill2DHistos (vector<mysample> & samples, HistoManager * manager,
               vector<vector<string> > & variablesList,
               vector<pair <TString, TCut> > & selections,
               float lumi,
@@ -219,7 +219,7 @@ fill2DHistos (vector<sample> & samples, HistoManager * manager,
 
 
 vector<THStack *> 
-stackHistos (vector<sample> & samples, HistoManager * manager, 
+stackHistos (vector<mysample> & samples, HistoManager * manager,
             vector<string> & variablesList,
             vector<pair <TString, TCut> > & selections,
             const string & tag)
@@ -284,7 +284,7 @@ int main (int argc, char** argv)
   // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
   
   vector<string> sigSamplesList = gConfigParser->readStringListOption ("general::signals") ;
-  vector<sample> sigSamples ;
+  vector<mysample> sigSamples ;
   readSamples (sigSamples, sigSamplesList) ;
 
   vector<float> signalScales ;
@@ -296,11 +296,11 @@ int main (int argc, char** argv)
     }
 
   vector<string> bkgSamplesList = gConfigParser->readStringListOption ("general::backgrounds") ;
-  vector<sample> bkgSamples ;
+  vector<mysample> bkgSamples ;
   readSamples (bkgSamples, bkgSamplesList) ;
 
   vector<string> DATASamplesList = gConfigParser->readStringListOption ("general::data") ;
-  vector<sample> DATASamples ;
+  vector<mysample> DATASamples ;
   readSamples (DATASamples, DATASamplesList) ;
 
   // get the selections to be applied

--- a/test/plotNEW.cpp
+++ b/test/plotNEW.cpp
@@ -91,7 +91,7 @@ int main (int argc, char** argv)
   // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
   
   vector<string> sigSamplesList = gConfigParser->readStringListOption ("general::signals") ;
-  vector<sample> sigSamples ;
+  vector<mysample> sigSamples ;
   readSamples (sigSamples, sigSamplesList) ;
 
   vector<float> signalScales ;
@@ -103,11 +103,11 @@ int main (int argc, char** argv)
     }
 
   vector<string> bkgSamplesList = gConfigParser->readStringListOption ("general::backgrounds") ;
-  vector<sample> bkgSamples ;
+  vector<mysample> bkgSamples ;
   readSamples (bkgSamples, bkgSamplesList) ;
 
   vector<string> DATASamplesList = gConfigParser->readStringListOption ("general::data") ;
-  vector<sample> DATASamples ;
+  vector<mysample> DATASamples ;
   readSamples (DATASamples, DATASamplesList) ;
 
   // get the selections to be applied

--- a/test/plotSimple.cpp
+++ b/test/plotSimple.cpp
@@ -63,13 +63,13 @@ int main (int argc, char** argv)
     
     vector<string> sigSamplesList; 
     vector<float> signalScales ;
-    vector<sample> sigSamples ;
+    vector<mysample> sigSamples ;
   
     vector<string> bkgSamplesList;
-    vector<sample> bkgSamples ;
+    vector<mysample> bkgSamples ;
   
     vector<string> DATASamplesList;
-    vector<sample> DATASamples ;
+    vector<mysample> DATASamples ;
   
   
     if (gConfigParser->isDefined ("general::signals"))

--- a/test/plotTMVA.cpp
+++ b/test/plotTMVA.cpp
@@ -28,7 +28,7 @@ using namespace std ;
 
 
 void
-calcTMVA (sample & thisSample, vector<string> & trainingVariables, 
+calcTMVA (mysample & thisSample, vector<string> & trainingVariables,
           string mvaName, string weightsFile)
 {
 
@@ -66,7 +66,7 @@ calcTMVA (sample & thisSample, vector<string> & trainingVariables,
 
 
 void
-calcTMVA (vector<sample> & samples,
+calcTMVA (vector<mysample> & samples,
            vector<string> & trainingVariables,
            string mvaName, string weightsFile)
 {
@@ -107,7 +107,7 @@ int main (int argc, char** argv)
   // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
   
   vector<string> sigSamplesList = gConfigParser->readStringListOption ("general::signals") ;
-  vector<sample> sigSamples ;
+  vector<mysample> sigSamples ;
   readSamples (sigSamples, sigSamplesList) ;
 
   vector<float> signalScales ;
@@ -119,11 +119,11 @@ int main (int argc, char** argv)
     }
 
   vector<string> bkgSamplesList = gConfigParser->readStringListOption ("general::backgrounds") ;
-  vector<sample> bkgSamples ;
+  vector<mysample> bkgSamples ;
   readSamples (bkgSamples, bkgSamplesList) ;
 
   vector<string> DATASamplesList = gConfigParser->readStringListOption ("general::data") ;
-  vector<sample> DATASamples ;
+  vector<mysample> DATASamples ;
   readSamples (DATASamples, DATASamplesList) ;
 
   // get the variables to be cosidered in the training

--- a/test/plotter.cpp
+++ b/test/plotter.cpp
@@ -72,7 +72,7 @@ int main (int argc, char** argv)
   // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
   
   vector<string> sigSamplesList = gConfigParser->readStringListOption ("general::signals") ;
-  vector<sample> sigSamples ;
+  vector<mysample> sigSamples ;
   readSamples (sigSamples, sigSamplesList) ;
 
   vector<float> signalScales ;
@@ -84,11 +84,11 @@ int main (int argc, char** argv)
     }
 
   vector<string> bkgSamplesList = gConfigParser->readStringListOption ("general::backgrounds") ;
-  vector<sample> bkgSamples ;
+  vector<mysample> bkgSamples ;
   readSamples (bkgSamples, bkgSamplesList) ;
 
   // FIXME si riesce ad evitare questa duplicazione?
-  vector<sample> allSamples (bkgSamples) ;  
+  vector<mysample> allSamples (bkgSamples) ;
   allSamples.insert (allSamples.end (), sigSamples.begin (), sigSamples.end ()) ;
   
   // get the selections to be applied

--- a/test/readSamples.cpp
+++ b/test/readSamples.cpp
@@ -32,11 +32,11 @@ int main (int argc, char** argv)
   // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 
   vector<string> sigSamplesList = gConfigParser->readStringListOption ("general::signals") ;
-  vector<sample> sigSamples ;
+  vector<mysample> sigSamples ;
   readSamples (sigSamples, sigSamplesList) ;
 
   vector<string> bkgSamplesList = gConfigParser->readStringListOption ("general::backgrounds") ;
-  vector<sample> bkgSamples ;
+  vector<mysample> bkgSamples ;
   readSamples (bkgSamples, bkgSamplesList) ;
 
   // get the selections to be applied


### PR DESCRIPTION
Since we need to switch to CMSSW_10_2_X (due to the new DNN for signal extraction and to have the most updated version of Combine) some changes in the code are need to adapt to C++17.

## Problems during compilation:

- the C++ function `throw(argument)` is now deprecated
- a new `std::sample` function is defined starting from C++17 and conflicts with `struct sample` defined in `interface/utils.h`

## Changes made: 

- `struct sample` in `interface/utils.h` has been renamed **`mysample`** and consequently propagated to all the files using it
- some of the `using namespace std` declarations in `interface` and `src` directories were preventing the compilation of the code, so I removed them and added `std::` where it was necessary
- changes in `README`:
  - switch to CMSSW_10_2_16
  - use tag `v8.0.1` of the Combine package
  - added a link to CodiMD with instructions to run the hh->bbtautau anlysis in the LLR framework