### PR TITLE
Sync Feb2020 changes

### DIFF
--- a/test/skimNtuple2016.cpp
+++ b/test/skimNtuple2016.cpp
@@ -2810,7 +2810,7 @@ int main (int argc, char** argv)
           // Fra Mar2020: for electron, we check (mvaEleID-Fall17-iso-V2-wp90 OR (mvaEleID-Fall17-noIso-V2-wp90 AND pfRelIso < 0.3))
           if (DEBUG) std::cout << "--- Debug for extra electrons:" << std::endl;
           bool passIso    = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-LepID-pTMin-etaMax"), (DEBUG ? true : false));
-          bool passNonISo = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("thirdLep"), (DEBUG ? true : false));
+          bool passNonISo = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-pTMin-etaMax-thirdLep"), (DEBUG ? true : false));
           if (!passIso && !passNonISo) continue; // if it passes one of the two --> the "if" is false and the lepton is saved as an extra lepton
         }
 

--- a/test/skimNtuple2017.cpp
+++ b/test/skimNtuple2017.cpp
@@ -2132,12 +2132,15 @@ int main (int argc, char** argv)
         {
           isVBFfired = trigReader.isVBFfired(triggerbit, matchFlag1, matchFlag2, trgNotOverlapFlag, goodTriggerType1, goodTriggerType2, tlv_firstLepton.Pt(), tlv_firstLepton.Eta(), tlv_secondLepton.Pt(), tlv_secondLepton.Eta());
         }
+        else
+          isVBFfired = false;
 
         bool triggerAccept = false;
         triggerAccept = passTrg || isVBFfired;
 
         if(DEBUG)
         {
+          cout << "---> isVBFfired?  "<<isVBFfired<<endl;
           if(pairType == 0)//MuTau
           {
             trigReader.listMuTau(triggerbit, matchFlag1, matchFlag2, trgNotOverlapFlag, goodTriggerType1, goodTriggerType2);
@@ -2880,7 +2883,7 @@ int main (int argc, char** argv)
           // Fra Mar2020: for electron, we check (mvaEleID-Fall17-iso-V2-wp90 OR (mvaEleID-Fall17-noIso-V2-wp90 AND pfRelIso < 0.3))
           if (DEBUG) std::cout << "--- Debug for extra electrons:" << std::endl;
           bool passIso    = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-LepID-pTMin-etaMax"), (DEBUG ? true : false));
-          bool passNonISo = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("thirdLep"), (DEBUG ? true : false));
+          bool passNonISo = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-pTMin-etaMax-thirdLep"), (DEBUG ? true : false));
           if (!passIso && !passNonISo) continue; // if it passes one of the two --> the "if" is false and the lepton is saved as an extra lepton
         }
 

--- a/test/skimNtuple2018.cpp
+++ b/test/skimNtuple2018.cpp
@@ -2101,12 +2101,15 @@ int main (int argc, char** argv)
         {
           isVBFfired = trigReader.isVBFfired(triggerbit, matchFlag1, matchFlag2, trgNotOverlapFlag, goodTriggerType1, goodTriggerType2, tlv_firstLepton.Pt(), tlv_firstLepton.Eta(), tlv_secondLepton.Pt(), tlv_secondLepton.Eta());
         }
+        else
+          isVBFfired = false;
 
         bool triggerAccept = false;
         triggerAccept = passTrg || isVBFfired;
 
         if(DEBUG)
         {
+          cout << "---> isVBFfired?  "<<isVBFfired<<endl;
           if(pairType == 0)//MuTau
           {
             trigReader.listMuTau(triggerbit, matchFlag1, matchFlag2, trgNotOverlapFlag, goodTriggerType1, goodTriggerType2);
@@ -2850,7 +2853,7 @@ int main (int argc, char** argv)
           // Fra Mar2020: for electron, we check (mvaEleID-Fall17-iso-V2-wp90 OR (mvaEleID-Fall17-noIso-V2-wp90 AND pfRelIso < 0.3))
           if (DEBUG) std::cout << "--- Debug for extra electrons:" << std::endl;
           bool passIso    = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-LepID-pTMin-etaMax"), (DEBUG ? true : false));
-          bool passNonISo = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("thirdLep"), (DEBUG ? true : false));
+          bool passNonISo = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-pTMin-etaMax-thirdLep"), (DEBUG ? true : false));
           if (!passIso && !passNonISo) continue; // if it passes one of the two --> the "if" is false and the lepton is saved as an extra lepton
         }
 


### PR DESCRIPTION
Fixed two things:
- selection flags for electron third lepton veto
- isVBFfired flag is set to false if the pairType!=2 (TauTau channel) in 2017 and 2018 (when the VBF triggers are online)