### PR TITLE
VBF trigger matching

### DIFF
--- a/interface/triggerReader_cross.h
+++ b/interface/triggerReader_cross.h
@@ -39,6 +39,7 @@ class triggerReader_cross
         void listTauTau (Long64_t triggerbit_1,Long64_t matchFlag1, Long64_t matchFlag2, Long64_t trgNoOverlap, Long64_t goodTriggerType1, Long64_t goodTriggerType2);
         void listETau   (Long64_t triggerbit_1,Long64_t matchFlag1, Long64_t matchFlag2, Long64_t trgNoOverlap, Long64_t goodTriggerType1, Long64_t goodTriggerType2);
         void listMuTau  (Long64_t triggerbit_1,Long64_t matchFlag1, Long64_t matchFlag2, Long64_t trgNoOverlap, Long64_t goodTriggerType1, Long64_t goodTriggerType2);
+        void listVBF     (Long64_t triggerbit_1, Long64_t matchFlag1, Long64_t matchFlag2, Long64_t trgNoOverlap, Long64_t goodTriggerType1, Long64_t goodTriggerType2, double pt_tau1, double eta_tau1, double pt_tau2, double eta_tau2);
 
         bool isVBFfired (Long64_t triggerbit_1, Long64_t matchFlag1, Long64_t matchFlag2, Long64_t trgNoOverlap, Long64_t goodTriggerType1, Long64_t goodTriggerType2, double pt_tau1, double eta_tau1, double pt_tau2, double eta_tau2);
 

