### PR TITLE
Include DNN in 2017 skimmer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ cmsrel CMSSW_10_2_16
 cd CMSSW_10_2_16/src
 cmsenv
 
+# DNN packages
+git clone git@github.com:GilesStrong/cms_hh_proc_interface.git
+git clone git@github.com:GilesStrong/cms_hh_tf_inference.git
+git clone git@github.com:GilesStrong/cms_runII_dnn_models.git
+
+# KinFit and Combine packages
 git clone https://github.com/bvormwald/HHKinFit2
 git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
 cd HiggsAnalysis/CombinedLimit

--- a/config/skim_Legacy2016_mib.cfg
+++ b/config/skim_Legacy2016_mib.cfg
@@ -120,3 +120,7 @@ weights    = //gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAna
 #variables  = VBFjj_dEtaSign:BDT_j1j2n_dEtaSign, HH_deltaR:BDT_n_HH_deltaR, dib_dEtaSign:BDT_n_b1b2_dEtaSign, VBFjj_deltaEta:BDT_j1j2n_dEta, VBFjj_mass:BDT_j1j2n_Mjj, VBFjet2_pt:BDT_j2n_pt, tauH_pt:BDT_n_ditau_pt, bH_VBF1_deltaEta:BDT_bbH_j1n_dEta, VBFjet1_btag:BDT_j1n_csv, VBFjet1_pt:BDT_j1n_pt, dib_deltaR:BDT_n_dib_deltaR, VBFjet2_PUjetID:BDT_j2n_PUjetID
 variables  = VBFjet1_pt:BDT_j1n_pt, bH_pt:BDT_n_bH_pt, dib_dEtaSign:BDT_n_b1b2_dEtaSign, ditau_deltaR:ditau_deltaR, HH_deltaR:BDT_n_HH_deltaR, HH_zV:BDT_HH_zV_n, VBFjj_dEtaSign:BDT_j1j2n_dEtaSign, VBFjj_mass:BDT_j1j2n_Mjj
 
+[DNN]
+computeMVA = true
+weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/DNN2/CMSSW_10_2_16/src/cms_runII_dnn_models/models/nonres_gluglu/2020-02-17-0/ensemble
+kl = 1

--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -122,3 +122,7 @@ weights    = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_10_2_16/src/KL
 #variables  = VBFjj_dEtaSign:BDT_j1j2n_dEtaSign, HH_deltaR:BDT_n_HH_deltaR, dib_dEtaSign:BDT_n_b1b2_dEtaSign, VBFjj_deltaEta:BDT_j1j2n_dEta, VBFjj_mass:BDT_j1j2n_Mjj, VBFjet2_pt:BDT_j2n_pt, tauH_pt:BDT_n_ditau_pt, bH_VBF1_deltaEta:BDT_bbH_j1n_dEta, VBFjet1_btag:BDT_j1n_csv, VBFjet1_pt:BDT_j1n_pt, dib_deltaR:BDT_n_dib_deltaR, VBFjet2_PUjetID:BDT_j2n_PUjetID
 variables  = VBFjet1_pt:BDT_j1n_pt, bH_pt:BDT_n_bH_pt, dib_dEtaSign:BDT_n_b1b2_dEtaSign, ditau_deltaR:ditau_deltaR, HH_deltaR:BDT_n_HH_deltaR, HH_zV:BDT_HH_zV_n, VBFjj_dEtaSign:BDT_j1j2n_dEtaSign, VBFjj_mass:BDT_j1j2n_Mjj
 
+[DNN]
+computeMVA = true
+weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/DNN2/CMSSW_10_2_16/src/cms_runII_dnn_models/models/nonres_gluglu/2020-02-17-0/ensemble
+kl = 1

--- a/config/skim_Legacy2018.cfg
+++ b/config/skim_Legacy2018.cfg
@@ -128,3 +128,8 @@ variables  = VBFjet1_pt:BDT_j1n_pt, bH_pt:BDT_n_bH_pt, dib_dEtaSign:BDT_n_b1b2_d
 doReweight = true
 inputFile = /home/llr/cms/amendola/HHLegacy/CMSSW_10_2_16/src/KLUBAnalysis/weights/DYLOtoNLOreweight/comp_LO_NLO_7.root
 sfFile    = /home/llr/cms/amendola/HHLegacy/CMSSW_10_2_16/src/KLUBAnalysis/weights/DYLOtoNLOreweight/DY_Scale_factor_nbjet_njetBins_other_bkg_fixed_27June.root
