### PR TITLE
VBF Reweighting

### DIFF
--- a/config/mainCfg_ETau_Legacy2016.cfg
+++ b/config/mainCfg_ETau_Legacy2016.cfg
@@ -92,3 +92,14 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+
+
+[VBF_rew]
+# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
+# See the list 'inputSignals' to understand the link node<->couplings
+doReweighting = False
+inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
+target_kl  = 1
+target_cv  = 0, 1
+target_c2v = 1
+target_xs = 1 #[pb]

--- a/config/mainCfg_ETau_Legacy2017.cfg
+++ b/config/mainCfg_ETau_Legacy2017.cfg
@@ -80,3 +80,14 @@ fitFunc      = [0] + [1]*x
 #fitFunc      = [0] + [1]*x
 #regionC      = SStight
 #regionD      = SSinviso
+
+
+[VBF_rew]
+# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
+# See the list 'inputSignals' to understand the link node<->couplings
+doReweighting = False
+inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
+target_kl  = 1
+target_cv  = 0, 1
+target_c2v = 1
+target_xs = 1 #[pb]

--- a/config/mainCfg_ETau_Legacy2018.cfg
+++ b/config/mainCfg_ETau_Legacy2018.cfg
@@ -92,3 +92,14 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+
+
+[VBF_rew]
+# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
+# See the list 'inputSignals' to understand the link node<->couplings
+doReweighting = False
+inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
+target_kl  = 1
+target_cv  = 0, 1
+target_c2v = 1
+target_xs = 1 #[pb]

--- a/config/mainCfg_MuTau_Legacy2016.cfg
+++ b/config/mainCfg_MuTau_Legacy2016.cfg
@@ -92,3 +92,14 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+
+
+[VBF_rew]
+# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
+# See the list 'inputSignals' to understand the link node<->couplings
+doReweighting = False
+inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
+target_kl  = 1
+target_cv  = 0, 1
+target_c2v = 1
+target_xs = 1 #[pb]

--- a/config/mainCfg_MuTau_Legacy2017.cfg
+++ b/config/mainCfg_MuTau_Legacy2017.cfg
@@ -80,3 +80,14 @@ fitFunc      = [0] + [1]*x
 #fitFunc      = [0] + [1]*x
 #regionC      = SStight
 #regionD      = SSinviso
+
+
+[VBF_rew]
+# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
+# See the list 'inputSignals' to understand the link node<->couplings
+doReweighting = False
+inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
+target_kl  = 1
+target_cv  = 0, 1
+target_c2v = 1
+target_xs = 1 #[pb]

--- a/config/mainCfg_MuTau_Legacy2018.cfg
+++ b/config/mainCfg_MuTau_Legacy2018.cfg
@@ -92,3 +92,14 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+
+
+[VBF_rew]
+# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
+# See the list 'inputSignals' to understand the link node<->couplings
+doReweighting = False
+inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
+target_kl  = 1
+target_cv  = 0, 1
+target_c2v = 1
+target_xs = 1 #[pb]

--- a/config/mainCfg_TauTau_Legacy2016.cfg
+++ b/config/mainCfg_TauTau_Legacy2016.cfg
@@ -93,3 +93,14 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+
+
+[VBF_rew]
+# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
+# See the list 'inputSignals' to understand the link node<->couplings
+doReweighting = False
+inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
+target_kl  = 1
+target_cv  = 0, 1
+target_c2v = 1
+target_xs = 1 #[pb]

--- a/config/mainCfg_TauTau_Legacy2017.cfg
+++ b/config/mainCfg_TauTau_Legacy2017.cfg
@@ -81,3 +81,14 @@ fitFunc      = [0] + [1]*x
 #fitFunc      = [0] + [1]*x
 #regionC      = SStight
 #regionD      = SSinviso
+
+
+[VBF_rew]
+# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
+# See the list 'inputSignals' to understand the link node<->couplings
+doReweighting = False
+inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
+target_kl  = 1
+target_cv  = 0, 1
+target_c2v = 1
+target_xs = 1 #[pb]

--- a/config/mainCfg_TauTau_Legacy2018.cfg
+++ b/config/mainCfg_TauTau_Legacy2018.cfg
@@ -90,3 +90,14 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+
+
+[VBF_rew]
+# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
+# See the list 'inputSignals' to understand the link node<->couplings
+doReweighting = False
+inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
+target_kl  = 1
+target_cv  = 0, 1
+target_c2v = 1
+target_xs = 1 #[pb]

--- a/scripts/combineFillerOutputs.py
+++ b/scripts/combineFillerOutputs.py
@@ -190,5 +190,34 @@ if cfg.hasSection('pp_QCD'):
         computeSBtoSR = computeSBtoSRdyn
         )
 
