### PR TITLE
Changes before skim

### DIFF
--- a/config/skim_Legacy2016_mib.cfg
+++ b/config/skim_Legacy2016_mib.cfg
@@ -72,11 +72,11 @@ vbfTriggers = NONE
 
 
 [bTagScaleFactors]
-SFFileDeepFlavor  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_9_0_0/src/KLUBAnalysis/weights/bTagWeights/DeepJet_2016LegacySF_V1.csv
-effFileDeepFlavor = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_9_0_0/src/KLUBAnalysis/weights/bTagWeights/ !! FIXME !!
+SFFileDeepFlavor  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/bTagWeights/DeepJet_2016LegacySF_V1.csv
+effFileDeepFlavor = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/bTagWeights/ !! FIXME !!
 
-SFFileDeepCSV  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_9_0_0/src/KLUBAnalysis/weights/bTagWeights/DeepCSV_2016LegacySF_V1.csv
-effFileDeepCSV = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_9_0_0/src/KLUBAnalysis/weights/bTagWeights/ !! FIXME !!
+SFFileDeepCSV  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/bTagWeights/DeepCSV_2016LegacySF_V1.csv
+effFileDeepCSV = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/bTagWeights/ !! FIXME !!
 
 [debug]
 skipTriggers = false
@@ -85,14 +85,14 @@ skipTriggers = false
 
 [BDTsm]
 computeMVA = true
-weights    = /gwpool/users/dzuolo/HbbtautauAnalysis2018/CMSSW_9_0_0/src/KLUBAnalysis/weights/newBDT/BDTnewSM.xml
+weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/newBDT/BDTnewSM.xml
 kl         = 1, 0, 2.45, 5, 30
 variables  = bjet2_pt:pt_b2, bH_pt:pt_hbb, dau1_pt:pt_l1, dau2_pt:pt_l2, tauH_SVFIT_pt:pt_htautau_sv, BDT_HT20:HT_otherjets, p_zeta:p_zeta, p_zeta_visible:p_zetavisible, BDT_ditau_deltaPhi:dphi_l1l2, BDT_tauHsvfitMet_deltaPhi:dphi_METhtautau_sv, mT_tauH_MET:MT_htautau, mT_total:MT_tot, MT2:MT2, BDT_MX:mass_X, BDT_bH_tauH_MET_InvMass:mass_H, BDT_bH_tauH_SVFIT_InvMass:mass_H_sv, BDT_bH_tauH_InvMass:mass_H_vis, HHKin_mass_raw:mass_H_kinfit, HHKin_mass_raw_chi2:mass_H_kinfit_chi2, BDT_MET_bH_cosTheta:costheta_METhbb
 
 
 [BDTlm]
 computeMVA = false
-weights    = /gwpool/users/dzuolo/HbbtautauAnalysis2018/CMSSW_9_0_0/src/KLUBAnalysis/weights/newBDT/BDTnewLM.xml
+weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/newBDT/BDTnewLM.xml
 mass       = 250, 280, 320, 350, 400, 450, 650, 900
 spin       = 0 #, 1
 variables  = bH_pt:pt_hbb, tauH_MET_pt:pt_htautau, met_et:pt_MET, p_zeta_visible:p_zetavisible, BDT_ditau_deltaPhi:dphi_l1l2, BDT_dib_deltaPhi:dphi_b1b2, BDT_dau1MET_deltaPhi:dphi_l1MET, bH_MET_deltaR:dR_hbbMET, ditau_deltaR_per_tauH_MET_pt:dR_l1l2Pt_htautau, ditau_deltaR_per_tauHsvfitpt:dR_l1l2Pt_htautau_sv, mT1:MT_l1, mT_tauH_SVFIT_MET:MT_htautau_sv, MT2:MT2, BDT_topPairMasses:mass_top1, BDT_bH_tauH_MET_InvMass:mass_H, BDT_bH_tauH_InvMass:mass_H_vis, HHKin_mass_raw:mass_H_kinfit, HHKin_mass_raw_chi2:mass_H_kinfit_chi2, BDT_dib_CalcPhi:phi_2_sv,  BDT_MET_tauH_SVFIT_cosTheta:costheta_METhtautau_sv
@@ -100,7 +100,7 @@ variables  = bH_pt:pt_hbb, tauH_MET_pt:pt_htautau, met_et:pt_MET, p_zeta_visible
 
 [BDTmm]
 computeMVA = false
-weights    = /gwpool/users/dzuolo/HbbtautauAnalysis2018/CMSSW_9_0_0/src/KLUBAnalysis/weights/newBDT/BDTnewMM.xml
+weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/newBDT/BDTnewMM.xml
 mass       = 250, 280, 320, 350, 400, 450, 650, 900
 spin       = 0 #, 1
 variables  = tauH_pt:pt_l1l2, p_zeta:p_zeta, BDT_dib_abs_deltaPhi:abs_dphi_b1b2, BDT_tauHsvfitMet_abs_deltaPhi:abs_dphi_METhtautau_sv, BDT_HHsvfit_abs_deltaPhi:abs_dphi_hbbhatutau_sv, dib_deltaEta:abs_deta_b1b2, dau2_MET_deltaEta:abs_deta_l2MET, bH_MET_deltaEta:abs_deta_hbbMET, ditau_deltaR:dR_l1l2, mT1:MT_l1, mT_tauH_SVFIT_MET:MT_htautau_sv, mT_total:MT_tot, BDT_MX:mass_X, BDT_bH_tauH_InvMass:mass_H_vis,  HHKin_mass_raw:mass_H_kinfit, HHKin_mass_raw_chi2:mass_H_kinfit_chi2, BDT_total_CalcPhi:phi_sv, BDT_ditau_CalcPhi:phi_1_sv, BDT_b1_bH_cosTheta:costheta_b1hbb, BDT_tauH_SVFIT_reson_cosTheta:costheta_htautau_svhhMET
@@ -108,7 +108,7 @@ variables  = tauH_pt:pt_l1l2, p_zeta:p_zeta, BDT_dib_abs_deltaPhi:abs_dphi_b1b2,
 
 [BDThm]
 computeMVA = false
-weights    = /gwpool/users/dzuolo/HbbtautauAnalysis2018/CMSSW_9_0_0/src/KLUBAnalysis/weights/newBDT/BDTnewHM.xml
+weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/newBDT/BDTnewHM.xml
 mass       = 250, 280, 320, 350, 400, 450, 650, 900
 spin       = 0 #, 1
 variables  = bH_pt:pt_hbb, dau1_pt:pt_l1, dau2_pt:pt_l2, tauH_SVFIT_pt:pt_htautau_sv, BDT_HT20:HT_otherjets, p_zeta:p_zeta, p_zeta_visible:p_zetavisible, BDT_tauHsvfitMet_abs_deltaPhi:abs_dphi_METhtautau_sv, BDT_bHMet_deltaPhi:dphi_hbbMET, ditau_deltaR:dR_l1l2, bH_tauH_MET_deltaR:dR_hbbhtautau, tauH_SVFIT_mass:mass_htautau_sv, mT_tauH_MET:MT_htautau, MT2:MT2, BDT_MX:mass_X,  BDT_bH_tauH_MET_InvMass:mass_H, BDT_bH_tauH_SVFIT_InvMass:mass_H_sv, BDT_bH_tauH_InvMass:mass_H_vis, HHKin_mass_raw:mass_H_kinfit, HHKin_mass_raw_chi2:mass_H_kinfit_chi2
@@ -116,12 +116,12 @@ variables  = bH_pt:pt_hbb, dau1_pt:pt_l1, dau2_pt:pt_l2, tauH_SVFIT_pt:pt_htauta
 
 [BDTVBF]
 computeMVA = false
-weights    = /gwpool/users/dzuolo/HbbtautauAnalysis2018/CMSSW_9_0_0/src/KLUBAnalysis/weights/newBDT/BDTVBF.xml
+weights    = //gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/newBDT/BDTVBF.xml
 #variables  = VBFjj_dEtaSign:BDT_j1j2n_dEtaSign, HH_deltaR:BDT_n_HH_deltaR, dib_dEtaSign:BDT_n_b1b2_dEtaSign, VBFjj_deltaEta:BDT_j1j2n_dEta, VBFjj_mass:BDT_j1j2n_Mjj, VBFjet2_pt:BDT_j2n_pt, tauH_pt:BDT_n_ditau_pt, bH_VBF1_deltaEta:BDT_bbH_j1n_dEta, VBFjet1_btag:BDT_j1n_csv, VBFjet1_pt:BDT_j1n_pt, dib_deltaR:BDT_n_dib_deltaR, VBFjet2_PUjetID:BDT_j2n_PUjetID
 variables  = VBFjet1_pt:BDT_j1n_pt, bH_pt:BDT_n_bH_pt, dib_dEtaSign:BDT_n_b1b2_dEtaSign, ditau_deltaR:ditau_deltaR, HH_deltaR:BDT_n_HH_deltaR, HH_zV:BDT_HH_zV_n, VBFjj_dEtaSign:BDT_j1j2n_dEtaSign, VBFjj_mass:BDT_j1j2n_Mjj
 
 
 [DYLOtoNLOreweight]
 doReweight = true