--- a/src/triggerReader_cross.cc
+++ b/src/triggerReader_cross.cc
@@ -950,152 +950,105 @@ void triggerReader_cross::listMuTau  (Long64_t triggerbit_1, Long64_t matchFlag1
 
 bool triggerReader_cross::isVBFfired  (Long64_t triggerbit_1, Long64_t matchFlag1, Long64_t matchFlag2, Long64_t trgNoOverlap, Long64_t goodTriggerType1, Long64_t goodTriggerType2, double pt_tau1, double eta_tau1, double pt_tau2, double eta_tau2)
 {
-
-    // Clean the ttCrossTriggers from the VBF triggers
-    std::vector<Long64_t> _ttCrossCleaned = _ttCrossTriggers;
-    for (unsigned int i=0; i < _ttCrossCleaned.size(); i++)
+  bool OR = false;
+  bool match1 = false;
+  bool match2 = false;
+  bool goodType1 = false;
+  bool goodType2 = false;
+  bool _trgNoOverlap = false;
+  bool match = false;
+  bool goodType = false;
+  std::string firedPath;
+  bool ptCut = false;
+  bool etaCut1 = false;
+  bool etaCut2 = false;
+  for (unsigned int i = 0; i < _vbfTriggers.size(); i++)
+  {
+    OR = CheckBit (triggerbit_1, _vbfTriggers.at(i));
+    if (OR)
     {
-      for (unsigned int j=0; j < _vbfTriggers.size(); j++)
+      match1 = CheckBit (matchFlag1, _vbfTriggers.at(i));
+      match2 = CheckBit (matchFlag2, _vbfTriggers.at(i));
+      match = match1 && match2;
+      goodType1 = CheckBit (goodTriggerType1, _vbfTriggers.at(i));
+      goodType2 = CheckBit (goodTriggerType2, _vbfTriggers.at(i));
+      goodType = goodType1 && goodType2;
+      _trgNoOverlap = CheckBit (trgNoOverlap, _vbfTriggers.at(i));
+
+      if (match && _trgNoOverlap && goodType)
       {
-        if (_ttCrossCleaned.at(i) == _vbfTriggers.at(j)) _ttCrossCleaned.erase(_ttCrossCleaned.begin() + i);
+        firedPath = _allTriggers.at(_vbfTriggers.at(i));
+        boost::regex re_tau1{"Tau(\\d+)|TauHPS(\\d+)"};
+        boost::regex re_tau2{"Tau(\\d+)|TauHPS(\\d+)"};
+        ptCut = checkPtCutCross(OR, firedPath, re_tau1, re_tau2, pt_tau1, pt_tau2, 5.0, 5.0);
+        etaCut1 = (fabs(eta_tau1) < 2.1); //tau threshold
+        etaCut2 = (fabs(eta_tau2) < 2.1); //tau threshold
+      }
+      else
+      {
+        ptCut = false;
+        etaCut1 = false;
+        etaCut2 = false;
       }
     }
+    if (!(OR && match && _trgNoOverlap && goodType && ptCut && etaCut1 && etaCut2)) OR = false;
+    if (OR) break;
+  }
+  return OR;
+}
 
-    // Use this list to check that the event does NOT pass any trigger (except for VBF)
-    // Check the crossTriggers (cleaned from the VBF)
-    bool OR_2     = false;
-    bool match1_2 = false;
-    bool match2_2 = false;
-    bool goodType1_2 = false;
-    bool goodType2_2 = false;
-    bool _trgNoOverlap_2 = false;
-    bool match_2 = false;
-    bool goodType_2 = false;
-    std::string firedPath_2;
-    bool ptCut_2 = false;
-    bool etaCut1_2 = false;
-    bool etaCut2_2 = false;
-    for (unsigned int i = 0; i < _ttCrossCleaned.size(); i++)
-    {
-      OR_2 = CheckBit (triggerbit_1, _ttCrossCleaned.at(i));
-      if (OR_2)
-      {
-        match1_2 = CheckBit (matchFlag1, _ttCrossCleaned.at(i));
-        match2_2 = CheckBit (matchFlag2, _ttCrossCleaned.at(i));
-        match_2 = match1_2 && match2_2;
-        goodType1_2 = CheckBit (goodTriggerType1, _ttCrossCleaned.at(i));
-        goodType2_2 = CheckBit (goodTriggerType2, _ttCrossCleaned.at(i));
-        goodType_2 = goodType1_2 && goodType2_2;
-        _trgNoOverlap_2 = CheckBit (trgNoOverlap, _ttCrossCleaned.at(i));
-
-        if (match_2 && _trgNoOverlap_2 && goodType_2)
-        {
-          firedPath_2 = _allTriggers.at(_ttCrossCleaned.at(i));
-          boost::regex re_tau1{"Tau(\\d+)|TauHPS(\\d+)"};
-          boost::regex re_tau2{"Tau(\\d+)|TauHPS(\\d+)"};
-          //ptCut_2 = checkPtCutCross(OR_2, firedPath_2, re_tau1, re_tau2, pt_tau1, pt_tau2, 5.0, 5.0);
-          ptCut_2 = (pt_tau1 > 40. && pt_tau2 > 40.); // suggested by tauTrigger Group
-          etaCut1_2 = (fabs(eta_tau1) < 2.1); //tau threshold
-          etaCut2_2 = (fabs(eta_tau2) < 2.1); //tau threshold
-        }
-        else
-        {
-          ptCut_2 = false;
-          etaCut1_2 = false;
-          etaCut2_2 = false;
-        }
-      }
-      if (!(OR_2 && match_2 && _trgNoOverlap_2 && goodType_2 && ptCut_2 && etaCut1_2 && etaCut2_2)) OR_2 = false;
-      if (OR_2) break;
-    }
-    // Check the singleTriggers
-    if (!OR_2)
-    {
-      for (unsigned int i = 0; i < _ttTriggers.size(); i++)
-      {
-        OR_2 = CheckBit (triggerbit_1, _ttTriggers.at(i));
-        if (OR_2)
-        {
-          match1_2 = CheckBit (matchFlag1, _ttTriggers.at(i));
-          match2_2 = true;
-          match_2 = match1_2 && match2_2;
-          goodType1_2 = CheckBit (goodTriggerType1, _ttTriggers.at(i));
-          goodType2_2 = true;
-          goodType_2 = goodType1_2 && goodType2_2;
-          _trgNoOverlap_2 = CheckBit (trgNoOverlap, _ttTriggers.at(i));
-
-          if (match_2 && _trgNoOverlap_2 && goodType_2)
-          {
-            firedPath_2 = _allTriggers.at(_ttTriggers.at(i));
-            boost::regex re_tau1{"Tau(\\d+)|TauHPS(\\d+)"};
-            ptCut_2 = checkPtCutSingle(OR_2, firedPath_2, re_tau1, pt_tau1, 5.0);
-            etaCut1_2 = (fabs(eta_tau1) < 2.1); //tau threshold
-            etaCut2_2 = (fabs(eta_tau2) < 2.1); //tau threshold
-          }
-          else
-          {
-            ptCut_2 = false;
-            etaCut1_2 = false;
-            etaCut2_2 = false;
-          }
-        }
-        if (!(OR_2 && match_2 && _trgNoOverlap_2 && goodType_2 && ptCut_2 && etaCut1_2 && etaCut2_2)) OR_2 = false;
-        if (OR_2) break;
-      }
-    }
-
-    // Finally check if the event passes at least one of the VBF triggers only
-    bool OR = false;
-
-    // if it passed some other trigger (not VBF), then return false because the event could be NOT ONLY VBF
-    if (OR_2)
-        return OR;
-    // else check if maybe it passed a VBF trigger, in this case for sure is VBF ONLY
+void triggerReader_cross::listVBF (Long64_t triggerbit_1, Long64_t matchFlag1, Long64_t matchFlag2, Long64_t trgNoOverlap, Long64_t goodTriggerType1, Long64_t goodTriggerType2, double pt_tau1, double eta_tau1, double pt_tau2, double eta_tau2)
+{
+  bool OR = false;
+  bool match1 = false;
+  bool match2 = false;
+  bool goodType1 = false;
+  bool goodType2 = false;
+  bool _trgNoOverlap = false;
+  bool match = false;
+  bool goodType = false;
+  std::string firedPath;
+  bool ptCut = false;
+  bool etaCut1 = false;
+  bool etaCut2 = false;
+  for (unsigned int i = 0; i < _vbfTriggers.size(); i++)
+  {
+    OR = CheckBit (triggerbit_1, _vbfTriggers.at(i));
+    if (OR)
+      cout <<"** trg: VBF fired: "<<_allTriggers.at(_vbfTriggers.at(i))<<endl;
     else
-    {
-      bool match1 = false;
-      bool match2 = false;
-      bool goodType1 = false;
-      bool goodType2 = false;
-      bool _trgNoOverlap = false;
-      bool match = false;
-      bool goodType = false;
-      std::string firedPath;
-      bool ptCut = false;
-      bool etaCut1 = false;
-      bool etaCut2 = false;
-      for (unsigned int i = 0; i < _vbfTriggers.size(); i++)
-      {
-        OR = CheckBit (triggerbit_1, _vbfTriggers.at(i));
-        if (OR)
-        {
-          match1 = CheckBit (matchFlag1, _vbfTriggers.at(i));
-          match2 = CheckBit (matchFlag2, _vbfTriggers.at(i));
-          match = match1 && match2;
-          goodType1 = CheckBit (goodTriggerType1, _vbfTriggers.at(i));
-          goodType2 = CheckBit (goodTriggerType2, _vbfTriggers.at(i));
-          goodType = goodType1 && goodType2;
-          _trgNoOverlap = CheckBit (trgNoOverlap, _vbfTriggers.at(i));
+      cout <<"** trg: VBF NOT fired: "<<_allTriggers.at(_vbfTriggers.at(i))<<endl;
 
-          if (match && _trgNoOverlap && goodType)
-          {
-            firedPath = _allTriggers.at(_vbfTriggers.at(i));
-            boost::regex re_tau1{"Tau(\\d+)|TauHPS(\\d+)"};
-            boost::regex re_tau2{"Tau(\\d+)|TauHPS(\\d+)"};
-            ptCut = checkPtCutCross(OR, firedPath, re_tau1, re_tau2, pt_tau1, pt_tau2, 5.0, 5.0);
-            etaCut1 = (fabs(eta_tau1) < 2.1); //tau threshold
-            etaCut2 = (fabs(eta_tau2) < 2.1); //tau threshold
-          }
-          else
-          {
-            ptCut = false;
-            etaCut1 = false;
-            etaCut2 = false;
-          }
-        }
-        if (!(OR && match && _trgNoOverlap && goodType && ptCut && etaCut1 && etaCut2)) OR = false;
-        if (OR) break;
+    if (OR)
+    {
+      match1 = CheckBit (matchFlag1, _vbfTriggers.at(i));
+      match2 = CheckBit (matchFlag2, _vbfTriggers.at(i));
+      match = match1 && match2;
+      goodType1 = CheckBit (goodTriggerType1, _vbfTriggers.at(i));
+      goodType2 = CheckBit (goodTriggerType2, _vbfTriggers.at(i));
+      goodType = goodType1 && goodType2;
+      _trgNoOverlap = CheckBit (trgNoOverlap, _vbfTriggers.at(i));
+
+      if (match && _trgNoOverlap && goodType)
+      {
+        firedPath = _allTriggers.at(_vbfTriggers.at(i));
+        boost::regex re_tau1{"Tau(\\d+)|TauHPS(\\d+)"};
+        boost::regex re_tau2{"Tau(\\d+)|TauHPS(\\d+)"};
+        ptCut = checkPtCutCross(OR, firedPath, re_tau1, re_tau2, pt_tau1, pt_tau2, 5.0, 5.0);
+        etaCut1 = (fabs(eta_tau1) < 2.1); //tau threshold
+        etaCut2 = (fabs(eta_tau2) < 2.1); //tau threshold
+      }
+      else
+      {
+        ptCut = false;
+        etaCut1 = false;
+        etaCut2 = false;
       }
     }
-    return OR;
+    cout <<"   matchFlag    "<< match<<endl;
+    cout <<"   trgNoOverlap "<< _trgNoOverlap<<endl;
+    cout <<"   goodType     "<< goodType<<endl;
+    cout <<"   ptCut        "<< ptCut<<endl;
+    cout <<"   etaCut1      "<< (etaCut1 && etaCut2)<<endl;
+  }
 }

--- a/test/skimNtuple2017.cpp
+++ b/test/skimNtuple2017.cpp
@@ -3120,10 +3120,6 @@ int main (int argc, char** argv)
               //if ( kjet.Pt()<50. && fabs(kjet.Eta())>2.65 && fabs(kjet.Eta()<3.139) ) continue; //Commented during March20 sync
 
               TLorentzVector jetPair = ijet+kjet;
-
-              bool VBFjetLegsMatched = true;
-              if (isVBFfired) VBFjetLegsMatched = checkVBFjetMatch(DEBUG, iJet, kJet, theBigTree);
-              if (isVBFfired && !VBFjetLegsMatched) continue;
               VBFcand_Mjj.push_back(make_tuple(jetPair.M(),iJet,kJet));
             }
           }
@@ -3171,6 +3167,17 @@ int main (int argc, char** argv)
         {
           if(DEBUG) cout << "---> Evt rejected because (isVBFfired && !isVBF) (VBF trig fired but no good VBF jet candidates available)" << endl;
           continue;
+        }
+
+        // Check that the the VBFjet-pair candidate is trigger matched
+        if (isVBFfired && isVBF)
+        {
+          bool VBFjetLegsMatched = checkVBFjetMatch(DEBUG, VBFidx1, VBFidx2, theBigTree);
+          if (!VBFjetLegsMatched)
+          {
+            if(DEBUG) cout << "---> Evt rejected because VBFjet-pair candidate is not trigger matched" << endl;
+            continue;
+          }
         }
 
         if (isVBF)
@@ -4230,8 +4237,8 @@ int main (int argc, char** argv)
       {
         cout << "--- VBF jets ---" << endl;
         cout << "isVBF: " << theSmallTree.m_isVBF << endl;
-        cout << "VBF1(pt,eta,phi): " << theSmallTree.m_VBFjet1_pt << " / " << theSmallTree.m_VBFjet1_eta << " / " << theSmallTree.m_VBFjet1_phi << endl;
-        cout << "VBF2(pt,eta,phi): " << theSmallTree.m_VBFjet2_pt << " / " << theSmallTree.m_VBFjet2_eta << " / " << theSmallTree.m_VBFjet2_phi << endl;
+        cout << "VBF1(pt,eta,phi,e): " << theSmallTree.m_VBFjet1_pt << " / " << theSmallTree.m_VBFjet1_eta << " / " << theSmallTree.m_VBFjet1_phi << " / " << theSmallTree.m_VBFjet1_e << endl;
+        cout << "VBF2(pt,eta,phi,e): " << theSmallTree.m_VBFjet2_pt << " / " << theSmallTree.m_VBFjet2_eta << " / " << theSmallTree.m_VBFjet2_phi << " / " << theSmallTree.m_VBFjet2_e << endl;
         cout << "----------------" << endl;
       }
 

--- a/test/skimNtuple2017.cpp
+++ b/test/skimNtuple2017.cpp
@@ -1052,20 +1052,10 @@ int main (int argc, char** argv)
     }
 
   //FRA debug