+# VBF HH Reweighting
+# reads from the config the 6 input samples and the target couplings
+if cfg.hasSection('VBF_rew'):
+    if eval(cfg.readOption('VBF_rew::doReweighting')):
+        print "--- VBF Reweighting ---"
+        inputSigList = cfg.readListOption("VBF_rew::inputSignals")
+        if len(inputSigList) != 6:
+            print "** ERROR: VBF reweighting requires 6 input samples! You only provided:", len(inputSigList), " --> Skipping VBF reweighting!"
+        else:
+            print "** INFO: VBF reweighting requires the input samples to be in the order: node1, node2, node3, node4, node5, node19!"
+            print "** INFO: I will assume they are passed in the correct order!"
+
+            # Check that all input samples are present in sigList
+            goodSamples = True
+            for sig in inputSigList:
+                if sig not in sigList:
+                    goodSamples = False
+                    print "** ERROR: VBF node ", sig, " not between provided signals  --> Skipping VBF reweighting!"
+
+            # Apply the actual VBF reweighting
+            if goodSamples:
+                target_kl  = [float(kl)  for kl  in cfg.readListOption("VBF_rew::target_kl") ]
+                target_cv  = [float(cv)  for cv  in cfg.readListOption("VBF_rew::target_cv") ]
+                target_c2v = [float(c2v) for c2v in cfg.readListOption("VBF_rew::target_c2v")]
+                target_xs  = float(cfg.readOption("VBF_rew::target_xs")) if cfg.hasOption("VBF_rew::target_xs") else -1.0
+
+                omngr.makeVBFrew(inputSigList, target_kl, target_cv, target_c2v, target_xs)
+
+
 fOut = ROOT.TFile(args.dir+"/" + 'analyzedOutPlotter.root', 'recreate')
 omngr.saveToFile(fOut)