-inputFile = /gwpool/users/dzuolo/HbbtautauAnalysis2018/CMSSW_9_0_0/src/KLUBAnalysis/weights/DYLOtoNLOreweight/comp_LO_NLO_7.root
-sfFile    = /gwpool/users/dzuolo/HbbtautauAnalysis2018/CMSSW_9_0_0/src/KLUBAnalysis/weights/DYLOtoNLOreweight/DY_Scale_factor_nbjet_njetBins_other_bkg_fixed_27June.root
+inputFile = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/DYLOtoNLOreweight/comp_LO_NLO_7.root
+sfFile    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/DYLOtoNLOreweight/DY_Scale_factor_nbjet_njetBins_other_bkg_fixed_27June.root

--- a/interface/bigTree.h
+++ b/interface/bigTree.h
@@ -84,7 +84,7 @@ public :
    Int_t           lheNOutPartons;
    Int_t           lheNOutB;
    Float_t         aMCatNLOweight;
-   TString         susyModel;
+   //TString         susyModel;
 
    std::vector<float>   *genpart_px;
    std::vector<float>   *genpart_py;
@@ -244,8 +244,6 @@ public :
    std::vector<int>     *decayMode;
    std::vector<Long64_t> *tauID;
    std::vector<float>   *combreliso;
-   // std::vector<float>   *daughters_IetaIeta;
-   // std::vector<float>   *daughters_deltaPhiSuperClusterTrackAtVtx;
    std::vector<float>   *daughters_depositR03_tracker;
    std::vector<float>   *daughters_depositR03_ecal;
    std::vector<float>   *daughters_depositR03_hcal;
@@ -255,10 +253,7 @@ public :
    std::vector<float>   *photonPtSumOutsideSignalCone;
    std::vector<int>     *daughters_decayModeFindingNewDMs;
    std::vector<float>   *daughters_byCombinedIsolationDeltaBetaCorrRaw3Hits;
-   std::vector<float>   *daughters_byIsolationMVArun2v1DBoldDMwLTraw;
-   std::vector<float>   *daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017;
    std::vector<float>   *daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017;
-   std::vector<float>   *daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017;
    std::vector<float>   *daughters_byDeepTau2017v2p1VSjetraw;
    std::vector<float>   *daughters_byDeepTau2017v2p1VSeraw;
    std::vector<float>   *daughters_byDeepTau2017v2p1VSmuraw;
@@ -326,6 +321,7 @@ public :
    // JEC uncertainty sources
    std::vector<float> *jets_jetUnc_AbsoluteFlavMap_up; // up variations
    std::vector<float> *jets_jetUnc_AbsoluteMPFBias_up;
+   std::vector<float> *jets_jetUnc_AbsoluteSample_up;
    std::vector<float> *jets_jetUnc_AbsoluteScale_up;
    std::vector<float> *jets_jetUnc_AbsoluteStat_up;
    std::vector<float> *jets_jetUnc_FlavorQCD_up;
@@ -345,6 +341,7 @@ public :
    std::vector<float> *jets_jetUnc_RelativePtEC1_up;
    std::vector<float> *jets_jetUnc_RelativePtEC2_up;
    std::vector<float> *jets_jetUnc_RelativePtHF_up;
+   std::vector<float> *jets_jetUnc_RelativeSample_up;
    std::vector<float> *jets_jetUnc_RelativeStatEC_up;
    std::vector<float> *jets_jetUnc_RelativeStatFSR_up;
    std::vector<float> *jets_jetUnc_RelativeStatHF_up;
@@ -353,6 +350,7 @@ public :
    std::vector<float> *jets_jetUnc_TimePtEta_up;
    std::vector<float> *jets_jetUnc_AbsoluteFlavMap_dw; // down variations
    std::vector<float> *jets_jetUnc_AbsoluteMPFBias_dw;
+   std::vector<float> *jets_jetUnc_AbsoluteSample_dw;
    std::vector<float> *jets_jetUnc_AbsoluteScale_dw;
    std::vector<float> *jets_jetUnc_AbsoluteStat_dw;
    std::vector<float> *jets_jetUnc_FlavorQCD_dw;
@@ -372,6 +370,7 @@ public :
    std::vector<float> *jets_jetUnc_RelativePtEC1_dw;
    std::vector<float> *jets_jetUnc_RelativePtEC2_dw;
    std::vector<float> *jets_jetUnc_RelativePtHF_dw;
+   std::vector<float> *jets_jetUnc_RelativeSample_dw;
    std::vector<float> *jets_jetUnc_RelativeStatEC_dw;
    std::vector<float> *jets_jetUnc_RelativeStatFSR_dw;
    std::vector<float> *jets_jetUnc_RelativeStatHF_dw;
@@ -414,6 +413,7 @@ public :
    TBranch        *b_EventNumber;   //!
    TBranch        *b_RunNumber;   //!
    TBranch        *b_lumi;   //!
+   TBranch        *b_year;   //!
    TBranch        *b_passecalBadCalibFilterUpdate;   //!
    TBranch        *b_prefiringweight;
    TBranch        *b_prefiringweightup;
@@ -472,7 +472,7 @@ public :
    TBranch        *b_lheNOutPartons; //!
    TBranch        *b_lheNOutB; //!
    TBranch        *b_aMCatNLOweight;   //!
-   TBranch        *b_susyModel;   //!
+   //TBranch        *b_susyModel;   //!
    TBranch        *b_genpart_px;   //!
    TBranch        *b_genpart_py;   //!
    TBranch        *b_genpart_pz;   //!
@@ -634,10 +634,10 @@ public :
    TBranch        *b_photonPtSumOutsideSignalCone;   //!
    TBranch        *b_daughters_decayModeFindingNewDMs;   //!
    TBranch        *b_daughters_byCombinedIsolationDeltaBetaCorrRaw3Hits;   //!
-   TBranch        *b_daughters_byIsolationMVArun2v1DBoldDMwLTraw; //!
-   TBranch        *b_daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017; //!
+   //TBranch        *b_daughters_byIsolationMVArun2v1DBoldDMwLTraw; //!
+   //TBranch        *b_daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017; //!
    TBranch        *b_daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017; //!
-   TBranch        *b_daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017;
+   //TBranch        *b_daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017;
    TBranch        *b_daughters_byDeepTau2017v2p1VSjetraw;
    TBranch        *b_daughters_byDeepTau2017v2p1VSeraw;
    TBranch        *b_daughters_byDeepTau2017v2p1VSmuraw;
@@ -705,6 +705,7 @@ public :
    // JEC uncertainties
    TBranch        *b_jets_jetUnc_AbsoluteFlavMap_up; // Up variations
    TBranch        *b_jets_jetUnc_AbsoluteMPFBias_up;
+   TBranch        *b_jets_jetUnc_AbsoluteSample_up;
    TBranch        *b_jets_jetUnc_AbsoluteScale_up;
    TBranch        *b_jets_jetUnc_AbsoluteStat_up;
    TBranch        *b_jets_jetUnc_FlavorQCD_up;
@@ -724,6 +725,7 @@ public :
    TBranch        *b_jets_jetUnc_RelativePtEC1_up;
    TBranch        *b_jets_jetUnc_RelativePtEC2_up;
    TBranch        *b_jets_jetUnc_RelativePtHF_up;
+   TBranch        *b_jets_jetUnc_RelativeSample_up;
    TBranch        *b_jets_jetUnc_RelativeStatEC_up;
    TBranch        *b_jets_jetUnc_RelativeStatFSR_up;
    TBranch        *b_jets_jetUnc_RelativeStatHF_up;
@@ -732,6 +734,7 @@ public :
    TBranch        *b_jets_jetUnc_TimePtEta_up;
    TBranch        *b_jets_jetUnc_AbsoluteFlavMap_dw;  // Down variations
    TBranch        *b_jets_jetUnc_AbsoluteMPFBias_dw;
+   TBranch        *b_jets_jetUnc_AbsoluteSample_dw;
    TBranch        *b_jets_jetUnc_AbsoluteScale_dw;
    TBranch        *b_jets_jetUnc_AbsoluteStat_dw;
    TBranch        *b_jets_jetUnc_FlavorQCD_dw;
@@ -751,6 +754,7 @@ public :
    TBranch        *b_jets_jetUnc_RelativePtEC1_dw;
    TBranch        *b_jets_jetUnc_RelativePtEC2_dw;
    TBranch        *b_jets_jetUnc_RelativePtHF_dw;
+   TBranch        *b_jets_jetUnc_RelativeSample_dw;
    TBranch        *b_jets_jetUnc_RelativeStatEC_dw;
    TBranch        *b_jets_jetUnc_RelativeStatFSR_dw;
    TBranch        *b_jets_jetUnc_RelativeStatHF_dw;
@@ -825,7 +829,7 @@ public :
        daughters_py_TauDown = 0;
        daughters_pz_TauDown = 0;
        daughters_e_TauDown = 0;
-       daughters_hasTES = 0;
+       daughters_hasEES = 0;
        daughters_px_EleUp = 0;
        daughters_py_EleUp = 0;
        daughters_pz_EleUp = 0;