+
+[DNN]
+computeMVA = true
+weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/DNN2/CMSSW_10_2_16/src/cms_runII_dnn_models/models/nonres_gluglu/2020-02-17-0/ensemble
+kl = 1

--- a/config/skim_Legacy2018_mib.cfg
+++ b/config/skim_Legacy2018_mib.cfg
@@ -122,3 +122,7 @@ weights    = /gwpool/users/dzuolo/HbbtautauAnalysis2018/CMSSW_9_0_0/src/KLUBAnal
 #variables  = VBFjj_dEtaSign:BDT_j1j2n_dEtaSign, HH_deltaR:BDT_n_HH_deltaR, dib_dEtaSign:BDT_n_b1b2_dEtaSign, VBFjj_deltaEta:BDT_j1j2n_dEta, VBFjj_mass:BDT_j1j2n_Mjj, VBFjet2_pt:BDT_j2n_pt, tauH_pt:BDT_n_ditau_pt, bH_VBF1_deltaEta:BDT_bbH_j1n_dEta, VBFjet1_btag:BDT_j1n_csv, VBFjet1_pt:BDT_j1n_pt, dib_deltaR:BDT_n_dib_deltaR, VBFjet2_PUjetID:BDT_j2n_PUjetID
 variables  = VBFjet1_pt:BDT_j1n_pt, bH_pt:BDT_n_bH_pt, dib_dEtaSign:BDT_n_b1b2_dEtaSign, ditau_deltaR:ditau_deltaR, HH_deltaR:BDT_n_HH_deltaR, HH_zV:BDT_HH_zV_n, VBFjj_dEtaSign:BDT_j1j2n_dEtaSign, VBFjj_mass:BDT_j1j2n_Mjj
 
+[DNN]
+computeMVA = true
+weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/DNN2/CMSSW_10_2_16/src/cms_runII_dnn_models/models/nonres_gluglu/2020-02-17-0/ensemble
+kl = 1

--- a/interface/smallTree.h
+++ b/interface/smallTree.h
@@ -556,6 +556,7 @@ struct smallTree
       m_BDT_HHsvfit_abs_deltaPhi      = -9. ;
       m_BDT_HT20                      = 0. ;
       m_BDT_topPairMasses             = -999. ;
+      m_BDT_topPairMasses2            = -999. ;
       m_BDT_MX                        = -999. ;
       m_BDT_bH_tauH_MET_InvMass       = -999. ;
       m_BDT_bH_tauH_SVFIT_InvMass     = -999. ;
@@ -1110,6 +1111,7 @@ struct smallTree
       m_smallT->Branch ("BDT_HHsvfit_abs_deltaPhi",       &m_BDT_HHsvfit_abs_deltaPhi      , "BDT_HHsvfit_abs_deltaPhi/F");
       m_smallT->Branch ("BDT_HT20",                       &m_BDT_HT20                      , "BDT_HT20/F");
       m_smallT->Branch ("BDT_topPairMasses",              &m_BDT_topPairMasses             , "BDT_topPairMasses/F");
+      m_smallT->Branch ("BDT_topPairMasses2",             &m_BDT_topPairMasses2            , "BDT_topPairMasses2/F");
       m_smallT->Branch ("BDT_MX",                         &m_BDT_MX                        , "BDT_MX/F");
       m_smallT->Branch ("BDT_bH_tauH_MET_InvMass",        &m_BDT_bH_tauH_MET_InvMass       , "BDT_bH_tauH_MET_InvMass/F");
       m_smallT->Branch ("BDT_bH_tauH_SVFIT_InvMass",      &m_BDT_bH_tauH_SVFIT_InvMass     , "BDT_bH_tauH_SVFIT_InvMass/F");
@@ -1686,6 +1688,7 @@ struct smallTree
   Float_t m_BDT_HHsvfit_abs_deltaPhi; //
   Float_t m_BDT_HT20; //
   Float_t m_BDT_topPairMasses; //
+  Float_t m_BDT_topPairMasses2; //
   Float_t m_BDT_MX; //
   Float_t m_BDT_bH_tauH_MET_InvMass; //
   Float_t m_BDT_bH_tauH_SVFIT_InvMass; //

