### PR TITLE
Ele MVA isolation for signal region

### DIFF
--- a/config/selectionCfg_ETau_Legacy2016.cfg
+++ b/config/selectionCfg_ETau_Legacy2016.cfg
@@ -103,12 +103,12 @@ nonresBDTCut = LepTauKine > -0.134
 #SRforEff      = SR, genDecMode1 == 1
 
 # ABCD regions used in the analysis - DeepTau
-SR           = isOS != 0 && dau1_iso < 0.1 && dau2_deepTauVsJet >= 5                          # signal region: opposite sign, isolated taus
-SStight      = isOS == 0 && dau1_iso < 0.1 && dau2_deepTauVsJet >= 5			              # B region
-OSrlx        = isOS != 0 && dau1_iso < 0.1 && dau2_deepTauVsJet >= 2
-SSrlx        = isOS == 0 && dau1_iso < 0.1 && dau2_deepTauVsJet >= 2			              # B' region
-OSinviso     = isOS != 0 && dau1_iso < 0.1 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # C region
-SSinviso     = isOS == 0 && dau1_iso < 0.1 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # D region
+SR           = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 5                          # signal region: opposite sign, isolated taus
+SStight      = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 5                          # B region
+OSrlx        = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2
+SSrlx        = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2                          # B' region
+OSinviso     = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # C region
+SSinviso     = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # D region
 
 
 baselineMassCut = baseline, ellypsMassCut

--- a/interface/smallTree.h
+++ b/interface/smallTree.h
@@ -114,6 +114,7 @@ struct smallTree
       m_mT2 = -1. ;
     
       m_dau1_iso  = -1. ;
+      m_dau1_eleMVAiso = -1;
       m_dau1_MVAiso = -1 ;
       m_dau1_MVAisoNew = -1 ; //FRA syncFeb2018
       m_dau1_MVAisoNewdR0p3 = -1; //FRA syncApr2018
@@ -932,6 +933,7 @@ struct smallTree
       m_smallT->Branch ("mT2", &m_mT2, "mT2/F") ;
 
       m_smallT->Branch ("dau1_iso", &m_dau1_iso, "dau1_iso/F") ;
+      m_smallT->Branch ("dau1_eleMVAiso", &m_dau1_eleMVAiso, "dau1_eleMVAiso/I") ;
       m_smallT->Branch ("dau1_MVAiso", &m_dau1_MVAiso, "dau1_MVAiso/I") ;
       m_smallT->Branch ("dau1_MVAisoNew", &m_dau1_MVAisoNew, "dau1_MVAisoNew/I") ; //FRA syncFeb2018
       m_smallT->Branch ("dau1_MVAisoNewdR0p3", &m_dau1_MVAisoNewdR0p3, "dau1_MVAisoNewdR0p3/I") ; //FRA syncApr2018
@@ -1739,6 +1741,7 @@ struct smallTree
 
   // the largest pT daughter visible candidate
   Float_t m_dau1_iso ;
+  Int_t   m_dau1_eleMVAiso;
   Int_t   m_dau1_MVAiso; // for taus only
   Int_t   m_dau1_MVAisoNew; // for taus only //FRA syncFeb2018
   Int_t   m_dau1_MVAisoNewdR0p3; // for taus only //FRA syncApr2018

--- a/test/skimNtuple2016.cpp
+++ b/test/skimNtuple2016.cpp
@@ -2643,6 +2643,7 @@ int main (int argc, char** argv)
       theSmallTree.m_BDT_dau1MET_deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(tlv_firstLepton, tlv_MET);
 
       theSmallTree.m_dau1_iso = getIso (firstDaughterIndex, tlv_firstLepton.Pt (), theBigTree) ;
+      theSmallTree.m_dau1_eleMVAiso = theBigTree.daughters_iseleWP80->at(firstDaughterIndex) ? 1 : 0;
       theSmallTree.m_dau1_MVAiso = makeIsoDiscr (firstDaughterIndex, tauMVAIDIdx, theBigTree) ;
       theSmallTree.m_dau1_MVAisoNew = makeIsoDiscr (firstDaughterIndex, tauMVAIDIdxNew, theBigTree) ; //FRA syncFeb2018
       theSmallTree.m_dau1_MVAisoNewdR0p3 = makeIsoDiscr (firstDaughterIndex, tauMVAIDIdxNewdR0p3, theBigTree) ; // FRA syncApr2018

--- a/test/skimNtuple2017.cpp
+++ b/test/skimNtuple2017.cpp
@@ -2658,6 +2658,7 @@ int main (int argc, char** argv)
       theSmallTree.m_BDT_dau1MET_deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(tlv_firstLepton, tlv_MET);
 
       theSmallTree.m_dau1_iso = getIso (firstDaughterIndex, tlv_firstLepton.Pt (), theBigTree) ;
+      theSmallTree.m_dau1_eleMVAiso = theBigTree.daughters_iseleWP80->at(firstDaughterIndex) ? 1 : 0;
       theSmallTree.m_dau1_MVAiso = makeIsoDiscr (firstDaughterIndex, tauMVAIDIdx, theBigTree) ;
       theSmallTree.m_dau1_MVAisoNew = makeIsoDiscr (firstDaughterIndex, tauMVAIDIdxNew, theBigTree) ; //FRA syncFeb2018
       theSmallTree.m_dau1_MVAisoNewdR0p3 = makeIsoDiscr (firstDaughterIndex, tauMVAIDIdxNewdR0p3, theBigTree) ; // FRA syncApr2018

--- a/test/skimNtuple2018.cpp
+++ b/test/skimNtuple2018.cpp
@@ -2690,6 +2690,7 @@ int main (int argc, char** argv)
       theSmallTree.m_BDT_dau1MET_deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(tlv_firstLepton, tlv_MET);
 
       theSmallTree.m_dau1_iso = getIso (firstDaughterIndex, tlv_firstLepton.Pt (), theBigTree) ;
+      theSmallTree.m_dau1_eleMVAiso = theBigTree.daughters_iseleWP80->at(firstDaughterIndex) ? 1 : 0;
       theSmallTree.m_dau1_MVAiso = makeIsoDiscr (firstDaughterIndex, tauMVAIDIdx, theBigTree) ;
       theSmallTree.m_dau1_MVAisoNew = makeIsoDiscr (firstDaughterIndex, tauMVAIDIdxNew, theBigTree) ; //FRA syncFeb2018
       theSmallTree.m_dau1_MVAisoNewdR0p3 = makeIsoDiscr (firstDaughterIndex, tauMVAIDIdxNewdR0p3, theBigTree) ; // FRA syncApr2018


### PR DESCRIPTION
Added a branch to the skims to store the correct electron isolation (`mvaEleID-Fall17-iso-V2-wp80`) for defining the SignalRegion in ETau channel