@@ -993,8 +997,6 @@ public :
        decayMode = 0;
        tauID = 0;
        combreliso = 0;
-       // daughters_IetaIeta = 0;
-       // daughters_deltaPhiSuperClusterTrackAtVtx = 0;
        daughters_depositR03_tracker = 0;
        daughters_depositR03_ecal = 0;
        daughters_depositR03_hcal = 0;
@@ -1004,10 +1006,7 @@ public :
        photonPtSumOutsideSignalCone = 0;
        daughters_decayModeFindingNewDMs = 0;
        daughters_byCombinedIsolationDeltaBetaCorrRaw3Hits = 0;
-       daughters_byIsolationMVArun2v1DBoldDMwLTraw = 0;
-       daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017 = 0;
        daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017 = 0;
-       daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017 = 0;
        daughters_byDeepTau2017v2p1VSjetraw = 0;
        daughters_byDeepTau2017v2p1VSeraw = 0;
        daughters_byDeepTau2017v2p1VSmuraw = 0;
@@ -1073,6 +1072,7 @@ public :
        jets_JER = 0;
        jets_jetUnc_AbsoluteFlavMap_up = 0;
        jets_jetUnc_AbsoluteMPFBias_up = 0;
+       jets_jetUnc_AbsoluteSample_up = 0;
        jets_jetUnc_AbsoluteScale_up = 0;
        jets_jetUnc_AbsoluteStat_up = 0;
        jets_jetUnc_FlavorQCD_up = 0;
@@ -1092,6 +1092,7 @@ public :
        jets_jetUnc_RelativePtEC1_up = 0;
        jets_jetUnc_RelativePtEC2_up = 0;
        jets_jetUnc_RelativePtHF_up = 0;
+       jets_jetUnc_RelativeSample_up = 0;
        jets_jetUnc_RelativeStatEC_up = 0;
        jets_jetUnc_RelativeStatFSR_up = 0;
        jets_jetUnc_RelativeStatHF_up = 0;
@@ -1100,6 +1101,7 @@ public :
        jets_jetUnc_TimePtEta_up = 0;
        jets_jetUnc_AbsoluteFlavMap_dw = 0;
        jets_jetUnc_AbsoluteMPFBias_dw = 0;
+       jets_jetUnc_AbsoluteSample_dw = 0;
        jets_jetUnc_AbsoluteScale_dw = 0;
        jets_jetUnc_AbsoluteStat_dw = 0;
        jets_jetUnc_FlavorQCD_dw = 0;
@@ -1119,6 +1121,7 @@ public :
        jets_jetUnc_RelativePtEC1_dw = 0;
        jets_jetUnc_RelativePtEC2_dw = 0;
        jets_jetUnc_RelativePtHF_dw = 0;
+       jets_jetUnc_RelativeSample_dw = 0;
        jets_jetUnc_RelativeStatEC_dw = 0;
        jets_jetUnc_RelativeStatFSR_dw = 0;
        jets_jetUnc_RelativeStatHF_dw = 0;
@@ -1160,6 +1163,7 @@ public :
        fChain->SetBranchAddress("EventNumber", &EventNumber, &b_EventNumber);
        fChain->SetBranchAddress("RunNumber", &RunNumber, &b_RunNumber);
        fChain->SetBranchAddress("lumi", &lumi, &b_lumi);
+       fChain->SetBranchAddress("year", &year, &b_year);
        fChain->SetBranchAddress("passecalBadCalibFilterUpdate", &passecalBadCalibFilterUpdate, &b_passecalBadCalibFilterUpdate);
        fChain->SetBranchAddress("prefiringweight", &prefiringweight, &b_prefiringweight);
        fChain->SetBranchAddress("prefiringweightup", &prefiringweightup, &b_prefiringweightup);
@@ -1257,10 +1261,10 @@ public :
        fChain->SetBranchAddress("photonPtSumOutsideSignalCone", &photonPtSumOutsideSignalCone, &b_photonPtSumOutsideSignalCone);
        fChain->SetBranchAddress("daughters_decayModeFindingNewDMs", &daughters_decayModeFindingNewDMs, &b_daughters_decayModeFindingNewDMs);
        fChain->SetBranchAddress("daughters_byCombinedIsolationDeltaBetaCorrRaw3Hits", &daughters_byCombinedIsolationDeltaBetaCorrRaw3Hits, &b_daughters_byCombinedIsolationDeltaBetaCorrRaw3Hits);
-       fChain->SetBranchAddress("daughters_byIsolationMVArun2v1DBoldDMwLTraw", &daughters_byIsolationMVArun2v1DBoldDMwLTraw, &b_daughters_byIsolationMVArun2v1DBoldDMwLTraw);
-       fChain->SetBranchAddress("daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017", &daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017, &b_daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017);
+       //fChain->SetBranchAddress("daughters_byIsolationMVArun2v1DBoldDMwLTraw", &daughters_byIsolationMVArun2v1DBoldDMwLTraw, &b_daughters_byIsolationMVArun2v1DBoldDMwLTraw);
+       //fChain->SetBranchAddress("daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017", &daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017, &b_daughters_byIsolationMVArun2017v1DBoldDMwLTraw2017);
        fChain->SetBranchAddress("daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017", &daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017, &b_daughters_byIsolationMVArun2017v2DBoldDMwLTraw2017);
-       fChain->SetBranchAddress("daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017", &daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017, &b_daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017);
+       //fChain->SetBranchAddress("daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017", &daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017, &b_daughters_byIsolationMVArun2017v2DBoldDMdR0p3wLTraw2017);
        fChain->SetBranchAddress("daughters_byDeepTau2017v2p1VSjetraw", &daughters_byDeepTau2017v2p1VSjetraw, &b_daughters_byDeepTau2017v2p1VSjetraw);
        fChain->SetBranchAddress("daughters_byDeepTau2017v2p1VSeraw", &daughters_byDeepTau2017v2p1VSeraw, &b_daughters_byDeepTau2017v2p1VSeraw);
        fChain->SetBranchAddress("daughters_byDeepTau2017v2p1VSmuraw", &daughters_byDeepTau2017v2p1VSmuraw, &b_daughters_byDeepTau2017v2p1VSmuraw);
@@ -1326,6 +1330,7 @@ public :
        fChain->SetBranchAddress("jets_JER", &jets_JER, &b_jets_JER);
        fChain->SetBranchAddress("jets_jetUnc_AbsoluteFlavMap_up",   &jets_jetUnc_AbsoluteFlavMap_up,    &b_jets_jetUnc_AbsoluteFlavMap_up);
        fChain->SetBranchAddress("jets_jetUnc_AbsoluteMPFBias_up",   &jets_jetUnc_AbsoluteMPFBias_up,    &b_jets_jetUnc_AbsoluteMPFBias_up);
+       fChain->SetBranchAddress("jets_jetUnc_AbsoluteSample_up",    &jets_jetUnc_AbsoluteSample_up,     &b_jets_jetUnc_AbsoluteSample_up);
        fChain->SetBranchAddress("jets_jetUnc_AbsoluteScale_up",     &jets_jetUnc_AbsoluteScale_up,      &b_jets_jetUnc_AbsoluteScale_up);
        fChain->SetBranchAddress("jets_jetUnc_AbsoluteStat_up",      &jets_jetUnc_AbsoluteStat_up,       &b_jets_jetUnc_AbsoluteStat_up);
        fChain->SetBranchAddress("jets_jetUnc_FlavorQCD_up",         &jets_jetUnc_FlavorQCD_up,          &b_jets_jetUnc_FlavorQCD_up);
@@ -1345,6 +1350,7 @@ public :
        fChain->SetBranchAddress("jets_jetUnc_RelativePtEC1_up",     &jets_jetUnc_RelativePtEC1_up,      &b_jets_jetUnc_RelativePtEC1_up);
        fChain->SetBranchAddress("jets_jetUnc_RelativePtEC2_up",     &jets_jetUnc_RelativePtEC2_up,      &b_jets_jetUnc_RelativePtEC2_up);
        fChain->SetBranchAddress("jets_jetUnc_RelativePtHF_up",      &jets_jetUnc_RelativePtHF_up,       &b_jets_jetUnc_RelativePtHF_up);
+       fChain->SetBranchAddress("jets_jetUnc_RelativeSample_up",    &jets_jetUnc_RelativeSample_up,     &b_jets_jetUnc_RelativeSample_up);
        fChain->SetBranchAddress("jets_jetUnc_RelativeStatEC_up",    &jets_jetUnc_RelativeStatEC_up,     &b_jets_jetUnc_RelativeStatEC_up);
        fChain->SetBranchAddress("jets_jetUnc_RelativeStatFSR_up",   &jets_jetUnc_RelativeStatFSR_up,    &b_jets_jetUnc_RelativeStatFSR_up);
        fChain->SetBranchAddress("jets_jetUnc_RelativeStatHF_up",    &jets_jetUnc_RelativeStatHF_up,     &b_jets_jetUnc_RelativeStatHF_up);
