### PR TITLE
DNN updates

### DIFF
--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -73,11 +73,11 @@ vbfTriggers = HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1_Reg_v
 
 
 [bTagScaleFactors]
-SFFileDeepFlavor  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_10_2_16/src/KLUBAnalysis/weights/bTagWeights/DeepFlavour_94XSF_V4_B_F.csv
-effFileDeepFlavor = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_10_2_16/src/KLUBAnalysis/weights/bTagWeights/bTagEfficiencies_DeepFlavour_Legacy2017_30Jan2020.root
+SFFileDeepFlavor  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/bTagWeights/DeepFlavour_94XSF_V4_B_F.csv
+effFileDeepFlavor = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/bTagWeights/bTagEfficiencies_DeepFlavour_Legacy2017_30Jan2020.root
 
-SFFileDeepCSV  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_10_2_16/src/KLUBAnalysis/weights/bTagWeights/DeepCSV_94XSF_V5_B_F.csv
-effFileDeepCSV = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_10_2_16/src/KLUBAnalysis/weights/bTagWeights/bTagEfficiencies_DeepCSV_Legacy2017_30Jan2020.root
+SFFileDeepCSV  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/bTagWeights/DeepCSV_94XSF_V5_B_F.csv
+effFileDeepCSV = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/bTagWeights/bTagEfficiencies_DeepCSV_Legacy2017_30Jan2020.root
 
 [debug]
 skipTriggers = false
@@ -86,9 +86,9 @@ skipTriggers = false
 # for variables: write as my_name:BDT_xml_name , as BDT is produced with different names
 
 [BDTsm]
-computeMVA = false
-weights    = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_10_2_16/src/KLUBAnalysis/weights/newBDT/BDTnewSM.xml
-kl         = 1, 0, 2.45, 5, 30
+computeMVA = true
+weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/KLUBAnalysis/weights/newBDT/BDTnewSM.xml
+kl         = 1 #, 0, 2.45, 5, 30
 variables  = bjet2_pt:pt_b2, bH_pt:pt_hbb, dau1_pt:pt_l1, dau2_pt:pt_l2, tauH_SVFIT_pt:pt_htautau_sv, BDT_HT20:HT_otherjets, p_zeta:p_zeta, p_zeta_visible:p_zetavisible, BDT_ditau_deltaPhi:dphi_l1l2, BDT_tauHsvfitMet_deltaPhi:dphi_METhtautau_sv, mT_tauH_MET:MT_htautau, mT_total:MT_tot, MT2:MT2, BDT_MX:mass_X, BDT_bH_tauH_MET_InvMass:mass_H, BDT_bH_tauH_SVFIT_InvMass:mass_H_sv, BDT_bH_tauH_InvMass:mass_H_vis, HHKin_mass_raw:mass_H_kinfit, HHKin_mass_raw_chi2:mass_H_kinfit_chi2, BDT_MET_bH_cosTheta:costheta_METhbb
 
 
@@ -124,5 +124,6 @@ variables  = VBFjet1_pt:BDT_j1n_pt, bH_pt:BDT_n_bH_pt, dib_dEtaSign:BDT_n_b1b2_d
 
 [DNN]
 computeMVA = true
-weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/DNN2/CMSSW_10_2_16/src/cms_runII_dnn_models/models/nonres_gluglu/2020-02-17-0/ensemble
+weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/cms_runII_dnn_models/models/nonres_gluglu/2020-03-11-0/ensemble
+features = /gwpool/users/brivio/Hhh_1718/LegacyRun2/CMSSW_10_2_16/src/cms_runII_dnn_models/models/nonres_gluglu/2020-03-11-0/features.txt
 kl = 1

--- a/test/skimNtuple2017.cpp
+++ b/test/skimNtuple2017.cpp
@@ -4756,6 +4756,8 @@ int main (int argc, char** argv)
       outFile->cd () ;
       h_eff.Write () ;
       treenew->Write ("", TObject::kOverwrite) ;
+      outFile->Write();
+      outFile->Close();
 
       delete reader;
       delete readerResonant;
@@ -5142,6 +5144,9 @@ int main (int argc, char** argv)
     // Update tree and delete readers
     outFile->cd();
     treenew->Write ("", TObject::kOverwrite) ;
+    outFile->Write();
+    outFile->Close();
+
     delete readerSM;
     delete readerLM;
     delete readerMM;

--- a/test/skimNtuple2017.cpp
+++ b/test/skimNtuple2017.cpp
@@ -5374,8 +5374,8 @@ int main (int argc, char** argv)
 
       DNN_n_vbf = 0;
       if (DNN_isvbf) {
-          if (*rv_vbf_1_e != std::numeric_limits<float>::lowest()) DNN_n_vbf++;
-          if (*rv_vbf_2_e != std::numeric_limits<float>::lowest()) DNN_n_vbf++;
+          if (*rv_vbf_1_e != -999.) DNN_n_vbf++;
+          if (*rv_vbf_2_e != -999.) DNN_n_vbf++;
       }
 
       // Loop on configurable options to get the output prediction