-/*unsigned long long int debugEvents[12] = {
-537621112,
-538855447,
-540452948,
-326296633,
-328306950,
-334818534,
-347105759,
-365718739,
-571229876,
-583040266,
-599505758,
-629661432
-};*/ 
+/*unsigned long long int debugEvents[2] = {
+57924,
+59095
+};*/
  
   // loop over events
   // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
@@ -2128,7 +2118,7 @@ int main (int argc, char** argv)
         }
 
         // Remember: isVBFfired means it passed ONLY a VBF trigger
-        if (pairType == 2)
+        if (pairType == 2 && !passTrg)
         {
           isVBFfired = trigReader.isVBFfired(triggerbit, matchFlag1, matchFlag2, trgNotOverlapFlag, goodTriggerType1, goodTriggerType2, tlv_firstLepton.Pt(), tlv_firstLepton.Eta(), tlv_secondLepton.Pt(), tlv_secondLepton.Eta());
         }
@@ -2152,6 +2142,7 @@ int main (int argc, char** argv)
           if(pairType == 2)//TauTau
           {
             trigReader.listTauTau(triggerbit, matchFlag1, matchFlag2, trgNotOverlapFlag, goodTriggerType1, goodTriggerType2);
+            trigReader.listVBF(triggerbit, matchFlag1, matchFlag2, trgNotOverlapFlag, goodTriggerType1, goodTriggerType2, tlv_firstLepton.Pt(), tlv_firstLepton.Eta(), tlv_secondLepton.Pt(), tlv_secondLepton.Eta());
           }
         }
 