@@ -1353,6 +1359,7 @@ public :
        fChain->SetBranchAddress("jets_jetUnc_TimePtEta_up",         &jets_jetUnc_TimePtEta_up,          &b_jets_jetUnc_TimePtEta_up);
        fChain->SetBranchAddress("jets_jetUnc_AbsoluteFlavMap_dw",   &jets_jetUnc_AbsoluteFlavMap_dw,    &b_jets_jetUnc_AbsoluteFlavMap_dw);
        fChain->SetBranchAddress("jets_jetUnc_AbsoluteMPFBias_dw",   &jets_jetUnc_AbsoluteMPFBias_dw,    &b_jets_jetUnc_AbsoluteMPFBias_dw);
+       fChain->SetBranchAddress("jets_jetUnc_AbsoluteSample_dw",    &jets_jetUnc_AbsoluteSample_dw,     &b_jets_jetUnc_AbsoluteSample_dw);
        fChain->SetBranchAddress("jets_jetUnc_AbsoluteScale_dw",     &jets_jetUnc_AbsoluteScale_dw,      &b_jets_jetUnc_AbsoluteScale_dw);
        fChain->SetBranchAddress("jets_jetUnc_AbsoluteStat_dw",      &jets_jetUnc_AbsoluteStat_dw,       &b_jets_jetUnc_AbsoluteStat_dw);
        fChain->SetBranchAddress("jets_jetUnc_FlavorQCD_dw",         &jets_jetUnc_FlavorQCD_dw,          &b_jets_jetUnc_FlavorQCD_dw);
@@ -1372,6 +1379,7 @@ public :
        fChain->SetBranchAddress("jets_jetUnc_RelativePtEC1_dw",     &jets_jetUnc_RelativePtEC1_dw,      &b_jets_jetUnc_RelativePtEC1_dw);
        fChain->SetBranchAddress("jets_jetUnc_RelativePtEC2_dw",     &jets_jetUnc_RelativePtEC2_dw,      &b_jets_jetUnc_RelativePtEC2_dw);
        fChain->SetBranchAddress("jets_jetUnc_RelativePtHF_dw",      &jets_jetUnc_RelativePtHF_dw,       &b_jets_jetUnc_RelativePtHF_dw);
+       fChain->SetBranchAddress("jets_jetUnc_RelativeSample_dw",    &jets_jetUnc_RelativeSample_dw,     &b_jets_jetUnc_RelativeSample_dw);
        fChain->SetBranchAddress("jets_jetUnc_RelativeStatEC_dw",    &jets_jetUnc_RelativeStatEC_dw,     &b_jets_jetUnc_RelativeStatEC_dw);
        fChain->SetBranchAddress("jets_jetUnc_RelativeStatFSR_dw",   &jets_jetUnc_RelativeStatFSR_dw,    &b_jets_jetUnc_RelativeStatFSR_dw);
        fChain->SetBranchAddress("jets_jetUnc_RelativeStatHF_dw",    &jets_jetUnc_RelativeStatHF_dw,     &b_jets_jetUnc_RelativeStatHF_dw);