--- a/src/Makefile
+++ b/src/Makefile
@@ -31,12 +31,18 @@ ROOTGLIBS     = $(shell root-config --glibs)
 BOOSTFLAGS      = $(shell scram tool info boost | grep -e '^LIBDIR' | sed -e 's/LIBDIR=/-L/')
 BOOSTLIB    = $(shell scram tool info boost | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
 
+TensFLowFLAGS = $(shell scram tool info tensorflow | grep -e '^LIBDIR' | sed -e 's/LIBDIR=/-L/')
+TensFLowLIB   = $(shell scram tool info tensorflow | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
+
+PROTOBUFLIB   = $(shell scram tool info protobuf | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
+EIGENLIB   = $(shell scram tool info eigen | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
+BASELIBS = -I$(shell echo $$CMSSW_RELEASE_BASE | sed -e 's/$$/\/src/')
 
 ARCHL = -m64
 CXX  =  g++
 CXXFLAGS  =  -Wall -O -fPIC -I$(HDR) $(ROOTCFLAGS) $(BOOSTFLAGS) $(BOOSTLIB)
 CPP  =  g++
-CPPFLAGS  = -Wall  $(ARCHL) -I$(HDR) $(ROOTCFLAGS) $(BOOSTFLAGS) $(BOOSTLIB)
+CPPFLAGS  = -Wall  $(ARCHL) -I$(HDR) $(ROOTCFLAGS) $(BOOSTFLAGS) $(BOOSTLIB) $(BASELIBS) $(TensFLowLIB) $(PROTOBUFLIB) $(EIGENLIB)
 
 F    = gfortran
 FFLAGS = -c
@@ -47,8 +53,11 @@ SONAME	 =  libDoubleHiggs.so
 SONAME2  =  DoubleHiggs
 SOFLAGS  =  -Wl,-soname,$(SONAME)
 
-GLIBS   =  -lm -ldl -rdynamic $(ROOTGLIBS) -lGenVector -lFoam -lMinuit -lTMVA -lMLP -lXMLIO -lGpad  -lTreePlayer -lRooFit -lRooFitCore -lRooStats -lHHKinFit2 -L../../HHKinFit2 -lboost_regex
+GLIBS   =  -lm -ldl -rdynamic $(ROOTGLIBS) -lGenVector -lFoam -lMinuit -lTMVA -lMLP -lXMLIO -lGpad  -lTreePlayer -lRooFit -lRooFitCore -lRooStats -lHHKinFit2 -L../../HHKinFit2 -lboost_regex -ltensorflow_cc -ltensorflow_framework $(TensFLowFLAGS)
 
+DNNARCH = $(shell scram arch)
+DNNPATH = $(shell echo $$CMSSW_BASE | grep "CMSSW" | sed -e 's/$$/\/lib/')/$(DNNARCH)/
+DNNLIBS = -lcms_hh_proc_interfaceprocessing -lcms_hh_tf_inferenceinference -L$(DNNPATH)
 
 #################################################
 #if mac 64
@@ -82,6 +91,8 @@ test:
 	@echo "OBJS = $(OBJS)"
 	@echo "PRGS = $(PRGS)"
 	@echo "BINS = $(BIN)%$(BinSuf): $(PRG)%$(PrgSuf)"
+	@echo "DNNLIBS   = $(DNNLIBS)"
+	@echo "CMSSWPATH = $(CMSSWPATH)"
 
 
 $(OBJ)%$(ObjSuf): %$(SrcSuf) $(HDRS)
@@ -97,7 +108,7 @@ $(LIB)$(SONAME): $(OBJS) $(OBJ)mydict.o
         @echo "Linking $(SONAME):"
 
 $(BIN)%$(BinSuf): $(PRG)%$(PrgSuf) $(HDRS) $(LIB)$(SONAME)
-	$(CPP) $<  -l$(SONAME2) $(CPPFLAGS) -L$(LIB) $(GLIBS)  -o $@
+	$(CPP) $<  -l$(SONAME2) $(CPPFLAGS) -L$(LIB) $(GLIBS) $(DNNLIBS) -o $@
 
 
 clean:


### PR DESCRIPTION
- updated instructions in `README`
- updated `src/MakeFile` to include tensorflow and other needed libraries
- added a new branch in `smallTree.h`
- added the computation of DNN output in `skimNtuple2017.cpp`
  - similar to what was done for the old BDT
  - a new branch is added to store the prediction for each value of kl (even tough for now the training is provided only for kl=1)
- updated the skimmer configs