### PR TITLE
Systematics module in skimming process

### DIFF
--- a/config/skim_Legacy2016_mib.cfg
+++ b/config/skim_Legacy2016_mib.cfg
@@ -136,3 +136,23 @@ weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src
 inputFile = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/outMap_5Dbinning_Legacy2016.root
 histoName = allHHNodeMap
 coeffFile = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/coefficientsByBin_extended_3M_costHHSim_19-4.txt
+
+
+[outPutter]
+nMaxEvts = -1 # use -1 to analyze all events
+
+doMT2      = true
+doKinFit   = true
+doSVfit    = true
+doDNN      = true
+doBDT      = true
+
+doMES      = true
+doEES      = true
+doTES      = true
+doSplitJES = false
+doTotalJES = true
+
+kl       = 1
+year     = 2016
+analysis = 2     # 0:radion, 1:graviton, 2:nonres

--- a/config/skim_Legacy2016_mib.cfg
+++ b/config/skim_Legacy2016_mib.cfg
@@ -147,6 +147,7 @@ doSVfit    = true
 doDNN      = true
 doBDT      = true
 
+doNominal  = false
 doMES      = true
 doEES      = true
 doTES      = true

--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -139,3 +139,23 @@ weights = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/H
 inputFile = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/outMap_5Dbinning_Legacy2017.root
 histoName = allHHNodeMap
 coeffFile = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/coefficientsByBin_extended_3M_costHHSim_19-4.txt
+
+
+[outPutter]
+nMaxEvts = -1 # use -1 to analyze all events
+
+doMT2      = true
+doKinFit   = true
+doSVfit    = true
+doDNN      = true
+doBDT      = true
+
+doMES      = true
+doEES      = true
+doTES      = true
+doSplitJES = false
+doTotalJES = true
+
+kl       = 1
+year     = 2017
+analysis = 2     # 0:radion, 1:graviton, 2:nonres

--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -150,6 +150,7 @@ doSVfit    = true
 doDNN      = true
 doBDT      = true
 
+doNominal  = false
 doMES      = true
 doEES      = true
 doTES      = true

--- a/config/skim_Legacy2018.cfg
+++ b/config/skim_Legacy2018.cfg
@@ -147,3 +147,23 @@ weights = /home/llr/cms/amendola/HHLegacy/CMSSW_11_1_0_pre6/src/HHTools/HHbtag/m
 inputFile = /home/llr/cms/amendola/HHLegacy/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/outMap_5Dbinning_Legacy2018.root
 histoName = allHHNodeMap
 coeffFile = /home/llr/cms/amendola/HHLegacy/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/coefficientsByBin_extended_3M_costHHSim_19-4.txt
+
+
+[outPutter]
+nMaxEvts = -1 # use -1 to analyze all events
+
+doMT2      = true
+doKinFit   = true
+doSVfit    = true
+doDNN      = true
+doBDT      = true
+
+doMES      = true
+doEES      = true
+doTES      = true
+doSplitJES = false
+doTotalJES = true
+
+kl       = 1
+year     = 2018
+analysis = 2     # 0:radion, 1:graviton, 2:nonres

--- a/config/skim_Legacy2018.cfg
+++ b/config/skim_Legacy2018.cfg
@@ -158,6 +158,7 @@ doSVfit    = true
 doDNN      = true
 doBDT      = true
 
+doNominal  = false
 doMES      = true
 doEES      = true
 doTES      = true

--- a/scripts/skimNtuple.py
+++ b/scripts/skimNtuple.py
@@ -74,6 +74,7 @@ if __name__ == "__main__":
     parser.add_option ('--DY',               dest='DY'        , help='if it is a DY sample'                 , default=False)
     parser.add_option ('--ttHToNonBB',       dest='ttHToNonBB', help='if it is a ttHToNonBB sample'         , default=False)
     parser.add_option ('--hhNLO',            dest='hhNLO'     , help='if it is an HH NLO sample'            , default=False)
+    parser.add_option ('--doSyst',           dest='doSyst'    , help='compute up/down values of outputs'    , default=False)
 
     (opt, args) = parser.parse_args()
 
@@ -262,6 +263,15 @@ if __name__ == "__main__":
         command += ' >& ' + opt.output + '/' + "output_" + str(n) + '.log\n'
         scriptFile.write (command)
         scriptFile.write ('touch ' + jobsDir + '/done_%d\n'%n)
+
+        if opt.doSyst:
+            sys_command = "skimOutputter.exe"
+            sys_command += (" " + opt.output + "/output_"+str(n)+".root")
+            sys_command += (" " + opt.output + "/syst_output_"+str(n)+".root")
+            sys_command += (" " + opt.config)
+            sys_command += (" " + ">& " + opt.output + "/syst_output_"+str(n)+".log\n")
+            scriptFile.write(sys_command)
+
         scriptFile.write ('echo "All done for job %d" \n'%n)
         scriptFile.close ()
         os.system ('chmod u+rwx %s/skimJob_%d.sh'% (jobsDir,n))

