### PR TITLE
2016 plotting updates

### DIFF
--- a/config/mainCfg_ETau_Legacy2016.cfg
+++ b/config/mainCfg_ETau_Legacy2016.cfg
@@ -90,8 +90,8 @@ data_obs  = DsingleEleB, DsingleEleC, DsingleEleD, DsingleEleE, DsingleEleF, Dsi
 #yieldSB      = SStight
 #shapeSB      = SSrlx
 #SBtoSRfactor = 1
-#regionD = SSinviso
-#regionC = OSinviso
+#regionD      = SSinviso
+#regionC      = OSinviso
 #doFitIf      = False
 #fitFunc      = [0] + [1]*x
 

--- a/config/mainCfg_ETau_Legacy2016.cfg
+++ b/config/mainCfg_ETau_Legacy2016.cfg
@@ -2,7 +2,7 @@
 
 lumi = 35922 # pb^-1 full 2016
 
-outputFolder = analysis_ETau_10May2020_Legacy2016
+outputFolder = analysis_ETau_2016_6June2020
 
 data = DsingleEleB, DsingleEleC, DsingleEleD, DsingleEleE, DsingleEleF, DsingleEleG, DsingleEleH
 
@@ -10,7 +10,7 @@ signals =  GGHHSM
 
 backgrounds = TTfullyHad, TTfullyLep, TTsemiLep, DY, DY_M_10_50, WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, ZH_HBB_ZLL, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, WWW, WWZ, WZZ, ZZZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ
 
-variables = dau1_pt, dau2_pt, dau1_eta, dau2_eta, bjet1_pt, bjet2_pt, tauH_mass, tauH_SVFIT_mass, ditau_deltaR, tauH_pt, bH_pt, bH_mass, HH_pt, HH_mass_raw
+variables = dau1_pt, dau2_pt, dau1_eta, dau2_eta, bjet1_pt, bjet2_pt, tauH_mass, tauH_SVFIT_mass, ditau_deltaR, tauH_pt, bH_pt, bH_mass, HH_pt, HH_mass_raw, BDToutSM_kl_1, DNNoutSM_kl_1
 
 selections = baseline, s1b1jresolved, s2b0jresolved, sboostedLL
 
@@ -24,10 +24,12 @@ cutCfg    = config/selectionCfg_ETau_Legacy2016.cfg
 
 
 [merge]
-TT        = TTfullyHad, TTfullyLep, TTsemiLep
-WJets     = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
+TT       = TTfullyHad, TTfullyLep, TTsemiLep
+WJets    = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 other	  = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, TWantitop, singleTop_top, singleTop_antitop, ZH_HBB_ZLL, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, WWW, WWZ, WZZ, ZZZ, DY_M_10_50
 
+# For shape sync
+#TT      = TTfullyHad, TTfullyLep, TTsemiLep
 #W       = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 #EWK     = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL
 #singleT = TWtop, TWantitop, singleTop_top, singleTop_antitop
@@ -38,6 +40,18 @@ other	  = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, T
 #VVV     = WWW, WWZ, WZZ, ZZZ
 #DY_LM   = DY_M_10_50
 
+# For limits
+#TT        = TTfullyHad, TTfullyLep, TTsemiLep
+#WJets     = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
+#EWK       = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL
+#singleT   = TWtop, TWantitop, singleTop_top, singleTop_antitop
+#VH        = ZH_HBB_ZLL, ZH_HTauTau, WplusHTauTau, WminusHTauTau
+#ttH       = ttHJetTononBB, ttHJetToBB
+#doubleTsingleV = TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu
+#doubleTVV      = TTWW, TTWZ, TTZZ
+#doubleV        = WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L
+#tripleV        = WWW, WWZ, WZZ, ZZZ
+#DY_lowMass     = DY_M_10_50
 
 data_obs  = DsingleEleB, DsingleEleC, DsingleEleD, DsingleEleE, DsingleEleF, DsingleEleG, DsingleEleH
 

--- a/config/mainCfg_MuMu_Legacy2016.cfg
+++ b/config/mainCfg_MuMu_Legacy2016.cfg
@@ -2,7 +2,7 @@
 
 lumi = 35922 # pb^-1 full 2016
 
-outputFolder = analysis_MuMu_10May2020_Legacy2016
+outputFolder = analysis_MuMu_2016_6June2020
 
 data = DsingleMuB, DsingleMuC, DsingleMuD, DsingleMuE, DsingleMuF, DsingleMuG, DsingleMuH
 

--- a/config/mainCfg_MuTau_Legacy2016.cfg
+++ b/config/mainCfg_MuTau_Legacy2016.cfg
@@ -2,7 +2,7 @@
 
 lumi = 35922 # pb^-1 full 2016
 
-outputFolder = analysis_MuTau_10May2020_Legacy2016_forLimits
+outputFolder = analysis_MuTau_2016_6June2020
 
 data = DsingleMuB, DsingleMuC, DsingleMuD, DsingleMuE, DsingleMuF, DsingleMuG, DsingleMuH
 
@@ -10,7 +10,7 @@ signals =  GGHHSM
 
 backgrounds = TTfullyHad, TTfullyLep, TTsemiLep, DY, DY_M_10_50, WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, ZH_HBB_ZLL, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, WWW, WWZ, WZZ, ZZZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ
 
-variables = dau1_pt, dau2_pt, dau1_eta, dau2_eta, bjet1_pt, bjet2_pt, tauH_mass, tauH_SVFIT_mass, ditau_deltaR, tauH_pt, bH_pt, bH_mass, HH_pt, HH_mass_raw, BDToutSM_kl_1
+variables = dau1_pt, dau2_pt, dau1_eta, dau2_eta, bjet1_pt, bjet2_pt, tauH_mass, tauH_SVFIT_mass, ditau_deltaR, tauH_pt, bH_pt, bH_mass, HH_pt, HH_mass_raw, BDToutSM_kl_1, DNNoutSM_kl_1
 
 selections = baseline, s1b1jresolved, s2b0jresolved, sboostedLL, VBFloose
 