@@ -2969,8 +2960,8 @@ int main (int argc, char** argv)
           cout << "dR(tau2)   : " << tlv_jet.DeltaR (tlv_secondLepton) << " - lepCleaningCone: " << lepCleaningCone << endl;
           cout << "pT < 20    : " << (tlv_jet.Pt () < 20.) << endl;
           cout << "eta > 2.4  : " << (TMath::Abs(tlv_jet.Eta()) > 2.4) << endl;
-          cout << "deepFlavour: " << theBigTree.bDeepFlavor_probb->at(iJet) + theBigTree.bDeepFlavor_probbb->at(iJet) + theBigTree.bDeepFlavor_problepb->at(iJet);
-	  cout << "---------------------------------" << endl;
+          cout << "deepFlavour: " << theBigTree.bDeepFlavor_probb->at(iJet) + theBigTree.bDeepFlavor_probbb->at(iJet) + theBigTree.bDeepFlavor_problepb->at(iJet) << endl;
+          cout << "---------------------------------" << endl;
         }
 
         if (tlv_jet.Pt () < 20.) continue ;
@@ -3174,6 +3165,12 @@ int main (int argc, char** argv)
               }
             }
           }
+        }
+
+        if (isVBFfired && !isVBF)
+        {
+          if(DEBUG) cout << "---> Evt rejected because (isVBFfired && !isVBF) (VBF trig fired but no good VBF jet candidates available)" << endl;
+          continue;
         }
 
         if (isVBF)