--- a/test/skimNtuple2017.cpp
+++ b/test/skimNtuple2017.cpp
@@ -5167,6 +5167,19 @@ int main (int argc, char** argv)
     vector<float> DNN_kl;
     DNN_kl = gConfigParser->readFloatListOption("DNN::kl");
 
+    std::string features_file = gConfigParser->readStringOption ("DNN::features");
+    std::cout << "DNN::features  : " << features_file << std::endl;
+
+    // Read from file the requested features to be computed
+    std::ifstream features_infile(features_file);
+    std::vector<std::string> requested;
+    std::string featureName;
+    while ( features_infile >> featureName)
+    {
+      requested.push_back(featureName);
+    }
+    features_infile.close();
+
     // Declare the wrapper
     InfWrapper wrapper(model_dir, 1, false);
 
@@ -5176,37 +5189,6 @@ int main (int argc, char** argv)
     // Store prediction in vector of vectors of floats:
     // [kl=1 : [evt1_pred, evt2_pred, evt3_pred ...], kl=2 : [evt1_opred, evt2_pred, evt3_pred...]]
     std::vector<std::vector<float>> outDNN;
-
-    // Requested features to be computed
-    std::vector<std::string> requested{"vbf_1_pT",
-                                       "l_2_pT",
-                                       "b_1_pT",
-                                       "dR_b1_b2_x_h_bb_pT",
-                                       "dphi_httvis_met",
-                                       "hh_kinfit_m",
-                                       "sv_mass",
-                                       "diH_mass_X",
-                                       "h_bb_mass",
-                                       "dphi_l1_met",
-                                       "dR_l1_l2_x_h_tt_met_pT",
-                                       "dR_b1_b2_boosted_hbb",
-                                       "costheta_l1_htt",
-                                       "l_1_pT",
-                                       "dphi_hbb_sv",
-                                       "costheta_met_hbb",
-                                       "costheta_htt_met_hh_met",
-                                       "vbf_2_pT",
-                                       "deta_l1_l2",
-                                       "costheta_met_htt",
-                                       "dphi_vbf1_vbf2",
-                                       "dR_l1_l2_boosted_htt_met",
-                                       "vbf_1_E",
-                                       "hh_pT",
-                                       "boosted",
-                                       "channel",
-                                       "jet_1_quality",
-                                       "jet_2_quality",
-                                       "year"};
 
     // Initialize the EvtProc
     EvtProc evt_proc(false, requested, true);

--- a/test/skimNtuple2017.cpp
+++ b/test/skimNtuple2017.cpp
@@ -5225,7 +5225,7 @@ int main (int argc, char** argv)
     bool DNN_svfit_conv, DNN_hh_kinfit_conv;
 
     Channel DNN_e_channel;
-    Year DNN_e_year(y16);
+    Year DNN_e_year(y17);
     Spin DNN_spin(nonres);
     float DNN_klambda;
     float DNN_res_mass = 125.; // FIXME

--- a/test/skimNtuple2017.cpp
+++ b/test/skimNtuple2017.cpp
@@ -5296,10 +5296,10 @@ int main (int argc, char** argv)
       if (c_event%5000 == 0) std::cout << "DNN::event " << c_event << " / " << n_tot_events << "\n";
 
       // Load values
-      DNN_evt =  *rv_evt;
-      DNN_pType = *rv_ptype;
+      DNN_evt        = *rv_evt;
+      DNN_pType      = *rv_ptype;
       DNN_is_boosted = *rv_isboosted;
-      DNN_isvbf = *rv_isvbf;
+      DNN_isvbf      = *rv_isvbf;
 
       DNN_kinfit_mass   = *rv_kinfit_mass;
       DNN_kinfit_chi2   = *rv_kinfit_chi2;
@@ -5321,18 +5321,18 @@ int main (int argc, char** argv)
       DNN_hh_kinfit_conv = DNN_kinfit_chi2 > 0;
 
       // Load PEP Vectors first
-      pep_l_1  .SetPtEtaPhiE (*rv_l_1_pT, *rv_l_1_eta, *rv_l_1_phi, *rv_l_1_e);
-      pep_l_2  .SetPtEtaPhiE (*rv_l_2_pT, *rv_l_2_eta, *rv_l_2_phi, *rv_l_2_e);
-      pep_met  .SetPtEtaPhiE (*rv_met_pT, 0, *rv_met_phi, 0);
+      pep_l_1  .SetPtEtaPhiE (*rv_l_1_pT  , *rv_l_1_eta  , *rv_l_1_phi  , *rv_l_1_e);
+      pep_l_2  .SetPtEtaPhiE (*rv_l_2_pT  , *rv_l_2_eta  , *rv_l_2_phi  , *rv_l_2_e);
+      pep_met  .SetPtEtaPhiE (*rv_met_pT  , 0            , *rv_met_phi  , 0);
       pep_svfit.SetPtEtaPhiM (*rv_svfit_pT, *rv_svfit_eta, *rv_svfit_phi, *rv_svfit_mass);