@@ -29,6 +29,7 @@ WJets     = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, 
 other	  = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, TWantitop, singleTop_top, singleTop_antitop, ZH_HBB_ZLL, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, WWW, WWZ, WZZ, ZZZ, DY_M_10_50
 
 # For shape sync
+#TT      = TTfullyHad, TTfullyLep, TTsemiLep
 #W       = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 #EWK     = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL
 #singleT = TWtop, TWantitop, singleTop_top, singleTop_antitop

--- a/config/mainCfg_MuTau_Legacy2016.cfg
+++ b/config/mainCfg_MuTau_Legacy2016.cfg
@@ -86,12 +86,12 @@ data_obs  = DsingleMuB, DsingleMuC, DsingleMuD, DsingleMuE, DsingleMuF, DsingleM
 
 [pp_QCD]
 #QCDname      = QCD
-#SR	     = SR
+#SR           = SR
 #yieldSB      = SStight
 #shapeSB      = SSrlx
 #SBtoSRfactor = 1
-#regionD = SSinviso
-#regionC = OSinviso
+#regionD      = SSinviso
+#regionC      = OSinviso
 #doFitIf      = False
 #fitFunc      = [0] + [1]*x
 

--- a/config/mainCfg_TauTau_Legacy2016.cfg
+++ b/config/mainCfg_TauTau_Legacy2016.cfg
@@ -91,8 +91,8 @@ data_obs  = DTauB, DTauC, DTauD, DTauE, DTauF, DTauG, DTauH
 #yieldSB      = SStight
 #shapeSB      = SSrlx
 #SBtoSRfactor = 1
-#regionD = SSinviso
-#regionC = OSinviso
+#regionD      = SSinviso
+#regionC      = OSinviso
 #doFitIf      = False
 #fitFunc      = [0] + [1]*x
 

--- a/config/mainCfg_TauTau_Legacy2016.cfg
+++ b/config/mainCfg_TauTau_Legacy2016.cfg
@@ -2,7 +2,7 @@
 
 lumi = 35922 # pb^-1 full 2016
 
-outputFolder = analysis_TauTau_12May2020_Legacy2016_tauIDhomemade
+outputFolder = analysis_TauTau_2016_6June2020
 
 data = DTauB, DTauC, DTauD, DTauE, DTauF, DTauG, DTauH
 
@@ -10,7 +10,7 @@ signals =  GGHHSM
 
 backgrounds = TTfullyHad, TTfullyLep, TTsemiLep, DY, DY_M_10_50, WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, ZH_HBB_ZLL, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, WWW, WWZ, WZZ, ZZZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ
 
-variables = dau1_pt, dau2_pt, dau1_eta, dau2_eta, bjet1_pt, bjet2_pt, tauH_mass, tauH_SVFIT_mass, ditau_deltaR, tauH_pt, bH_pt, bH_mass, HH_pt, HH_mass_raw, BDToutSM_kl_1
+variables = dau1_pt, dau2_pt, dau1_eta, dau2_eta, bjet1_pt, bjet2_pt, tauH_mass, tauH_SVFIT_mass, ditau_deltaR, tauH_pt, bH_pt, bH_mass, HH_pt, HH_mass_raw, BDToutSM_kl_1, DNNoutSM_kl_1
 
 selections = baseline, s1b1jresolved, s2b0jresolved, sboostedLL, VBFloose
 
@@ -29,6 +29,7 @@ WJets     = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, 
 other	  = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, TWantitop, singleTop_top, singleTop_antitop, ZH_HBB_ZLL, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, WWW, WWZ, WZZ, ZZZ, DY_M_10_50
 
 # For shape sync
+#TT      = TTfullyHad
 #W       = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 #EWK     = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL
 #singleT = TWtop, TWantitop, singleTop_top, singleTop_antitop

--- a/config/sampleCfg_Legacy2016.cfg
+++ b/config/sampleCfg_Legacy2016.cfg
@@ -1,106 +1,108 @@
 [samples]
-DsingleMuB = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Mu_2016B
-DsingleMuC = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Mu_2016C
-DsingleMuD = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Mu_2016D
-DsingleMuE = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Mu_2016E
-DsingleMuF = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Mu_2016F
-DsingleMuG = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Mu_2016G
-DsingleMuH = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Mu_2016H
+DsingleMuB = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Mu_2016B
+DsingleMuC = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Mu_2016C
+DsingleMuD = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Mu_2016D
+DsingleMuE = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Mu_2016E
+DsingleMuF = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Mu_2016F
+DsingleMuG = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Mu_2016G
+DsingleMuH = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Mu_2016H
 
-DsingleEleB = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Ele_2016B
-DsingleEleC = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Ele_2016C
-DsingleEleD = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Ele_2016D
-DsingleEleE = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Ele_2016E
-DsingleEleF = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Ele_2016F
-DsingleEleG = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Ele_2016G
-DsingleEleH = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Ele_2016H
+DsingleEleB = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Ele_2016B
+DsingleEleC = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Ele_2016C
+DsingleEleD = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Ele_2016D
+DsingleEleE = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Ele_2016E
+DsingleEleF = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Ele_2016F
+DsingleEleG = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Ele_2016G
+DsingleEleH = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Ele_2016H
 
-DTauB = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Tau_2016B
-DTauC = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Tau_2016C
-DTauD = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Tau_2016D
-DTauE = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Tau_2016E
-DTauF = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Tau_2016F
-DTauG = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Tau_2016G
-DTauH = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_Tau_2016H
+DTauB = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Tau_2016B
+DTauC = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Tau_2016C
+DTauD = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Tau_2016D
+DTauE = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Tau_2016E
+DTauF = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Tau_2016F
+DTauG = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Tau_2016G
+DTauH = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_Tau_2016H
 
 ########
 
