### PR TITLE
Segmentation violation in CMSSW_11_1_0_pre6

### DIFF
--- a/interface/Sample.h
+++ b/interface/Sample.h
@@ -76,7 +76,8 @@ class Sample
         void clearWeights() {weights_.clear();}
         void clearExtWeights() {weights_ext_.clear();}
 
-        TChain* getTree() {return tree_.get();}
+        //TChain* getTree() {return tree_.get();}
+        TChain* getTree() {return tree_;}
 
         const std::vector<Weight>& getWeights() const {return weights_;}
         std::vector<Weight>& getWeights() {return weights_;}
@@ -87,8 +88,8 @@ class Sample
         std::string filelistname_;
         std::string treename_;
         std::string histoname_;
-        // TChain* tree_;
-        std::unique_ptr<TChain> tree_;
+        TChain* tree_;
+        //std::unique_ptr<TChain> tree_;
         std::string name_;
         
         int    bin_eff_den_;

--- a/src/Sample.cc
+++ b/src/Sample.cc
@@ -20,8 +20,8 @@ Sample::Sample (string name, string filelistname, string treename, string histon
 // Sample (name, treename)
 {
     name_ = name;
-    // tree_ = new TChain (treename.c_str());
-    tree_ = unique_ptr<TChain>(new TChain(treename.c_str()));
+    tree_ = new TChain (treename.c_str());
+    //tree_ = unique_ptr<TChain>(new TChain(treename.c_str()));
     filelistname_ = filelistname;
     eff_         = 0.;
     evt_num_     = 0.;


### PR DESCRIPTION
Since we switched to CMSSW_11_1_0_pre6 there is some conflict between ROOT memory managment and std::unique_ptr in the class `Sample.h`.

The only solution we found for now is to switch from std::unique_ptr to a simple pointer.
This is not a very nice solution because the memory is not automatically freed when the pointer goes out of scope, but since the pointer is not created in loop this should not create memory leaks.