-      pep_b_1  .SetPtEtaPhiE (*rv_b_1_pT, *rv_b_1_eta, *rv_b_1_phi, *rv_b_1_e);
-      pep_b_2  .SetPtEtaPhiE (*rv_b_2_pT, *rv_b_2_eta, *rv_b_2_phi, *rv_b_2_e);
+      pep_b_1  .SetPtEtaPhiE (*rv_b_1_pT  , *rv_b_1_eta  , *rv_b_1_phi  , *rv_b_1_e);
+      pep_b_2  .SetPtEtaPhiE (*rv_b_2_pT  , *rv_b_2_eta  , *rv_b_2_phi  , *rv_b_2_e);
       pep_vbf_1.SetPtEtaPhiE (*rv_vbf_1_pT, *rv_vbf_1_eta, *rv_vbf_1_phi, *rv_vbf_1_e);
       pep_vbf_2.SetPtEtaPhiE (*rv_vbf_2_pT, *rv_vbf_2_eta, *rv_vbf_2_phi, *rv_vbf_2_e);
 
       // Use PEP Vectors to declare DNN vectors
-      DNN_l_1.SetCoordinates(pep_l_1.Px(),     pep_l_1.Py(),   pep_l_1.Pz(),   pep_l_1.M());
-      if      (DNN_pType == 0 )
+      DNN_l_1.SetCoordinates(pep_l_1.Px(), pep_l_1.Py(), pep_l_1.Pz(), pep_l_1.M());
+      if      (DNN_pType == 0)
       {
         DNN_e_channel = muTau;
         DNN_l_1.SetM(MU_MASS);
@@ -5346,11 +5346,11 @@ int main (int argc, char** argv)
       {
         DNN_e_channel = tauTau;
       }
-      DNN_l_2.SetCoordinates(pep_l_2.Px(),     pep_l_2.Py(),   pep_l_2.Pz(),   pep_l_2.M());
-      DNN_met.SetCoordinates(pep_met.Px(),     pep_met.Py(),   0,              0);
+      DNN_l_2.SetCoordinates  (pep_l_2.Px()  , pep_l_2.Py()  , pep_l_2.Pz()  , pep_l_2.M());
+      DNN_met.SetCoordinates  (pep_met.Px()  , pep_met.Py()  , 0             , 0);
       DNN_svfit.SetCoordinates(pep_svfit.Px(), pep_svfit.Py(), pep_svfit.Pz(), pep_svfit.M());
-      DNN_b_1.SetCoordinates(pep_b_1.Px(),     pep_b_1.Py(),   pep_b_1.Pz(),   pep_b_1.M());
-      DNN_b_2.SetCoordinates(pep_b_2.Px(),     pep_b_2.Py(),   pep_b_2.Pz(),   pep_b_2.M());
+      DNN_b_1.SetCoordinates  (pep_b_1.Px()  , pep_b_1.Py()  , pep_b_1.Pz()  , pep_b_1.M());
+      DNN_b_2.SetCoordinates  (pep_b_2.Px()  , pep_b_2.Py()  , pep_b_2.Pz()  , pep_b_2.M());
       DNN_vbf_1.SetCoordinates(pep_vbf_1.Px(), pep_vbf_1.Py(), pep_vbf_1.Pz(), pep_vbf_1.M());
       DNN_vbf_2.SetCoordinates(pep_vbf_2.Px(), pep_vbf_2.Py(), pep_vbf_2.Pz(), pep_vbf_2.M());
 

--- a/test/skimNtuple2017.cpp
+++ b/test/skimNtuple2017.cpp
@@ -5341,7 +5341,7 @@ int main (int argc, char** argv)
       // Load PEP Vectors first
       pep_l_1  .SetPtEtaPhiE (*rv_l_1_pT  , *rv_l_1_eta  , *rv_l_1_phi  , *rv_l_1_e);
       pep_l_2  .SetPtEtaPhiE (*rv_l_2_pT  , *rv_l_2_eta  , *rv_l_2_phi  , *rv_l_2_e);
-      pep_met  .SetPtEtaPhiE (*rv_met_pT  , 0            , *rv_met_phi  , 0);
+      pep_met  .SetPtEtaPhiM (*rv_met_pT  , 0            , *rv_met_phi  , 0);
       pep_svfit.SetPtEtaPhiM (*rv_svfit_pT, *rv_svfit_eta, *rv_svfit_phi, *rv_svfit_mass);
       pep_b_1  .SetPtEtaPhiE (*rv_b_1_pT  , *rv_b_1_eta  , *rv_b_1_phi  , *rv_b_1_e);
       pep_b_2  .SetPtEtaPhiE (*rv_b_2_pT  , *rv_b_2_eta  , *rv_b_2_phi  , *rv_b_2_e);


### PR DESCRIPTION
- Fixed bug in DNN input year
- Close the files after each update: this way we can save both DNN **and** BDT outputs
- Apply minimal selection before computing DNN output (without this selection the DNN output crashes as the models were not trained for those events):
   - 3rd lepton veto
   - at least 2 bjets candidates
   - channel MuTau/ETau/TauTau

For all the events not passing this selection the DNN output is set to `-1.`

- Also, the requested features are now read from a txt file that is in the same directory of the actual models