-TTfullyHad = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_TT_fullyHad
-TTfullyLep = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_TT_fullyLep
-TTsemiLep  = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_TT_semiLep
+TTfullyHad = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_TT_semiLep
 
-DY = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_DY
+DY = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_DY
 
-DY_M_10_50 = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_DY_Low_Mass
+DY_M_10_50 = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_DY_Low_Mass
 
-WJets_HT_0_70       = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WJets_HT_0_70
-WJets_HT_70_100     = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WJets_HT_70_100
-WJets_HT_100_200    = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WJets_HT_100_200
-WJets_HT_200_400    = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WJets_HT_200_400
-WJets_HT_400_600    = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WJets_HT_400_600
-WJets_HT_600_800    = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WJets_HT_600_800
-WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WJets_HT_800_1200
-WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WJets_HT_1200_2500
-WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WJets_HT_2500_Inf
+WJets_HT_0_70       = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WJets_HT_0_70
+WJets_HT_70_100     = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WJets_HT_70_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WJets_HT_2500_Inf
 
-TWtop                  = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ST_tW_top
-TWantitop              = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ST_tW_antitop
-singleTop_top          = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ST_t_channel_top
-singleTop_antitop      = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ST_t_channel_antitop
+TWtop                  = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ST_t_channel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ST_t_channel_antitop
 
-EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_EWKWMinus2Jets_WToLNu
-EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_EWKWPlus2Jets_WToLNu
-EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_EWKZ2Jets_ZToLL
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_EWKZ2Jets_ZToLL
 
-#WW                     = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WW
-#WZ                     = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WZ
-#ZZ                     = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ZZ
-WWTo2L2Nu              = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WWTo2L2Nu
-WWTo4Q                 = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WWTo4Q
-WWToLNuQQ              = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WWToLNuQQ
-WZTo1L1Nu2Q            = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WZTo1L1Nu2Q
-WZTo1L3Nu              = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WZTo1L3Nu
-WZTo2L2Q               = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WZTo2L2Q
-WZTo3LNu               = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WZTo3LNu
-ZZTo2L2Nu              = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ZZTo2L2Nu
-ZZTo2L2Q               = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ZZTo2L2Q
-ZZTo2Q2Nu              = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ZZTo2Q2Nu
-ZZTo4L                 = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ZZTo4L
-ZZTo4Q                 = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ZZTo4Q
+#WW                     = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WW
+#WZ                     = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WZ
+#ZZ                     = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ZZ
+WWTo2L2Nu              = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WWTo2L2Nu
+WWTo4Q                 = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WWTo4Q
+WWToLNuQQ              = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WWToLNuQQ
+WZTo1L1Nu2Q            = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu              = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WZTo1L3Nu
+WZTo2L2Q               = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WZTo2L2Q
+WZTo3LNu               = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WZTo3LNu
+ZZTo2L2Nu              = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ZZTo2L2Nu
+ZZTo2L2Q               = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu              = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ZZTo2Q2Nu
+ZZTo4L                 = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ZZTo4L
+ZZTo4Q                 = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ZZTo4Q
 
 
-ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ZH_HBB_ZLL
-ZH_HTauTau             = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ZH_HTauTau
-ggHTauTau              = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ggHTauTau
-VBFHTauTau             = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_VBFHTauTau
-WplusHTauTau           = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WplusHTauTau
-WminusHTauTau          = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WminusHTauTau
-ttHJetTononBB          = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ttHJetTononBB
-ttHJetToBB             = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ttHJetToBB
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ZH_HTauTau
+ggHTauTau              = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ttHJetToBB
 
-WWW                    = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WWW
-WWZ                    = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WWZ
-WZZ                    = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_WZZ
-ZZZ                    = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_ZZZ
+WWW                    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_WZZ
+ZZZ                    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_ZZZ
 
-TTWJetsToLNu           = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_TTWJetsToLNu
-TTWJetsToQQ            = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_TTWJetsToQQ
-TTZToLLNuNu            = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_TTZToLLNuNu
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_TTZToLLNuNu
 
-TTWW                   = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_TTWW
-TTWZ                   = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_TTWZ
-TTZZ                   = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_TTZZ
+TTWW                   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_TTZZ
 
 #########
 
-GGHHSM  = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_GGHHSM
-VBFHHSM = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+#GGHHSM  = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_GGHHSM
+GGHHSM  = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_HHRew_SM
 
-VBFHHSM_CV_0_5_C2V_1_C3_1 = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1
-VBFHHSM_CV_1_5_C2V_1_C3_1 = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1
-VBFHHSM_CV_1_C2V_1_C3_0   = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0
-VBFHHSM_CV_1_C2V_1_C3_2   = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2
-VBFHHSM_CV_1_C2V_2_C3_1   = /gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1
+VBFHHSM = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+
+VBFHHSM_CV_0_5_C2V_1_C3_1 = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1
+VBFHHSM_CV_1_5_C2V_1_C3_1 = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1
+VBFHHSM_CV_1_C2V_1_C3_0   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0
+VBFHHSM_CV_1_C2V_1_C3_2   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2
+VBFHHSM_CV_1_C2V_2_C3_1   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1
 
 #########
 

--- a/config/selectionCfg_ETau_Legacy2016.cfg
+++ b/config/selectionCfg_ETau_Legacy2016.cfg
@@ -178,7 +178,8 @@ s0b2jresolvedMcutMtcutNoZMCut = s0b2jresolvedMcutNoZMCut, mT1 < 30
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline      = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
+#baseline  = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
+baseline   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
 
 btagLL   = bTagweightL
 btagMM   = bTagweightM