--- a/test/skimNtuple2018.cpp
+++ b/test/skimNtuple2018.cpp
@@ -3092,10 +3092,6 @@ int main (int argc, char** argv)
               }
 
               TLorentzVector jetPair = ijet+kjet;
-
-              bool VBFjetLegsMatched = true;
-              if (isVBFfired) VBFjetLegsMatched = checkVBFjetMatch(DEBUG, iJet, kJet, theBigTree);
-              if (isVBFfired && !VBFjetLegsMatched) continue;
               VBFcand_Mjj.push_back(make_tuple(jetPair.M(),iJet,kJet));
             }
           }
@@ -3143,6 +3139,17 @@ int main (int argc, char** argv)
         {
           if(DEBUG) cout << "---> Evt rejected because (isVBFfired && !isVBF) (VBF trig fired but no good VBF jet candidates available)" << endl;
           continue;
+        }
+
+        // Check that the the VBFjet-pair candidate is trigger matched
+        if (isVBFfired && isVBF)
+        {
+          bool VBFjetLegsMatched = checkVBFjetMatch(DEBUG, VBFidx1, VBFidx2, theBigTree);
+          if (!VBFjetLegsMatched)
+          {
+            if(DEBUG) cout << "---> Evt rejected because VBFjet-pair candidate is not trigger matched" << endl;
+            continue;
+          }
         }
 
         if (isVBF)