@@ -1414,7 +1422,7 @@ public :
        {
             fChain->SetBranchAddress("PUNumInteractions", &PUNumInteractions, &b_PUNumInteractions);
             fChain->SetBranchAddress("aMCatNLOweight", &aMCatNLOweight, &b_aMCatNLOweight);
-            fChain->SetBranchAddress("susyModel", &susyModel, &b_susyModel);
+            //fChain->SetBranchAddress("susyModel", &susyModel, &b_susyModel);
             fChain->SetBranchAddress("MC_weight", &MC_weight, &b_MC_weight);
             fChain->SetBranchAddress("daughters_genindex", &daughters_genindex, &b_daughters_genindex);
             fChain->SetBranchAddress("genpart_px", &genpart_px, &b_genpart_px);

--- a/scripts/makeListOnStorage_mib.py
+++ b/scripts/makeListOnStorage_mib.py
@@ -1,61 +1,21 @@
 import os, sys
 from subprocess import Popen, PIPE
 
-#tag = "MC_VBF_Summer16_singleTop"
-#tag = "MC_Fall17"
-#tag = "MC_PU12Apr_18May2018"
-#tag = "Data2017BF_31Mar2018ReReco_17May2018"
-#tag = "MC_26June2018"
-#tag = "MC_28June2018_ZZ4L"
-#tag = "MC_3July2018"
-#tag = "MC_4July2018_allFail"
-#tag = "MC_28June2018_DY4J"
-#tag = "MC_7July2018_GGH450"
-#tag = "MC_7July2018_GGH900"
-#tag = "MC_7July2018_VBF800"
-#tag = "MC_7July2018_VBF850"
-#tag = "MC_7July2018_VBF1250"
-#tag = "MC_7July2018_DYBB"
-#tag = "MC_7July2018_EWKminus"
-#tag = "MC_7July2018_EWK2Jets"
-#tag = "MC_7July2018_Wjets800to1200"
-#tag = "MC_7July2018_ttHnonbb"
-#tag = "MC_7July2018_TTWW"
-#tag = "MC_7July2018_WW"
-#tag = "MC_7July2018_WZTo3LNu_3Jets"
-#tag = "MC_24July2018"
-#tag = "MC_14JOct2018"
-#tag = "MC_23JOct2018_signalsTESI"
-#tag = "MC_bkg_25January2019"
-#tag = "MC_bkg_25January2019_njobs"
-#tag = "MC_bkg_25January2019_njobs2"
-#tag = "MC_bkg_25January2019_njobs3"
-#tag = "MC_06June2019"
-#tag = "MC_07June2019"
-#tag = "MC_08June2019"
-#tag = "MC_19June2019"
-#tag = "MC_20June2019"
-#tag = "Data_26June2019"
-#tag = "MC_27June2019"
-#tag = "MC_28July2019"
-#tag = "MC_30July2019"
-#tag = "MC_31July2019"
-#tag = "MC_23Aug2019"
-#tag = "Sig_30July2019"
-#tag = "Data_30July2019"
-tag="Data_29Aug2019"
+#tag="Legacy2016_Signals_Dec2019"
+#tag="Legacy2016_Backgrounds_Dec2019"
+#tag="Legacy2016_Backgrounds2_Dec2019"
+#tag="Legacy2016_Backgrounds5_Dec2019"
+tag="Legacy2016_Data_Muon_Dec2019"
+#tag="Legacy2016_Data_Electron_Dec2019"
+#tag="Legacy2016_Data_Tau_Dec2019"
 
-#outFolder = '/home/llr/cms/amendola/CMSSW_7_4_7/src/KLUBAnalysis/inputFiles/Files_17Nov_VBF'
-#outFolder = '../inputFiles/Fall17_MC/'
-#outFolder = '../inputFiles/Fall17_DATA/'
-#outFolder = '../inputFiles/Files_June2018/'
-#outFolder = '../inputFiles/Files_June2018/signals/'
-#outFolder = '../inputFiles/Files_June2018/signals_tesi/'
-#outFolder = '../inputFiles/Files_January2019/Files_January2019/'
-#outFolder = '../inputFiles/Files_January2019/Files_January2019_njobs/'
-#outFolder = '../inputFiles/Files_January2019/Files_January2019_njobs2/'
-#outFolder = '../inputFiles/Files_January2019/Files_January2019_njobs3/'
-outFolder = '../inputFiles/Files_June2019/Files_June2019_secondLook/'
+#outFolder = '../inputFiles/Files_Legacy_Run2/2016/Signals/'
+#outFolder = '../inputFiles/Files_Legacy_Run2/2016/Backgrounds/'
+#outFolder = '../inputFiles/Files_Legacy_Run2/2016/Backgrounds2/'
+#outFolder = '../inputFiles/Files_Legacy_Run2/2016/Backgrounds5/'
+outFolder = '../inputFiles/Files_Legacy_Run2/2016/Data/Muon/'
+#outFolder = '../inputFiles/Files_Legacy_Run2/2016/Data/Electron/'
+#outFolder = '../inputFiles/Files_Legacy_Run2/2016/Data/Tau/'
 
 areEnrichedMiniAOD = False; # if true:  add a header and the /store.. etc to run ntuplizer on Tier3 on CMSSW
                                  # if false: only add the polgrid server to run the skim and submit on root
@@ -94,8 +54,8 @@ print useOnly
 dpmhome = "/gwteras/cms"
 
 #partialPath = "/store/user/lcadamur/HHNtuples/" #folder contenente la produzione
-#partialPath = "/store/user/fbrivio/Hhh_1718/"
-partialPath = "/store/user/dzuolo/HHbbtautauNtuples/"
+partialPath = "/store/user/fbrivio/Hhh_1718/"
+#partialPath = "/store/user/dzuolo/HHbbtautauNtuples/"
 
 
 path = dpmhome + partialPath + tag

--- a/scripts/skimNtuple_mib.py
+++ b/scripts/skimNtuple_mib.py
@@ -163,7 +163,8 @@ if __name__ == "__main__":
     # ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 
 
-    skimmer = 'skimNtuple.exe'
+    #skimmer = 'skimNtuple.exe'
+    skimmer = 'skimNtuple2016.exe'
     #skimmer = 'skimNtuple_oldOrder.exe' # first the bjets by deepCSV and then VBFjets as highest Mjj pair
 
     if opt.config == 'none' :
@@ -253,12 +254,21 @@ if __name__ == "__main__":
         scriptFile.close ()
         os.system ('chmod u+rwx %s/skimJob_%d.sh'% (jobsDir,n))
 
-        command = '/usr/bin/qsub -q '+opt.queue + ' ' + jobsDir + '/skimJob_' + str (n) + '.sh'
+        condorFile = open ('%s/condorLauncher_%d.sh'% (jobsDir,n), 'w')
+        condorFile.write ('Universe = vanilla\n')
+        condorFile.write ('Executable  = '+jobsDir + '/skimJob_' + str (n) + '.sh\n')
+        condorFile.write ('Log         = condor_job_$(ProcId).log\n')
+        condorFile.write ('Output      = condor_job_$(ProcId).out\n')
+        condorFile.write ('Error       = condor_job_$(ProcId).error\n')
+        condorFile.write ('queue 1\n')
+        condorFile.close ()
+
+        #command = '/usr/bin/qsub -q '+opt.queue + ' ' + jobsDir + '/skimJob_' + str (n) + '.sh'
+        command = 'condor_submit '+ jobsDir + '/condorLauncher_' + str (n) + '.sh'
         if opt.sleep : time.sleep (0.1)
         os.system (command)
         commandFile.write (command + '\n')
         n = n + 1
     commandFile.close ()
-    
 
 

--- a/scripts/submit_skims_mib.sh
+++ b/scripts/submit_skims_mib.sh
@@ -1,60 +1,14 @@
-#OUTDIRR="Skims_Fall17_DATA"
-#OUTDIRR="Skims_Fall17_MC_TT"
-#OUTDIRR="Skims_Fall17_MC_TT2"
-#OUTDIRR="Skims_Fall17_MC_DY"
-#OUTDIRR="Skims_Fall17_MC_WJets"
-#OUTDIRR="Skims_Fall17_MC_WJetsINF"
-#OUTDIRR="Skims_Fall17_MC_EWKW"
-#OUTDIRR="Skims_Fall17_MC_SingleTop"
-#OUTDIRR="Skims_Fall17_MC_Others"
-#OUTDIRR="Skims_Fall17_MC_WJetsSpecial"
-#OUTDIRR="Skims_Fall17_MC_15July2018"
-#OUTDIRR="Skims_Fall17_MC_24July2018"
-#OUTDIRR="Skims_Fall17_MC_24July2018_PU"
-#OUTDIRR="Skims_Fall17_MC_28Aug2018"
-#OUTDIRR="Skims_Fall17_MC_22Oct2018"
-#OUTDIRR="Skims_Fall17_MC_6Nov2018"
-#OUTDIRR="Skims_Fall17_MC_27Nov2018"
-#OUTDIRR="Skims_Fall17_MC_14Dec2018"
-#OUTDIRR="Skims_Fall17_MC_7Feb2019"
-#OUTDIRR="Skims_Fall17_MC_28Feb2019"
-OUTDIRR="Skims_Autumn18_MC_19Jun2019"
+#OUTDIRR="Skims_Autumn18_MC_19Jun2019"
+OUTDIRR="Skims_Legacy2016_17Jan2020"
 
-#INPUTDIR="inputFiles/JECproduction_Lug2017"
-#INPUTDIR="inputFiles/Fall17_MC/"
-#INPUTDIR="/gwpool/users/brivio/Hhh_1718/syncFeb2018/CMSSW_7_4_7/src/KLUBAnalysis/skimNtuples"
-#INPUTDIR="inputFiles/Fall17_MC"
-#INPUTDIR="inputFiles/Fall17_DATA"
-#INPUTDIR="inputFiles/Files_June2018"
-#INPUTDIR="inputFiles/Files_January2019/finals"
-INPUTDIR="inputFiles/Files_June2019/Files_June2019_secondLook"
+#INPUTDIR="inputFiles/Files_June2019/Files_June2019_secondLook"
+INPUTDIR="inputFiles/Files_Legacy_Run2/2016/Signals"
 
-#SKIMDIR="/gwteraz/users/brivio/SKIMMED_VBF"
-#SKIMDIR="/gwteraz/users/brivio/SKIMMED_Fall17_MC"
-#SKIMDIR="/gwteraz/users/brivio/SKIMMED_syncFeb2018"
-#SKIMDIR="/gwteraz/users/brivio/SKIMMED_20may2018/SKIMMED_Fall17_MC"
-#SKIMDIR="/gwteraz/users/brivio/SKIMMED_20may2018/SKIMMED_Fall17_DATA"
-#SKIMDIR="/gwteraz/users/brivio/SKIMMED_15july2018"
-#SKIMDIR="/gwteraz/users/brivio/SKIMMED_24july2018_PU"
-#SKIMDIR="/gwteraz/users/brivio/SKIMMED_2aug2018"
-#SKIMDIR="/gwpool/users/brivio/Hhh_1718/syncFeb2018/CMSSW_9_0_0/src/KLUBAnalysis/SKIM_DY"
-#SKIMDIR="/gwteraz/users/brivio/SKIMMED_28aug2018"
-#SKIMDIR="/gwpool/users/brivio/Hhh_1718/syncFeb2018/CMSSW_9_0_0/src/KLUBAnalysis/studies/VBFjetChoice/skims_tesi"
-#SKIMDIR="/gwteraz/users/brivio/SKIMMED_22Oct2018"
-#SKIMDIR="/gwteraz/users/brivio/SKIMMED_6Nov2018"
-#SKIMDIR="/gwteraz/users/brivio/SKIMMED_27Nov2018"
-#SKIMDIR="/gwteraz/users/brivio/SKIMMED_14Dec2018"
-#SKIMDIR="/gwteraz/users/brivio/SKIMMED_7Feb2019"
 #SKIMDIR="/gwteraz/users/brivio/SKIMMED_28Feb2019"
-#SKIMDIR="/gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_TTBarBKG_ForDeepFlavorEfficiency"
-#SKIMDIR="/gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_secondLookSkims_deepFlavor"
-#SKIMDIR="/gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_secondLookSkims_deepCSV"
-#SKIMDIR="/gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Prova"
-#SKIMDIR="/gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_thirdLookSkims_deepFlavor"
-SKIMDIR="/gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_thirdLookSkims_deepCSV"
+SKIMDIR="/gwteraz/users/brivio/SKIMMED_Legacy2016_17Jan2020"
 
 #PUDIR="/gwpool/users/brivio/Hhh_1718/syncFeb2018/CMSSW_9_0_0/src/KLUBAnalysis/weights/PUreweight/outputs"
-PUDIR="/gwpool/users/dzuolo/HbbtautauAnalysis2018/CMSSW_9_0_0/src/KLUBAnalysis/weights/PUreweight"
+PUDIR="/gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/PUreweight/Legacy_Run2_PU_SF/2016"
 
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 source scripts/setup.sh
@@ -63,11 +17,11 @@ mkdir $OUTDIRR
 #### GGH SM :
 # XS:  0.03349 pb^-1
 echo "Submitting - GGH SM - "
-echo "Submitting - GGH SM - " >> log_26Aug2019.txt
+echo "Submitting - GGH SM - " >> log_17Jan2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_26Aug2019.txt
+echo "OUTDIR = $OUTDIRR" >> log_17Jan2020.txt
 
-python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_2018_sync_mib.cfg  -n 13 -k True -o $SKIMDIR/SKIM_GGHSM -i $INPUTDIR/1_GluGluToHHTo2B2Tau_node_SM_TuneCP5_PSWeights_13TeV-madgraph-pythia8__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1.txt -x 0.03349 -a True -q longcms --pu $PUDIR/2018_PuReWeight_SF.txt
+python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg  -n 1 -k False -o $SKIMDIR/SKIM_GGHSM -i $INPUTDIR/1_GluGluToHHTo2B2Tau_node_10_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt -x 1. -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
 
 <<COMMENT1
 ###################
@@ -80,34 +34,34 @@ python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_2018_sync_mi
 
 # TT had
 echo "Submitting - TThad - "
-echo "Submitting - TThad - " >> log_26Aug2019.txt
+echo "Submitting - TThad - " >> log_17Jan2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_26Aug2019.txt
+echo "OUTDIR = $OUTDIRR" >> log_17Jan2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_2018_sync_mib.cfg -n 13 -k True -o $SKIMDIR/SKIM_TT_fullyHad -i $INPUTDIR/4_TTToHadronic_TuneCP5_13TeV-powheg-pythia8__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1.txt -x 377.96 -t True -b 1 -q longcms --pu $PUDIR/2018_PuReWeight_SF.txt
 
 # TT lep
 echo "Submitting - TTlep - "
-echo "Submitting - TTlep - " >> log_26Aug2019.txt
+echo "Submitting - TTlep - " >> log_17Jan2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_26Aug2019.txt
+echo "OUTDIR = $OUTDIRR" >> log_17Jan2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_2018_sync_mib.cfg -n 13 -k True -o $SKIMDIR/SKIM_TT_fullyLep -i $INPUTDIR/1_TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1.txt -x 88.29  -t True -b 4 -q longcms --pu $PUDIR/2018_PuReWeight_SF.txt
 
 # TT semi
 echo "Submitting - TTsemi - "
-echo "Submitting - TTsemi - " >> log_26Aug2019.txt
+echo "Submitting - TTsemi - " >> log_17Jan2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_26Aug2019.txt
+echo "OUTDIR = $OUTDIRR" >> log_17Jan2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_2018_sync_mib.cfg -n 13 -k True -o $SKIMDIR/SKIM_TT_semiLep -i $INPUTDIR/3_TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1.txt -x 365.34 -t True -b 5 -q longcms --pu $PUDIR/2018_PuReWeight_SF.txt
 
 # # #####################
 # Wjets
 echo "Submitting - WJets - "
-echo "Submitting - WJets - " >> log_26Aug2019.txt
+echo "Submitting - WJets - " >> log_17Jan2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_26Aug2019.txt
+echo "OUTDIR = $OUTDIRR" >> log_17Jan2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_2018_sync_mib.cfg -n 13 -k True -o $SKIMDIR/SKIM_WJets_Inclusive -i $INPUTDIR/1_WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2.txt -x 52940.0 -q longcms --pu $PUDIR/2018_PuReWeight_SF.txt
 
@@ -115,32 +69,32 @@ python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_2018_sync_mi
 # DY NLO
 # total XS= 6225.42 pb - 8 october 2018
 echo "Submitting - DY NLO - "
-echo "Submitting - DY NLO - " >> log_26Aug2019.txt
+echo "Submitting - DY NLO - " >> log_17Jan2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_26Aug2019.txt
+echo "OUTDIR = $OUTDIRR" >> log_17Jan2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_2018_sync_mib.cfg -n 13 -k True -o $SKIMDIR/SKIM_DY_NLO_NewSF_Huge -i $INPUTDIR/1_DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8__RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1-All.txt -x 6225.42 -q longcms --pu $PUDIR/2018_PuReWeight_SF.txt  --DY True
 
 ### DATA :
 echo "Submitting - DATA tau - "
-echo "Submitting - DATA tau - " >> log_26Aug2019.txt
+echo "Submitting - DATA tau - " >> log_17Jan2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_26Aug2019.txt
+echo "OUTDIR = $OUTDIRR" >> log_17Jan2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -d True  -s True -c config/skim_2018_sync_mib.cfg -n 13 -k True -o $SKIMDIR/SKIM_Tau_2018B -i $INPUTDIR/1_Tau__Run2018B-17Sep2018-v1.txt -q longcms
 
 ### DATA :
 echo "Submitting - DATA Mu - "
-echo "Submitting - DATA Mu - " >> log_26Aug2019.txt
+echo "Submitting - DATA Mu - " >> log_17Jan2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_26Aug2019.txt
+echo "OUTDIR = $OUTDIRR" >> log_17Jan2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -d True  -s True -c config/skim_2018_sync_mib.cfg -n 13 -k True -o $SKIMDIR/SKIM_Mu_2018B -i $INPUTDIR/2_SingleMuon__Run2018B-17Sep2018-v1.txt -q longcms
 
 echo "Submitting - DATA Electron - "
-echo "Submitting - DATA Electron - " >> log_26Aug2019.txt
+echo "Submitting - DATA Electron - " >> log_17Jan2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_26Aug2019.txt
+echo "OUTDIR = $OUTDIRR" >> log_17Jan2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -d True  -s True -c config/skim_2018_sync_mib.cfg -n 13 -k True -o $SKIMDIR/SKIM_EGamma_2018B -i $INPUTDIR/1_EGamma__Run2018B-17Sep2018-v1.txt -q longcms
 

--- a/test/skimNtuple2016.cpp
+++ b/test/skimNtuple2016.cpp
@@ -765,11 +765,11 @@ int main (int argc, char** argv)
       cout << endl;
     }
 