--- a/config/selectionCfg_ETau_Legacy2016.cfg
+++ b/config/selectionCfg_ETau_Legacy2016.cfg
@@ -180,6 +180,7 @@ s0b2jresolvedMcutMtcutNoZMCut = s0b2jresolvedMcutNoZMCut, mT1 < 30
 [selectionWeights]
 #baseline  = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
 baseline   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+#baseline   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
 
 btagLL   = bTagweightL
 btagMM   = bTagweightM
@@ -305,6 +306,8 @@ BDToutSM_kl_1            = 20,-1,1
 BDToutLM_spin_0_mass_280 = 20,-1,1
 BDToutMM_spin_0_mass_400 = 20,-1,1
 BDToutHM_spin_0_mass_650 = 20,-1,1
+
+DNNoutSM_kl_1 = 20, 0, 1
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_MuMu_Legacy2016.cfg
+++ b/config/selectionCfg_MuMu_Legacy2016.cfg
@@ -76,8 +76,8 @@ baseline_MHH = baseline, dRtauCut, ellCut, MET45, vtxs
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline      = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
-baseline_wlep = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
+baseline      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+baseline_wlep = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
 
 btagLL   = bTagweightL
 btagMM   = bTagweightM

--- a/config/selectionCfg_MuTau_Legacy2016.cfg
+++ b/config/selectionCfg_MuTau_Legacy2016.cfg
@@ -242,10 +242,11 @@ DYregHTT_MTcutTight_invMETCut_minHmass_cross  = baselineHTT_cross , nobtagM, MTc
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline      = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
-baselineHTT   = MC_weight, PUReweight, IdAndIsoSF, trigSF, FakeRateSF
-baselineHTT_S = MC_weight, PUReweight, IdAndIsoSF, trigSF_single, FakeRateSF
-baselineHTT_C = MC_weight, PUReweight, IdAndIsoSF, trigSF_cross , FakeRateSF
+baseline       = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+#baseline      = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
+#baselineHTT   = MC_weight, PUReweight, IdAndIsoSF, trigSF, FakeRateSF
+#baselineHTT_S = MC_weight, PUReweight, IdAndIsoSF, trigSF_single, FakeRateSF
+#baselineHTT_C = MC_weight, PUReweight, IdAndIsoSF, trigSF_cross , FakeRateSF
 
 btagLL   = bTagweightL
 btagMM   = bTagweightM

--- a/config/selectionCfg_MuTau_Legacy2016.cfg
+++ b/config/selectionCfg_MuTau_Legacy2016.cfg
@@ -243,6 +243,7 @@ DYregHTT_MTcutTight_invMETCut_minHmass_cross  = baselineHTT_cross , nobtagM, MTc
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
 baseline       = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+#baseline       = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
 #baseline      = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
 #baselineHTT   = MC_weight, PUReweight, IdAndIsoSF, trigSF, FakeRateSF
 #baselineHTT_S = MC_weight, PUReweight, IdAndIsoSF, trigSF_single, FakeRateSF
@@ -372,6 +373,8 @@ BDToutSM_kl_1            = 15,-1,1
 BDToutLM_spin_0_mass_280 = 20,-1,1
 BDToutMM_spin_0_mass_400 = 20,-1,1
 BDToutHM_spin_0_mass_650 = 20,-1,1
+
+DNNoutSM_kl_1 = 20, 0, 1
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_TauTau_Legacy2016.cfg
+++ b/config/selectionCfg_TauTau_Legacy2016.cfg
@@ -389,10 +389,9 @@ VBF_BDT_p09 = baseline, BDToutVBF > 0.9
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-#baseline         = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
-baseline         = MC_weight, PUReweight, L1pref_weight, trigSF, FakeRateSF_deep, DYscale_MTT
-baselineHTauTau  = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep
-baselineVBFtight  = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep, VBFtrigNorm, VBFtrigSFjet, VBFtrigSFtau
+baseline          = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+#baselineHTauTau   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep
+#baselineVBFtight  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep, VBFtrigNorm, VBFtrigSFjet, VBFtrigSFtau
 
 
 # remove DY weights, they are already taken into account in baseline weights
@@ -430,7 +429,7 @@ btagMfirst    = bTagweightM
 #baseline = (dau1_decayMode == 0 && isTau1real ): 1.060, (dau2_decayMode == 0 && isTau2real ): 1.060, (dau1_decayMode == 1 && isTau1real): 0.928, (dau2_decayMode == 1 && isTau2real ): 0.928, (dau1_decayMode == 10 && isTau1real ): 0.931, (dau2_decayMode == 10 && isTau2real ): 0.931
 
 # Legacy2016 - May2020
-baseline = (dau1_decayMode == 0 && isTau1real ): 0.975, (dau2_decayMode == 0 && isTau2real ): 0.975, (dau1_decayMode == 1 && isTau1real): 0.979, (dau2_decayMode == 1 && isTau2real ): 0.979, (dau1_decayMode == 10 && isTau1real ): 1.017, (dau2_decayMode == 10 && isTau2real ): 1.017, (dau1_decayMode == 11 && isTau1real ): 1.206, (dau2_decayMode == 11 && isTau2real ): 1.206
+#baseline = (dau1_decayMode == 0 && isTau1real ): 0.975, (dau2_decayMode == 0 && isTau2real ): 0.975, (dau1_decayMode == 1 && isTau1real): 0.979, (dau2_decayMode == 1 && isTau2real ): 0.979, (dau1_decayMode == 10 && isTau1real ): 1.017, (dau2_decayMode == 10 && isTau2real ): 1.017, (dau1_decayMode == 11 && isTau1real ): 1.206, (dau2_decayMode == 11 && isTau2real ): 1.206
 
 
 #########################################################################

--- a/config/selectionCfg_TauTau_Legacy2016.cfg
+++ b/config/selectionCfg_TauTau_Legacy2016.cfg
@@ -390,6 +390,7 @@ VBF_BDT_p09 = baseline, BDToutVBF > 0.9
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
 baseline          = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+#baseline          = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
 #baselineHTauTau   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep
 #baselineVBFtight  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep, VBFtrigNorm, VBFtrigSFjet, VBFtrigSFtau
 