--- a/scripts/modules/VBFReweightModules.py
+++ b/scripts/modules/VBFReweightModules.py
@@ -1,0 +1,192 @@
+## VBF Reweighting Module
+## Implements the formula from slides 11 and 12 of:
+## https://indico.cern.ch/event/890825/contributions/3759797/attachments/1993521/3324873/2020_25_02_bbtautau_HIGPAG.pdf
+## C -> vector of couplings
+## S -> vector of samples (generated xs)
+## V -> vector of components (a,b,c,iab,ibc,iac)
+## M -> matrix that describes the single samples as sum of components, so that S = M * V
+## so that M^-1 * S = V
+##
+## And the final cross section is sigma(CV, C2V, kl) = C^T * V = C^T * M-1 * S
+
+from sympy import *
+from sympy import Matrix
+from array import array
+import sys
+import ROOT
+
+
+#########################
+### General functions ###
+#########################
+
+# General function to rescale any histogram to a specific value
+def scaleTo(hIn, val):
+    hIn.Scale(val)
+
+# General function to build a sympy.Matrix from a list of "inputSample"
+def build_matrix(sample_list):    
+    if len(sample_list) != 6:
+        print "[ERROR] : expecting 6 samples in input"
+        raise RuntimeError("malformed input sample list")
+
+    M_tofill = [
+        [None,None,None,None,None,None],
+        [None,None,None,None,None,None],
+        [None,None,None,None,None,None],
+        [None,None,None,None,None,None],
+        [None,None,None,None,None,None],
+        [None,None,None,None,None,None]
+    ]
+
+    # Implement the 6 scalings
+    for isample, sample in enumerate(sample_list):
+        M_tofill[isample][0] = sample.val_CV**2 * sample.val_kl**2
+        M_tofill[isample][1] = sample.val_CV**4
+        M_tofill[isample][2] = sample.val_C2V**2
+        M_tofill[isample][3] = sample.val_CV**3 * sample.val_kl
+        M_tofill[isample][4] = sample.val_CV    * sample.val_C2V    * sample.val_kl
+        M_tofill[isample][5] = sample.val_CV**2 * sample.val_C2V
+    
+    res = Matrix(M_tofill)
+    return res
+
+# General function to print progression bar
+def printProgressBar (iteration, total, prefix = '', suffix = '', decimals = 1, length = 100, fill = '#'):
+    """
+    Call in a loop to create terminal progress bar
+    @params:
+        iteration   - Required  : current iteration (Int)
+        total       - Required  : total iterations (Int)
+        prefix      - Optional  : prefix string (Str)
+        suffix      - Optional  : suffix string (Str)
+        decimals    - Optional  : positive number of decimals in percent complete (Int)
+        length      - Optional  : character length of bar (Int)
+        fill        - Optional  : bar fill character (Str)
+    """
+    percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
+    filledLength = int(length * iteration // total)
+    bar = fill * filledLength + '-' * (length - filledLength)
+    sys.stdout.write('\r%s |%s| %s%s %s' % (prefix, bar, percent, '%', suffix))
+    if iteration == total:
+        sys.stdout.write('\n')
+
+
+################################################
+### Class for handling the six input samples ###
+################################################
+class inputSample:
+    def __init__(self, val_CV, val_C2V, val_kl, val_xs, histo):
+        self.val_CV  = val_CV
+        self.val_C2V = val_C2V
+        self.val_kl  = val_kl
+        self.val_xs  = val_xs
+        self.histo   = histo
+
+
+########################################
+### Class for actual VBF reweighting ###
+########################################
+class VBFReweight:
+    def __init__(self, sample_list):
+        self.sample_list = sample_list
+        
+        # Declare symbols to be used in the solution of the systems
+        CV, C2V, kl, a, b, c, iab, iac, ibc, s1, s2, s3, s4, s5, s6 = symbols('CV C2V kl a b c iab iac ibc s1 s2 s3 s4 s5 s6')
+        self.CV  = CV
+        self.C2V = C2V
+        self.kl  = kl
+        self.s1  = s1
+        self.s2  = s2
+        self.s3  = s3
+        self.s4  = s4
+        self.s5  = s5
+        self.s6  = s6
+
+        # Automatically build the matrix of the initial 6-equation system given the list of samples
+        M = build_matrix(sample_list)
+
+        # Declare the vectors of samples, couplings and components
+        # The vector of couplings
+        C = Matrix([
+            [CV**2 * kl**2] ,
+            [CV**4]         ,
+            [C2V**2]        ,
+            [CV**3 * kl]    ,
+            [CV * C2V * kl] ,
+            [CV**2 * C2V]   
+        ])
+
+        # The vector of components
+        V = Matrix([
+            [a]   ,
+            [b]   ,
+            [c]   ,
+            [iab] ,
+            [iac] ,
+            [ibc]  
+        ])
+
+        # The vector of samples (i.e. cross sections of the input samples)
+        S = Matrix([
+            [s1] ,
+            [s2] ,
+            [s3] ,
+            [s4] ,
+            [s5] ,
+            [s6] 
+        ])
+
+        # Invert the system matrix to get the resolution
+        Minv   = M.inv()
+
+        # Multiply the Minv for the couplings to get the coefficients of the six addendums of the final cross sections
+        coeffs = C.transpose() * Minv
+        self.coefficients = coeffs
+
+        # Final cross section from multiplying the coefficients for the samples
+        sigma  = coeffs*S
+        self.modeled_cross_section = sigma
+
+
+    # Returns the modeled cross section and histogram given the target couplings
+    def modelSignal(self,t_cv,t_c2v,t_kl,target_xs):
+
+        # Eval the final cross section
+        total_xs = self.modeled_cross_section[0].evalf(subs={
+            self.CV  : t_cv,
+            self.C2V : t_c2v,
+            self.kl  : t_kl,
+            self.s1  : self.sample_list[0].val_xs,
+            self.s2  : self.sample_list[1].val_xs,
+            self.s3  : self.sample_list[2].val_xs,
+            self.s4  : self.sample_list[3].val_xs,
+            self.s5  : self.sample_list[4].val_xs,
+            self.s6  : self.sample_list[5].val_xs,
+        })
+
+        # Eval the single coefficients
+        eval_coeffs = []
+        for coeff in self.coefficients:
+            eval_coeffs.append(coeff.evalf(subs={self.CV:t_cv, self.C2V:t_c2v, self.kl:t_kl}))
+
+        # Get a clone of the input histograms to be scaled and summed
+        hists = []
+        for sample in self.sample_list:
+            hists.append(sample.histo.Clone(sample.histo.GetName()))
+
+        # Normalize each histo to his coefficient * xs
+        for i,sample in enumerate(self.sample_list):
+            if target_xs == -1:
+                scaleTo(hists[i], eval_coeffs[i])
+            else:
+                scaleTo(hists[i], eval_coeffs[i] * target_xs / sample.val_xs)
+
+        # Get the final histogram by adding the six hists
+        for i,histo in enumerate(hists):
+            if i == 0:
+                tot_histo = histo.Clone('VBFHH_CV_'+str(t_cv)+'_C2V_'+str(t_c2v)+'_C3_'+str(t_kl))
+            else:
+                tot_histo.Add(histo)
+
+        return total_xs, tot_histo


### PR DESCRIPTION
**VBF reweighting**

Done at `combineFillerOutputs` level:
- Takes as input:
  - 6 histograms (6 different VBF nodes) for each variable [required]
  - `kl, cV, c2V` target values [required]
  - target cross section [optional]
- Returns:
  - one histogram per each combination of `(kl, cV, c2V)` for each variable

Workflow:
- class `VBFReweight` defined in `scripts/modules/VBFReweightModules.py`
- reweight function (`makeVBFrew`) implemented in `scripts/modules/OutputManager.py`
- example of usage of the reweight function in:
  - `scripts/combineFillerOutputs.py`
  - configurables defined in e.g. `mainCfg_ETau_Legacy2016.cfg` under the section `[VBF_rew]`