-  string bRegrWeights("");
-  bool computeBregr = gConfigParser->readBoolOption ("bRegression::computeBregr");
-  if (computeBregr) bRegrWeights = gConfigParser->readStringOption("bRegression::weights");
+  //string bRegrWeights("");
+  //bool computeBregr = gConfigParser->readBoolOption ("bRegression::computeBregr");
+  //if (computeBregr) bRegrWeights = gConfigParser->readStringOption("bRegression::weights");
 
-  cout << "** INFO: computing b jet regression? " << computeBregr << " with weights " << bRegrWeights << endl;
+  //cout << "** INFO: computing b jet regression? " << computeBregr << " with weights " << bRegrWeights << endl;
 
   // DY new reweight (LO to NLO) map - Fractional Weight, Pt Weight and SF Weight maps
   bool doDYLOtoNLOreweight = (gConfigParser->isDefined("DYLOtoNLOreweight::doReweight") ? gConfigParser->readBoolOption ("DYLOtoNLOreweight::doReweight") : false);
@@ -874,12 +874,12 @@ int main (int argc, char** argv)
 
   // ------------------------------
 
-  bJetRegrVars bjrv;
-  TMVA::Reader *bRreader = new TMVA::Reader();
-  bjrv.setReader (bRreader);
-  string bRegrMethodName = "BDTG method";
-  if (computeBregr)
-    bRreader->BookMVA( bRegrMethodName.c_str(), bRegrWeights.c_str() ); 
+  //bJetRegrVars bjrv;
+  //TMVA::Reader *bRreader = new TMVA::Reader();
+  //bjrv.setReader (bRreader);
+  //string bRegrMethodName = "BDTG method";
+  //if (computeBregr)
+  //  bRreader->BookMVA( bRegrMethodName.c_str(), bRegrWeights.c_str() );
   
   // ------------------------------
 
@@ -887,6 +887,8 @@ int main (int argc, char** argv)
   PUReweight reweight (PUReweight::RUN2ANALYSIS, PUreweightFile);
 
   // ------------------------------
+
+  cout << "** INFO: useDepFlavor? " << useDeepFlavor << endl;
 
   string bTag_SFFile;
   string bTag_effFile;
@@ -1235,10 +1237,10 @@ int main (int argc, char** argv)
 	}
 
       // skip event if I want a specific SUSY point from the fastsim
-      if (susyModel != string("NOTSUSY"))
-	{
-	  if (string(theBigTree.susyModel.Data()) != susyModel) continue;  
-	}
+      //if (susyModel != string("NOTSUSY"))
+      //{
+      //  if (string(theBigTree.susyModel.Data()) != susyModel) continue;
+      //}
 
       float stitchWeight = 1.0;
       if (DY_tostitch)
@@ -3348,33 +3350,33 @@ int main (int argc, char** argv)
         theSmallTree.m_bjet2_gen_matched = bjet2_gen_matched ? 1 : 0;
 
         double ptRegr[2] = {tlv_firstBjet.Pt(), tlv_secondBjet.Pt()};