@@ -766,6 +767,7 @@ dau2_decayMode = 11, 0, 11
 
 trigSF = 40, 0.5, 1.5
 
+DNNoutSM_kl_1 = 20, 0, 1
 
 
 #########################################################################

--- a/config/skim_Legacy2016_mib.cfg
+++ b/config/skim_Legacy2016_mib.cfg
@@ -131,3 +131,8 @@ kl = 1
 
 [HHbtag]
 weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/HHTools/HHbtag/models/HHbtag_v1_par_
+
+[HHReweight]
+inputFile = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/outMap_5Dbinning_Legacy2016.root
+histoName = allHHNodeMap
+coeffFile = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/coefficientsByBin_extended_3M_costHHSim_19-4.txt

--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -134,3 +134,8 @@ kl = 1
 
 [HHbtag]
 weights = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/HHTools/HHbtag/models/HHbtag_v1_par_
+
+[HHReweight]
+inputFile = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/outMap_5Dbinning_Legacy2017.root
+histoName = allHHNodeMap
+coeffFile = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/coefficientsByBin_extended_3M_costHHSim_19-4.txt

--- a/scripts/LLR_convert_shapes.py
+++ b/scripts/LLR_convert_shapes.py
@@ -19,6 +19,8 @@ parser.add_argument('--analysis', required=True, dest='analysis', type=str, meta
                     help="res_lm, res_hm, nonres or sync")
 parser.add_argument('--norm-unc-path', required=False, dest='norm_unc_path', default='', type=str, metavar='NORM_PATH',
                     help="path to the text files with normailzation variations for shape uncertainties")
+parser.add_argument('--year', required=False, dest='year', default='2016', type=str, metavar='YEAR',
+                    help="year of the analysis, for TDirectory structure")
 parser.add_argument('--ignoreShapeUnc', action="store_true", help="Ignore shape uncertainties.")
 args = parser.parse_args()
 
@@ -257,8 +259,7 @@ for channel,channel_desc in channels.iteritems():
         #tauES_unc.norm_correction_dict = NormCorrectionDictionary(args.norm_unc_path, LLR_channel, LLR_category, 'tes')
         #jetES_unc.norm_correction_dict = NormCorrectionDictionary(args.norm_unc_path, LLR_channel, LLR_category, 'jes')
         for LLR_region,region in regions.iteritems():
-            output_dir_name = '{}_{}'.format(channel, category)
-            #output_dir_name = '2016_' + channel + '_' + category
+            output_dir_name = '{}_{}_{}'.format(args.year, channel, category)
             if len(region) > 0:
                 output_dir_name += '_{}'.format(region)
             print '\tprocessing {}'.format(output_dir_name)

--- a/scripts/LLR_convert_shapes.py
+++ b/scripts/LLR_convert_shapes.py
@@ -38,7 +38,8 @@ def NumToName(x):
 def OpenLLRFile(channel):
     #file_name = '{}/{}.root'.format(args.input_path, channel)
     #file_name = args.input_path
-    file_name = args.input_path+channel+'.root'
+    #file_name = args.input_path+channel+'.root'
+    file_name = 'analysis_'+ channel + '_' + args.input_path + '/analyzedOutPlotter.root'
     return TFile(file_name, 'OPEN')
 
 def GetLLRHistName(sample, category, region, variable, uncertainty = None):