@@ -4194,8 +4201,8 @@ int main (int argc, char** argv)
       {
         cout << "--- VBF jets ---" << endl;
         cout << "isVBF: " << theSmallTree.m_isVBF << endl;
-        cout << "VBF1(pt,eta,phi): " << theSmallTree.m_VBFjet1_pt << " / " << theSmallTree.m_VBFjet1_eta << " / " << theSmallTree.m_VBFjet1_phi << endl;
-        cout << "VBF2(pt,eta,phi): " << theSmallTree.m_VBFjet2_pt << " / " << theSmallTree.m_VBFjet2_eta << " / " << theSmallTree.m_VBFjet2_phi << endl;
+        cout << "VBF1(pt,eta,phi,e): " << theSmallTree.m_VBFjet1_pt << " / " << theSmallTree.m_VBFjet1_eta << " / " << theSmallTree.m_VBFjet1_phi << " / " << theSmallTree.m_VBFjet1_e << endl;
+        cout << "VBF2(pt,eta,phi,e): " << theSmallTree.m_VBFjet2_pt << " / " << theSmallTree.m_VBFjet2_eta << " / " << theSmallTree.m_VBFjet2_phi<< " / " << theSmallTree.m_VBFjet2_e << endl;
         cout << "----------------" << endl;
       }
 

--- a/test/skimNtuple2018.cpp
+++ b/test/skimNtuple2018.cpp
@@ -2097,7 +2097,7 @@ int main (int argc, char** argv)
         }
 
         // Remember: isVBFfired means it passed ONLY a VBF trigger
-        if (pairType == 2)
+        if (pairType == 2 && !passTrg)
         {
           isVBFfired = trigReader.isVBFfired(triggerbit, matchFlag1, matchFlag2, trgNotOverlapFlag, goodTriggerType1, goodTriggerType2, tlv_firstLepton.Pt(), tlv_firstLepton.Eta(), tlv_secondLepton.Pt(), tlv_secondLepton.Eta());
         }
@@ -2121,6 +2121,7 @@ int main (int argc, char** argv)
           if(pairType == 2)//TauTau
           {
             trigReader.listTauTau(triggerbit, matchFlag1, matchFlag2, trgNotOverlapFlag, goodTriggerType1, goodTriggerType2);
+            trigReader.listVBF(triggerbit, matchFlag1, matchFlag2, trgNotOverlapFlag, goodTriggerType1, goodTriggerType2, tlv_firstLepton.Pt(), tlv_firstLepton.Eta(), tlv_secondLepton.Pt(), tlv_secondLepton.Eta());
           }
         }
 
@@ -2939,6 +2940,7 @@ int main (int argc, char** argv)
           cout << "dR(tau2)   : " << tlv_jet.DeltaR (tlv_secondLepton) << " - lepCleaningCone: " << lepCleaningCone << endl;
           cout << "pT < 20    : " << (tlv_jet.Pt () < 20.) << endl;
           cout << "eta > 2.4  : " << (TMath::Abs(tlv_jet.Eta()) > 2.4) << endl;
+          cout << "deepFlavour: " << theBigTree.bDeepFlavor_probb->at(iJet) + theBigTree.bDeepFlavor_probbb->at(iJet) + theBigTree.bDeepFlavor_problepb->at(iJet) << endl;
           cout << "---------------------------------" << endl;
         }
 
@@ -3135,6 +3137,12 @@ int main (int argc, char** argv)
               }
             }
           }
+        }
+
+        if (isVBFfired && !isVBF)
+        {
+          if(DEBUG) cout << "---> Evt rejected because (isVBFfired && !isVBF) (VBF trig fired but no good VBF jet candidates available)" << endl;
+          continue;
         }
 
         if (isVBF)


### PR DESCRIPTION
In **triggerReader_cross**:
- added `listVBF` function to print debug info for VBF trigger
- re-arranged `isVBFfired` function: no more checking the other tautau triggers to declare if an event is VBF triggered or not

In **skimNtuple2017/2018** fixed logic of VBF trigger matching:
- check isVBFfired only if `pairType==2 && !passTrg` (is tauTau channel and didn't pass any other tautau trigger)
- added a check on `isVBFfired && !isVBF`: the event is rejected if the VBF trigger is fired but no good VBF jet candidates are available. Technically this is not an error: the events would have been rejected anyway later during categorization, but this way we save space/time especially in view of SVfit and DNN computation in the skimmer.
- added some debug info