--- a/scripts/skimNtuple_mib.py
+++ b/scripts/skimNtuple_mib.py
@@ -73,6 +73,7 @@ if __name__ == "__main__":
     parser.add_option ('--DY',               dest='DY'        , help='if it is a DY sample'                 , default=False)
     parser.add_option ('--ttHToNonBB',       dest='ttHToNonBB', help='if it is a ttHToNonBB sample'         , default=False)
     parser.add_option ('--hhNLO',            dest='hhNLO'     , help='if it is an HH NLO sample'            , default=False)
+    parser.add_option ('--doSyst',           dest='doSyst'    , help='compute up/down values of outputs'    , default=False)
 
     (opt, args) = parser.parse_args()
 
@@ -255,6 +256,15 @@ if __name__ == "__main__":
         command += ' >& ' + opt.output + '/' + "output_" + str(n) + '.log\n'
         scriptFile.write (command)
         scriptFile.write ('touch ' + jobsDir + '/done_%d\n'%n)
+
+        if opt.doSyst:
+            sys_command = "skimOutputter.exe"
+            sys_command += (" " + opt.output + "/output_"+str(n)+".root")
+            sys_command += (" " + opt.output + "/syst_output_"+str(n)+".root")
+            sys_command += (" " + opt.config)
+            sys_command += (" " + ">& " + opt.output + "/syst_output_"+str(n)+".log\n")
+            scriptFile.write(sys_command)
+
         scriptFile.write ('echo "All done for job %d" \n'%n)
         scriptFile.close ()
         os.system ('chmod u+rwx %s/skimJob_%d.sh'% (jobsDir,n))

--- a/test/skimOutputter.cpp
+++ b/test/skimOutputter.cpp
@@ -154,8 +154,10 @@ int main (int argc, char** argv)
   "EventNumber", "RunNumber","nleps","pairType","nbjetscand",          // General
   "isOS", "isBoosted",
 
-  "MC_weight", "PUReweight", "L1pref_weight", "trigSF",                // Weights
-  "IdAndIsoAndFakeSF_deep", "DYscale_MTT", "TTtopPtreweight",
+  "MC_weight","PUReweight","PUjetID_SF","L1pref_weight",               // Weights and SFs
+  "prescaleWeight","trigSF","VBFtrigSF","DYscale_MTT","DYscale_MH",
+  "IdAndIsoAndFakeSF_deep","IdAndIsoAndFakeSF_deep_pt",
+  "TTtopPtreweight",
 
   "isVBFtrigger", "isVBF",                                             // Trigger vbf selection
 


### PR DESCRIPTION
Included the new module for computing the up/down variations in the skimming workflow.

**--- Config files ---**
I added to the skim config file a section named `[outPutter]` with all needed switches. Please note that:
- `doMT2, doKinFit, doSVfit, doDNN, doBDT` should all be set to **true** to get valid systematic variations
- `doNominal` is for re-computing the nominal value (already done in the skims), so should be set to false (true only for debugging purposes)
- `doSplitJES` activates all the up/down split JES variations and slows down the whole process quite a lot, so it should be used with care.
- `nMaxEvts` is also used for debugging purposes if one want to run the up/down variations only on a small subset of events

@camendola and @dzuolo I already modified both 2017 and 2018 config files, but since this is a new section it should not create any conflict when merging.

**--- skimNtuple.py/skimNtuple_mib.py ---**
Added a `--doSyst` option to set if you want to run the systeamtics module as well (default is false).
If it's set to true, a new line with the correct command is added to the skim launch script: it takes as input the output of the skim and creates two files: `syst_output_*.root/.log`. So once the skim command is done, the syst command is automatically executed before finishing the job.

@camendola and @dzuolo also in this case I already modified the scripts for 2017 and 2018

**--- Systematics module ---**
Several updates:
- added new weights branches
- all configurable options (input, output, bools...) are now read from the skim config file
- all the `std::vector<Float_t>` variables are initialized to zero, otherwise ROOT crashes...
- added 8 branches to store the timing information (_i.e._ how much time it took to run TES, MES, JES... for each event analyzed)

**--- Final remarks ---**
In order to use this new module a new instruction should be added and set to true in the command line command used when launching the skims: `--doSyst True` (default value is false). 
@camendola and @dzuolo this should be added to all the lines in [submit_skims2017_mib.sh](https://github.com/LLRCMS/KLUBAnalysis/blob/VBF_legacy/scripts/submit_skims2017_mib.sh) and [submit_skims_2018.sh](https://github.com/LLRCMS/KLUBAnalysis/blob/VBF_legacy/scripts/submit_skims_2018.sh) which I did not modify.