@@ -181,6 +182,7 @@ topPt_unc = UncDesc('topPt', CorrelationRange.Experiment, 'top', True)
 bins = [
     BinDesc('data_obs', ['data_obs'], save_all_regions = False),
     BinDesc('DY'      , ['DY']      , unc_list = [ ], save_all_regions = False),
+    BinDesc('DY_LM'   , ['DY_LM']   , unc_list = [ ], save_all_regions = False),
     BinDesc('TT'      , ['TT']      , unc_list = [ ], save_all_regions = False),
     BinDesc('W'       , ['W']       , unc_list = [ ], save_all_regions = False),
     BinDesc('QCD'     , ['QCD']     , unc_list = [ ], save_all_regions = False),
@@ -234,7 +236,8 @@ else:
 #}
 
 if args.analysis == 'sync':
-    tauTau_categories = {'2j': 'baseline', 'res1b': 's1b1jresolved', 'res2b': 's2b0jresolved', 'boosted': 'sboostedLL'}
+    #tauTau_categories = {'2j': 'baseline', 'res1b': 's1b1jresolved', 'res2b': 's2b0jresolved', 'boosted': 'sboostedLL'}
+    tauTau_categories = {'2j': 'baseline'}
     channels = {
         'eTau'   : [ 'ETau'  , tauTau_categories],
         'muTau'  : [ 'MuTau' , tauTau_categories],
@@ -255,6 +258,7 @@ for channel,channel_desc in channels.iteritems():
         #jetES_unc.norm_correction_dict = NormCorrectionDictionary(args.norm_unc_path, LLR_channel, LLR_category, 'jes')
         for LLR_region,region in regions.iteritems():
             output_dir_name = '{}_{}'.format(channel, category)
+            #output_dir_name = '2016_' + channel + '_' + category
             if len(region) > 0:
                 output_dir_name += '_{}'.format(region)
             print '\tprocessing {}'.format(output_dir_name)

--- a/scripts/makePlotsFinal_Legacy2016.sh
+++ b/scripts/makePlotsFinal_Legacy2016.sh
@@ -1,4 +1,4 @@
-tag=12May2020_Legacy2016_tauIDhomemade
+tag=2016_6June2020
 
 log=(--log)
 

--- a/scripts/submitHistoFiller_Legacy2016.py
+++ b/scripts/submitHistoFiller_Legacy2016.py
@@ -3,23 +3,22 @@
 ###### LAUNCH COMMAND EXAMPLE:
 
 # - TauTau -
-# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_TauTau_Legacy2016.cfg --tag analysis_TauTau_10May2020_Legacy2016 --n 60
-# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_TauTau_Legacy2016.cfg --tag analysis_TauTau_10May2020_Legacy2016_DY_LM --n 90
-# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_TauTau_Legacy2016.cfg --tag analysis_TauTau_10May2020_Legacy2016_forLimits --n 100
-# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_TauTau_Legacy2016.cfg --tag analysis_TauTau_12May2020_Legacy2016_tauIDhomemade --n 150
-
+# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_TauTau_Legacy2016.cfg --tag analysis_TauTau_2016_6June2020 --n 100
+# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_TauTau_Legacy2016.cfg --tag analysis_TauTau_2016_6June2020_oldQCD --n 100
+# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_TauTau_Legacy2016.cfg --tag analysis_TauTau_2016_6June2020_DMtauID --n 84
 
 # - MuTau -
-# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_MuTau_Legacy2016.cfg --tag analysis_MuTau_23Jan2020 --n 60
-# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_MuTau_Legacy2016.cfg --tag analysis_MuTau_10May2020_Legacy2016 --n 90
-# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_MuTau_Legacy2016.cfg --tag analysis_MuTau_10May2020_Legacy2016_forLimits --n 100
-
+# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_MuTau_Legacy2016.cfg --tag analysis_MuTau_2016_6June2020 --n 100
+# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_MuTau_Legacy2016.cfg --tag analysis_MuTau_2016_6June2020_oldQCD --n 100
+# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_MuTau_Legacy2016.cfg --tag analysis_MuTau_2016_6June2020_DMtauID --n 84
 
 # - ETau -
-# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_ETau_Legacy2016.cfg --tag analysis_ETau_invertedQCD_13Feb2020_Legacy2016 --n 70
+# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_ETau_Legacy2016.cfg --tag analysis_ETau_2016_6June2020 --n 100
+# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_ETau_Legacy2016.cfg --tag analysis_ETau_2016_6June2020_oldQCD --n 100
+# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_ETau_Legacy2016.cfg --tag analysis_ETau_2016_6June2020_DMtauID --n 84
 
 # - MuMu -
-# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_MuMu_Legacy2016.cfg --tag analysis_MuMu_10May2020_Legacy2016 --n 90
+# python scripts/submitHistoFiller_Legacy2016.py --cfg config/mainCfg_MuMu_Legacy2016.cfg --tag analysis_MuMu_2016_6June2020 --n 150
 
 
 # - TauTau tauIDSF -

--- a/scripts/submit_skims2016_mib.sh
+++ b/scripts/submit_skims2016_mib.sh
@@ -1,5 +1,5 @@
 # LOG
-OUTDIRR="Skims_Legacy2016_6May2020"
+OUTDIRR="Skims_Legacy2016_1June2020"
 
 # INPUT
 INPUTDIR="inputFiles/Legacy2016_backgrounds"
@@ -7,10 +7,10 @@ INPUTDIR_DATA="inputFiles/Legacy2016_data"
 INPUTDIR_SIG="inputFiles/Legacy2016_signals"
 
 # OUTPUT
-SKIMDIR="/gwteraz/users/brivio/SKIMMED_Legacy2016_6May2020"
+SKIMDIR="/gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020"
 
 # PU weights
-PUDIR="/gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_10_2_16/src/KLUBAnalysis/weights/PUreweight/Legacy_Run2_PU_SF/2016"
+PUDIR="/gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/PUreweight/Legacy_Run2_PU_SF/2016"
 
 # Environment
 source /cvmfs/cms.cern.ch/cmsset_default.sh
@@ -28,29 +28,28 @@ mkdir $OUTDIRR
 # hl = 21.9% (x2 for permutation t-tbar)
 # TT had
 echo "Submitting - TThad - "
-echo "Submitting - TThad - " >> log_6May2020.txt
+echo "Submitting - TThad - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
-python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg  -n 70 -k True -o $SKIMDIR/SKIM_TT_fullyHad -i $INPUTDIR/TTToHadronic.txt    -x 377.96 -t True -b 1 -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
+python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg  -n 50 -k True -o $SKIMDIR/SKIM_TT_fullyHad -i $INPUTDIR/TTToHadronic.txt    -x 377.96 -t True -b 1 -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
 
 # TT lep
 echo "Submitting - TTlep - "
-echo "Submitting - TTlep - " >> log_6May2020.txt
+echo "Submitting - TTlep - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
-python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg  -n 70 -k True -o $SKIMDIR/SKIM_TT_fullyLep -i $INPUTDIR/TTTo2L2Nu.txt       -x 88.29 -t True -b 4 -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
-
+python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg  -n 50 -k True -o $SKIMDIR/SKIM_TT_fullyLep -i $INPUTDIR/TTTo2L2Nu.txt       -x 88.29 -t True -b 4 -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
 
 
 # TT semi
 echo "Submitting - TTsemi - "
-echo "Submitting - TTsemi - " >> log_6May2020.txt
+echo "Submitting - TTsemi - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
-python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg  -n 70 -k True -o $SKIMDIR/SKIM_TT_semiLep -i $INPUTDIR/TTToSemiLeptonic.txt -x 365.34 -t True -b 5 -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
+python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg  -n 200 -k True -o $SKIMDIR/SKIM_TT_semiLep -i $INPUTDIR/TTToSemiLeptonic.txt -x 365.34 -t True -b 5 -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
 
 
 
@@ -62,9 +61,9 @@ python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_m
 # xs LO (HT < 100 ) = 50380 - sum (xs HT > 100) = 50380 pb -  3126.828 pb = 47253.172  pb
 # Finally, everything is scaled from the LO to the NNLO xs : (61526.7/50380) = 1.221252481
 echo "Submitting - WJets - "
-echo "Submitting - WJets - " >> log_6May2020.txt
+echo "Submitting - WJets - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 30 -k True -o $SKIMDIR/SKIM_WJets_HT_0_70      -i $INPUTDIR/WJetsToLNu.txt               -y 1.221252481 -x 47253.172 -z 70 -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
 
@@ -89,9 +88,9 @@ python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_m
 #### ELECTROWEAK
 # XS Taken from HTT http://cms.cern.ch/iCMS/user/noteinfo?cmsnoteid=CMS%20AN-2019/109
 echo "Submitting - EWK - "
-echo "Submitting - EWK - " >> log_6May2020.txt
+echo "Submitting - EWK - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg  -n 25 -k True -o $SKIMDIR/SKIM_EWKWPlus2Jets_WToLNu  -i $INPUTDIR/EWKWPlus2Jets.txt  -x 25.62 -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
 
@@ -104,9 +103,9 @@ python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_m
 #### Single Top
 # XS Taken from HTT http://cms.cern.ch/iCMS/user/noteinfo?cmsnoteid=CMS%20AN-2019/109
 echo "Submitting - SingleTop - "
-echo "Submitting - SingleTop - " >> log_6May2020.txt
+echo "Submitting - SingleTop - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg  -n 25 -k True -o $SKIMDIR/SKIM_ST_tW_antitop        -i $INPUTDIR/ST_tW_antitop_5f.txt        -x 35.85   -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
 
@@ -131,9 +130,9 @@ python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_m
 ### ZH (Zqq, Hbb)      : XSBD (xs ZH * BR Z) * H->bb
 ### ZH (Zall, Htautau) : XS teor ZH * BR H->tautau
 echo "Submitting - SM Higgs - "
-echo "Submitting - SM Higgs - " >> log_6May2020.txt
+echo "Submitting - SM Higgs - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_ZH_HBB_ZLL    -i $INPUTDIR/ZH_HToBB_ZToLL.txt  -x 0.08781 -y 0.577  -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
 
@@ -150,15 +149,14 @@ python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_m
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHTauTau    -i $INPUTDIR/VBFHToTauTau.txt    -x 3.766   -y 0.0632 -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
 
 
-
 #####################
 ### Multiboson:
 # Some XS Taken from HTT http://cms.cern.ch/iCMS/user/noteinfo?cmsnoteid=CMS%20AN-2019/109
 # Some other XS taken from http://cms.cern.ch/iCMS/jsp/db_notes/noteInfo.jsp?cmsnoteid=CMS%20AN-2019/111
 echo "Submitting - MultiBoson - "
-echo "Submitting - MultiBoson - " >> log_6May2020.txt
+echo "Submitting - MultiBoson - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg  -n 35  -k True -o $SKIMDIR/SKIM_ZZTo4L      -i $INPUTDIR/ZZTo4L.txt      -x 1.26   -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
 
@@ -197,9 +195,9 @@ python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_m
 #### TTX :
 # HXSWG: xs(ttH) = 0.5071 pb
 echo "Submitting - TTX - "
-echo "Submitting - TTX - " >> log_6May2020.txt
+echo "Submitting - TTX - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 20 -k True -o $SKIMDIR/SKIM_ttHJetTononBB -i $INPUTDIR/ttHToNonbb.txt   -x 0.5071 -y 0.423  -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
 
@@ -222,50 +220,73 @@ python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_m
 #### GGH SM :
 # XS:  0.03349 pb^-1
 echo "Submitting - GGH SM - "
-echo "Submitting - GGH SM - " >> log_6May2020.txt
+echo "Submitting - GGH SM - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_GGHHSM -i $INPUTDIR_SIG/7_GluGluToHHTo2B2Tau_node_SM_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt -x 1. -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
+
+
+COMMENT1
+
+
+######################
+#### Reweighting ggF non res - filelists up to date
+echo "Submitting - GGF LO Reweight - "
+echo "Submitting - GGF LO Reweight - " >> log_1June2020.txt
+echo "OUTDIR = $OUTDIRR"
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
+### norm xs = 1 pb
+python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 30 -k True -o $SKIMDIR/SKIM_HHRew_SM -i $INPUTDIR_SIG/GluGluToHHTo2B2Tau_LO_allNodes.txt --pu $PUDIR/PU_Legacy2016_SF.txt  -x 1.0  --kl 1.0  --kt 1.0 -a True
+
+<<COMMENT2
 
 
 #### VBF SM :
 # XS: 0.001626 pb^-1 from XSBD
 echo "Submitting - VBF SM - "
-echo "Submitting - VBF SM - " >> log_6May2020.txt
+echo "Submitting - VBF SM - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
-python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1   -i $INPUTDIR_SIG/9_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt     -x 1. -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
-python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1 -i $INPUTDIR_SIG/10_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt  -x 1. -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
-python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1 -i $INPUTDIR_SIG/11_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt  -x 1. -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
-python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0   -i $INPUTDIR_SIG/12_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt    -x 1. -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
-python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2   -i $INPUTDIR_SIG/13_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt    -x 1. -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
-python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1   -i $INPUTDIR_SIG/14_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt    -x 1. -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
+### norm xs = 1 pb
+#python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1   -i $INPUTDIR_SIG/9_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt     -x 1. -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
+#python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1 -i $INPUTDIR_SIG/10_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt  -x 1. -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
+#python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1 -i $INPUTDIR_SIG/11_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt  -x 1. -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
+#python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0   -i $INPUTDIR_SIG/12_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt    -x 1. -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
+#python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2   -i $INPUTDIR_SIG/13_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt    -x 1. -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
+#python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1   -i $INPUTDIR_SIG/14_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt    -x 1. -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
 
-
+### norm to theoretical xs
+python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1   -i $INPUTDIR_SIG/9_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt     -x 0.001601 -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
+python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1 -i $INPUTDIR_SIG/10_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt  -x 0.01009  -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
+python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1 -i $INPUTDIR_SIG/11_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt  -x 0.06153  -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
+python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0   -i $INPUTDIR_SIG/12_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt    -x 0.004259 -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
+python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2   -i $INPUTDIR_SIG/13_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt    -x 0.001327 -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
+python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 10 -k True -o $SKIMDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1   -i $INPUTDIR_SIG/14_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1_13TeV-madgraph__RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2.txt    -x 0.01335  -a True -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
 
 
 
 # # #####################
 # DY
 echo "Submitting - DY - "
-echo "Submitting - DY - " >> log_6May2020.txt
+echo "Submitting - DY - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 100 -k True -o $SKIMDIR/SKIM_DY          -i $INPUTDIR/DYmerged.txt            -x 6077.22 -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt -g True --DY True
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -s True -c config/skim_Legacy2016_mib.cfg -n 20 -k True -o $SKIMDIR/SKIM_DY_Low_Mass -i $INPUTDIR/DYJetsToLL_M-10to50.txt -x 18610   -q longcms --pu $PUDIR/PU_Legacy2016_SF.txt
 
 
+
 ######################
 ### DATA :
 ######################
 echo "Submitting - DATA tau - "
-echo "Submitting - DATA tau - " >> log_6May2020.txt
+echo "Submitting - DATA tau - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -d True -s True -c config/skim_Legacy2016_mib.cfg -n 30 -k True -o $SKIMDIR/SKIM_Tau_2016B -i $INPUTDIR_DATA/Tau_2016B.txt -q longcms
 python scripts/skimNtuple_mib.py -T $OUTDIRR -d True -s True -c config/skim_Legacy2016_mib.cfg -n 30 -k True -o $SKIMDIR/SKIM_Tau_2016C -i $INPUTDIR_DATA/Tau_2016C.txt -q longcms
@@ -276,10 +297,11 @@ python scripts/skimNtuple_mib.py -T $OUTDIRR -d True -s True -c config/skim_Lega
 python scripts/skimNtuple_mib.py -T $OUTDIRR -d True -s True -c config/skim_Legacy2016_mib.cfg -n 30 -k True -o $SKIMDIR/SKIM_Tau_2016H -i $INPUTDIR_DATA/Tau_2016H.txt -q longcms
 
 
+
 echo "Submitting - DATA Mu - "
-echo "Submitting - DATA Mu - " >> log_6May2020.txt
+echo "Submitting - DATA Mu - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -d True -s True -c config/skim_Legacy2016_mib.cfg -n 35 -k True -o $SKIMDIR/SKIM_Mu_2016B -i $INPUTDIR_DATA/Muon_2016B.txt -q longcms
 python scripts/skimNtuple_mib.py -T $OUTDIRR -d True -s True -c config/skim_Legacy2016_mib.cfg -n 35 -k True -o $SKIMDIR/SKIM_Mu_2016C -i $INPUTDIR_DATA/Muon_2016C.txt -q longcms
@@ -290,12 +312,11 @@ python scripts/skimNtuple_mib.py -T $OUTDIRR -d True -s True -c config/skim_Lega
 python scripts/skimNtuple_mib.py -T $OUTDIRR -d True -s True -c config/skim_Legacy2016_mib.cfg -n 30 -k True -o $SKIMDIR/SKIM_Mu_2016H -i $INPUTDIR_DATA/Muon_2016H.txt -q longcms
 
 
-COMMENT1
 
 echo "Submitting - DATA Electron - "
-echo "Submitting - DATA Electron - " >> log_6May2020.txt
+echo "Submitting - DATA Electron - " >> log_1June2020.txt
 echo "OUTDIR = $OUTDIRR"
-echo "OUTDIR = $OUTDIRR" >> log_6May2020.txt
+echo "OUTDIR = $OUTDIRR" >> log_1June2020.txt
 
 python scripts/skimNtuple_mib.py -T $OUTDIRR -d True -s True -c config/skim_Legacy2016_mib.cfg -n 35 -k True -o $SKIMDIR/SKIM_Ele_2016B -i $INPUTDIR_DATA/Electron_2016B.txt -q longcms
 python scripts/skimNtuple_mib.py -T $OUTDIRR -d True -s True -c config/skim_Legacy2016_mib.cfg -n 35 -k True -o $SKIMDIR/SKIM_Ele_2016C -i $INPUTDIR_DATA/Electron_2016C.txt -q longcms
@@ -305,6 +326,6 @@ python scripts/skimNtuple_mib.py -T $OUTDIRR -d True -s True -c config/skim_Lega
 python scripts/skimNtuple_mib.py -T $OUTDIRR -d True -s True -c config/skim_Legacy2016_mib.cfg -n 35 -k True -o $SKIMDIR/SKIM_Ele_2016G -i $INPUTDIR_DATA/Electron_2016G.txt -q longcms
 python scripts/skimNtuple_mib.py -T $OUTDIRR -d True -s True -c config/skim_Legacy2016_mib.cfg -n 35 -k True -o $SKIMDIR/SKIM_Ele_2016H -i $INPUTDIR_DATA/Electron_2016H.txt -q longcms
 
-<<COMMENT2
+
 
 COMMENT2


### PR DESCRIPTION
- Updated some configs for Legacy 2016 plotting.

- Also updated the skim configs for HHreweighting. 
@dzuolo I already modified the 2017 config for you, please check that the paths are correct.
Now if you want to use this reweighting just add something like [this](https://github.com/LLRCMS/KLUBAnalysis/blob/VBF_legacy/scripts/submit_skims_2018.sh#L196-L199)

- Finally, updated the `LLR_convert_shapes.py` script: added one argument so that the year of the analysis (needed for the TDirectory structure) can be passed from command line.