-        if (computeBregr)
-        {
-          for (int iBJet = 0; iBJet <=1; iBJet++)
-          {
-            int bidx = (iBJet == 0 ? bjet1idx : bjet2idx);
-            bjrv.Jet_pt     = (iBJet == 0 ? tlv_firstBjet.Pt()  : tlv_secondBjet.Pt());
-            bjrv.Jet_eta    = (iBJet == 0 ? tlv_firstBjet.Eta() : tlv_secondBjet.Eta());
-            //bjrv.Jet_corr         = theBigTree.jets_rawPt->at(bidx);
-            bjrv.Jet_corr         = theBigTree.jetRawf->at(bidx); // should be 1./jetrawf ??
-            bjrv.rho              = theBigTree.rho;
-            bjrv.Jet_mt           = theBigTree.jets_mT->at(bidx);
-            bjrv.Jet_leadTrackPt  = theBigTree.jets_leadTrackPt->at(bidx);
-            bjrv.Jet_leptonPtRel  = theBigTree.jets_leptonPtRel->at(bidx);
-            bjrv.Jet_leptonPt     = theBigTree.jets_leptonPt->at(bidx);
-            bjrv.Jet_leptonDeltaR = theBigTree.jets_leptonDeltaR->at(bidx);
-            bjrv.Jet_neHEF   = theBigTree.jets_nHEF->at(bidx);
-            bjrv.Jet_neEmEF  = theBigTree.jets_nEmEF->at(bidx);
-            bjrv.Jet_chMult  = theBigTree.jets_chMult->at(bidx);
-            bjrv.Jet_vtxPt   = theBigTree.jets_vtxPt->at(bidx);
-            bjrv.Jet_vtxMass = theBigTree.jets_vtxMass->at(bidx);
-            bjrv.Jet_vtx3dL  = theBigTree.jets_vtx3dL->at(bidx);
-            bjrv.Jet_vtxNtrk = theBigTree.jets_vtxNtrk->at(bidx);
-            bjrv.Jet_vtx3deL = theBigTree.jets_vtx3deL->at(bidx);
+        //if (computeBregr)
+        //{
+        //  for (int iBJet = 0; iBJet <=1; iBJet++)
+        //  {
+        //    int bidx = (iBJet == 0 ? bjet1idx : bjet2idx);
+        //    bjrv.Jet_pt     = (iBJet == 0 ? tlv_firstBjet.Pt()  : tlv_secondBjet.Pt());
+        //    bjrv.Jet_eta    = (iBJet == 0 ? tlv_firstBjet.Eta() : tlv_secondBjet.Eta());
+        //    //bjrv.Jet_corr         = theBigTree.jets_rawPt->at(bidx);
+        //    bjrv.Jet_corr         = theBigTree.jetRawf->at(bidx); // should be 1./jetrawf ??
+        //    bjrv.rho              = theBigTree.rho;
+        //    bjrv.Jet_mt           = theBigTree.jets_mT->at(bidx);
+        //    bjrv.Jet_leadTrackPt  = theBigTree.jets_leadTrackPt->at(bidx);
+        //    bjrv.Jet_leptonPtRel  = theBigTree.jets_leptonPtRel->at(bidx);
+        //    bjrv.Jet_leptonPt     = theBigTree.jets_leptonPt->at(bidx);
+        //    bjrv.Jet_leptonDeltaR = theBigTree.jets_leptonDeltaR->at(bidx);
+        //    bjrv.Jet_neHEF   = theBigTree.jets_nHEF->at(bidx);
+        //    bjrv.Jet_neEmEF  = theBigTree.jets_nEmEF->at(bidx);
+        //    bjrv.Jet_chMult  = theBigTree.jets_chMult->at(bidx);
+        //    bjrv.Jet_vtxPt   = theBigTree.jets_vtxPt->at(bidx);
+        //    bjrv.Jet_vtxMass = theBigTree.jets_vtxMass->at(bidx);
+        //    bjrv.Jet_vtx3dL  = theBigTree.jets_vtx3dL->at(bidx);
+        //    bjrv.Jet_vtxNtrk = theBigTree.jets_vtxNtrk->at(bidx);
+        //    bjrv.Jet_vtx3deL = theBigTree.jets_vtx3deL->at(bidx);
 
-            ptRegr[iBJet] = (bRreader->EvaluateRegression (bRegrMethodName.c_str()))[0];
-          }
-        }
+        //    ptRegr[iBJet] = (bRreader->EvaluateRegression (bRegrMethodName.c_str()))[0];
+        //  }
+        //}
 
         // save the b-jets
         TLorentzVector tlv_firstBjet_raw = tlv_firstBjet;

--- a/test/skimNtuple2017.cpp
+++ b/test/skimNtuple2017.cpp
@@ -788,11 +788,11 @@ int main (int argc, char** argv)
       cout << endl;
     }
 
-  string bRegrWeights("");
-  bool computeBregr = gConfigParser->readBoolOption ("bRegression::computeBregr");
-  if (computeBregr) bRegrWeights = gConfigParser->readStringOption("bRegression::weights");
+  //string bRegrWeights("");
+  //bool computeBregr = gConfigParser->readBoolOption ("bRegression::computeBregr");
+  //if (computeBregr) bRegrWeights = gConfigParser->readStringOption("bRegression::weights");
 
-  cout << "** INFO: computing b jet regression? " << computeBregr << " with weights " << bRegrWeights << endl;
+  //cout << "** INFO: computing b jet regression? " << computeBregr << " with weights " << bRegrWeights << endl;
 
   // DY new reweight (LO to NLO) map - Fractional Weight, Pt Weight and SF Weight maps
   bool doDYLOtoNLOreweight = (gConfigParser->isDefined("DYLOtoNLOreweight::doReweight") ? gConfigParser->readBoolOption ("DYLOtoNLOreweight::doReweight") : false);
@@ -897,12 +897,12 @@ int main (int argc, char** argv)
 
   // ------------------------------
 
-  bJetRegrVars bjrv;
-  TMVA::Reader *bRreader = new TMVA::Reader();
-  bjrv.setReader (bRreader);
-  string bRegrMethodName = "BDTG method";
-  if (computeBregr)
-    bRreader->BookMVA( bRegrMethodName.c_str(), bRegrWeights.c_str() ); 
+  //bJetRegrVars bjrv;
+  //TMVA::Reader *bRreader = new TMVA::Reader();
+  //bjrv.setReader (bRreader);
+  //string bRegrMethodName = "BDTG method";
+  //if (computeBregr)
+  //  bRreader->BookMVA( bRegrMethodName.c_str(), bRegrWeights.c_str() );
   
   // ------------------------------
 
@@ -910,6 +910,8 @@ int main (int argc, char** argv)
   PUReweight reweight (PUReweight::RUN2ANALYSIS, PUreweightFile);
 
   // ------------------------------
+
+  cout << "** INFO: useDepFlavor? " << useDeepFlavor << endl;
 
   string bTag_SFFile;
   string bTag_effFile;
@@ -1262,10 +1264,10 @@ int main (int argc, char** argv)
 	}
 
       // skip event if I want a specific SUSY point from the fastsim
-      if (susyModel != string("NOTSUSY"))
-	{
-	  if (string(theBigTree.susyModel.Data()) != susyModel) continue;  
-	}
+      //if (susyModel != string("NOTSUSY"))
+      //{
+      //  if (string(theBigTree.susyModel.Data()) != susyModel) continue;
+      //}
 
       float stitchWeight = 1.0;
       if (DY_tostitch)
@@ -3411,33 +3413,33 @@ int main (int argc, char** argv)
         theSmallTree.m_bjet2_gen_matched = bjet2_gen_matched ? 1 : 0;
 
         double ptRegr[2] = {tlv_firstBjet.Pt(), tlv_secondBjet.Pt()};
-        if (computeBregr)
-        {
-          for (int iBJet = 0; iBJet <=1; iBJet++)
-          {
-            int bidx = (iBJet == 0 ? bjet1idx : bjet2idx);
-            bjrv.Jet_pt     = (iBJet == 0 ? tlv_firstBjet.Pt()  : tlv_secondBjet.Pt());
-            bjrv.Jet_eta    = (iBJet == 0 ? tlv_firstBjet.Eta() : tlv_secondBjet.Eta());
-            //bjrv.Jet_corr         = theBigTree.jets_rawPt->at(bidx);
-            bjrv.Jet_corr         = theBigTree.jetRawf->at(bidx); // should be 1./jetrawf ??
-            bjrv.rho              = theBigTree.rho;
-            bjrv.Jet_mt           = theBigTree.jets_mT->at(bidx);
-            bjrv.Jet_leadTrackPt  = theBigTree.jets_leadTrackPt->at(bidx);
-            bjrv.Jet_leptonPtRel  = theBigTree.jets_leptonPtRel->at(bidx);
-            bjrv.Jet_leptonPt     = theBigTree.jets_leptonPt->at(bidx);
-            bjrv.Jet_leptonDeltaR = theBigTree.jets_leptonDeltaR->at(bidx);
-            bjrv.Jet_neHEF   = theBigTree.jets_nHEF->at(bidx);
-            bjrv.Jet_neEmEF  = theBigTree.jets_nEmEF->at(bidx);
-            bjrv.Jet_chMult  = theBigTree.jets_chMult->at(bidx);
-            bjrv.Jet_vtxPt   = theBigTree.jets_vtxPt->at(bidx);
-            bjrv.Jet_vtxMass = theBigTree.jets_vtxMass->at(bidx);
-            bjrv.Jet_vtx3dL  = theBigTree.jets_vtx3dL->at(bidx);
-            bjrv.Jet_vtxNtrk = theBigTree.jets_vtxNtrk->at(bidx);
-            bjrv.Jet_vtx3deL = theBigTree.jets_vtx3deL->at(bidx);
+        //if (computeBregr)
+        //{
+        //  for (int iBJet = 0; iBJet <=1; iBJet++)
+        //  {
+        //    int bidx = (iBJet == 0 ? bjet1idx : bjet2idx);
+        //    bjrv.Jet_pt     = (iBJet == 0 ? tlv_firstBjet.Pt()  : tlv_secondBjet.Pt());
+        //    bjrv.Jet_eta    = (iBJet == 0 ? tlv_firstBjet.Eta() : tlv_secondBjet.Eta());
+        //    //bjrv.Jet_corr         = theBigTree.jets_rawPt->at(bidx);
+        //    bjrv.Jet_corr         = theBigTree.jetRawf->at(bidx); // should be 1./jetrawf ??
+        //    bjrv.rho              = theBigTree.rho;
+        //    bjrv.Jet_mt           = theBigTree.jets_mT->at(bidx);
+        //    bjrv.Jet_leadTrackPt  = theBigTree.jets_leadTrackPt->at(bidx);
+        //    bjrv.Jet_leptonPtRel  = theBigTree.jets_leptonPtRel->at(bidx);
+        //    bjrv.Jet_leptonPt     = theBigTree.jets_leptonPt->at(bidx);
+        //    bjrv.Jet_leptonDeltaR = theBigTree.jets_leptonDeltaR->at(bidx);
+        //    bjrv.Jet_neHEF   = theBigTree.jets_nHEF->at(bidx);
+        //    bjrv.Jet_neEmEF  = theBigTree.jets_nEmEF->at(bidx);
+        //    bjrv.Jet_chMult  = theBigTree.jets_chMult->at(bidx);
+        //    bjrv.Jet_vtxPt   = theBigTree.jets_vtxPt->at(bidx);
+        //    bjrv.Jet_vtxMass = theBigTree.jets_vtxMass->at(bidx);
+        //    bjrv.Jet_vtx3dL  = theBigTree.jets_vtx3dL->at(bidx);
+        //    bjrv.Jet_vtxNtrk = theBigTree.jets_vtxNtrk->at(bidx);
+        //    bjrv.Jet_vtx3deL = theBigTree.jets_vtx3deL->at(bidx);
 
-            ptRegr[iBJet] = (bRreader->EvaluateRegression (bRegrMethodName.c_str()))[0];
-          }
-        }
+        //    ptRegr[iBJet] = (bRreader->EvaluateRegression (bRegrMethodName.c_str()))[0];
+        //  }
+        //}
 
         // save the b-jets
         TLorentzVector tlv_firstBjet_raw = tlv_firstBjet;

--- a/test/skimNtuple2018.cpp
+++ b/test/skimNtuple2018.cpp
@@ -788,11 +788,11 @@ int main (int argc, char** argv)
       cout << endl;
     }
 
-  string bRegrWeights("");
-  bool computeBregr = gConfigParser->readBoolOption ("bRegression::computeBregr");
-  if (computeBregr) bRegrWeights = gConfigParser->readStringOption("bRegression::weights");
+  //string bRegrWeights("");
+  //bool computeBregr = gConfigParser->readBoolOption ("bRegression::computeBregr");
+  //if (computeBregr) bRegrWeights = gConfigParser->readStringOption("bRegression::weights");
 
-  cout << "** INFO: computing b jet regression? " << computeBregr << " with weights " << bRegrWeights << endl;
+  //cout << "** INFO: computing b jet regression? " << computeBregr << " with weights " << bRegrWeights << endl;
 
   // DY new reweight (LO to NLO) map - Fractional Weight, Pt Weight and SF Weight maps
   bool doDYLOtoNLOreweight = (gConfigParser->isDefined("DYLOtoNLOreweight::doReweight") ? gConfigParser->readBoolOption ("DYLOtoNLOreweight::doReweight") : false);
@@ -897,12 +897,12 @@ int main (int argc, char** argv)
 
   // ------------------------------
 
-  bJetRegrVars bjrv;
-  TMVA::Reader *bRreader = new TMVA::Reader();
-  bjrv.setReader (bRreader);
-  string bRegrMethodName = "BDTG method";
-  if (computeBregr)
-    bRreader->BookMVA( bRegrMethodName.c_str(), bRegrWeights.c_str() ); 
+  //bJetRegrVars bjrv;
+  //TMVA::Reader *bRreader = new TMVA::Reader();
+  //bjrv.setReader (bRreader);
+  //string bRegrMethodName = "BDTG method";
+  //if (computeBregr)
+  //  bRreader->BookMVA( bRegrMethodName.c_str(), bRegrWeights.c_str() );
   
   // ------------------------------
 
@@ -910,6 +910,8 @@ int main (int argc, char** argv)
   PUReweight reweight (PUReweight::RUN2ANALYSIS, PUreweightFile);
 
   // ------------------------------
+
+  cout << "** INFO: useDepFlavor? " << useDeepFlavor << endl;
 
   string bTag_SFFile;
   string bTag_effFile;
@@ -1262,10 +1264,10 @@ int main (int argc, char** argv)
 	}
 
       // skip event if I want a specific SUSY point from the fastsim
-      if (susyModel != string("NOTSUSY"))
-	{
-	  if (string(theBigTree.susyModel.Data()) != susyModel) continue;  
-	}
+      //if (susyModel != string("NOTSUSY"))
+      //{
+      //  if (string(theBigTree.susyModel.Data()) != susyModel) continue;
+      //}
 
       float stitchWeight = 1.0;
       if (DY_tostitch)
@@ -3378,33 +3380,33 @@ int main (int argc, char** argv)
         theSmallTree.m_bjet2_gen_matched = bjet2_gen_matched ? 1 : 0;
 
         double ptRegr[2] = {tlv_firstBjet.Pt(), tlv_secondBjet.Pt()};
-        if (computeBregr)
-        {
-          for (int iBJet = 0; iBJet <=1; iBJet++)
-          {
-            int bidx = (iBJet == 0 ? bjet1idx : bjet2idx);
-            bjrv.Jet_pt     = (iBJet == 0 ? tlv_firstBjet.Pt()  : tlv_secondBjet.Pt());
-            bjrv.Jet_eta    = (iBJet == 0 ? tlv_firstBjet.Eta() : tlv_secondBjet.Eta());
-            //bjrv.Jet_corr         = theBigTree.jets_rawPt->at(bidx);
-            bjrv.Jet_corr         = theBigTree.jetRawf->at(bidx); // should be 1./jetrawf ??
-            bjrv.rho              = theBigTree.rho;
-            bjrv.Jet_mt           = theBigTree.jets_mT->at(bidx);
-            bjrv.Jet_leadTrackPt  = theBigTree.jets_leadTrackPt->at(bidx);
-            bjrv.Jet_leptonPtRel  = theBigTree.jets_leptonPtRel->at(bidx);
-            bjrv.Jet_leptonPt     = theBigTree.jets_leptonPt->at(bidx);
-            bjrv.Jet_leptonDeltaR = theBigTree.jets_leptonDeltaR->at(bidx);
-            bjrv.Jet_neHEF   = theBigTree.jets_nHEF->at(bidx);
-            bjrv.Jet_neEmEF  = theBigTree.jets_nEmEF->at(bidx);
-            bjrv.Jet_chMult  = theBigTree.jets_chMult->at(bidx);
-            bjrv.Jet_vtxPt   = theBigTree.jets_vtxPt->at(bidx);
-            bjrv.Jet_vtxMass = theBigTree.jets_vtxMass->at(bidx);
-            bjrv.Jet_vtx3dL  = theBigTree.jets_vtx3dL->at(bidx);
-            bjrv.Jet_vtxNtrk = theBigTree.jets_vtxNtrk->at(bidx);
-            bjrv.Jet_vtx3deL = theBigTree.jets_vtx3deL->at(bidx);
+        //if (computeBregr)
+        //{
+        //  for (int iBJet = 0; iBJet <=1; iBJet++)
+        //  {
+        //    int bidx = (iBJet == 0 ? bjet1idx : bjet2idx);
+        //    bjrv.Jet_pt     = (iBJet == 0 ? tlv_firstBjet.Pt()  : tlv_secondBjet.Pt());
+        //    bjrv.Jet_eta    = (iBJet == 0 ? tlv_firstBjet.Eta() : tlv_secondBjet.Eta());
+        //    //bjrv.Jet_corr         = theBigTree.jets_rawPt->at(bidx);
+        //    bjrv.Jet_corr         = theBigTree.jetRawf->at(bidx); // should be 1./jetrawf ??
+        //    bjrv.rho              = theBigTree.rho;
+        //    bjrv.Jet_mt           = theBigTree.jets_mT->at(bidx);
+        //    bjrv.Jet_leadTrackPt  = theBigTree.jets_leadTrackPt->at(bidx);
+        //    bjrv.Jet_leptonPtRel  = theBigTree.jets_leptonPtRel->at(bidx);
+        //    bjrv.Jet_leptonPt     = theBigTree.jets_leptonPt->at(bidx);
+        //    bjrv.Jet_leptonDeltaR = theBigTree.jets_leptonDeltaR->at(bidx);
+        //    bjrv.Jet_neHEF   = theBigTree.jets_nHEF->at(bidx);
+        //    bjrv.Jet_neEmEF  = theBigTree.jets_nEmEF->at(bidx);
+        //    bjrv.Jet_chMult  = theBigTree.jets_chMult->at(bidx);
+        //    bjrv.Jet_vtxPt   = theBigTree.jets_vtxPt->at(bidx);
+        //    bjrv.Jet_vtxMass = theBigTree.jets_vtxMass->at(bidx);
+        //    bjrv.Jet_vtx3dL  = theBigTree.jets_vtx3dL->at(bidx);
+        //    bjrv.Jet_vtxNtrk = theBigTree.jets_vtxNtrk->at(bidx);
+        //    bjrv.Jet_vtx3deL = theBigTree.jets_vtx3deL->at(bidx);
 
-            ptRegr[iBJet] = (bRreader->EvaluateRegression (bRegrMethodName.c_str()))[0];
-          }
-        }
+        //    ptRegr[iBJet] = (bRreader->EvaluateRegression (bRegrMethodName.c_str()))[0];
+        //  }
+        //}
 
         // save the b-jets
         TLorentzVector tlv_firstBjet_raw = tlv_firstBjet;


### PR DESCRIPTION
Common changes
- aligned branches in bigTree.h to LLR branches
- removed unused "susyModel" branch
- commented out the bJet regression (tested in 2016, but never used for the analysis)

MIB-related changes:
- switch from batch to condor for the skimmer
- minor fixes in some MIB-scripts/configs