### PR TITLE
Standalone systematics

### DIFF
--- a/scripts/submit_syst2016.sh
+++ b/scripts/submit_syst2016.sh
@@ -1,0 +1,120 @@
+# LOG
+OUTDIRR="Skims_Legacy2016_1June2020"
+
+# WORKDIR
+WORKDIR="/gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020"
+
+# ENVIRONMENT
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+source scripts/setup.sh
+mkdir $OUTDIRR
+
+################################################################################################################################
+################################################################################################################################
+
+# Testing
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_SYST_TEST3 -c config/skim_Legacy2016_mib.cfg
+
+
+<<COMMENT1
+
+
+# DY
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DY          -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DY_Low_Mass -c config/skim_Legacy2016_mib.cfg
+
+
+# EWK
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_EWKWMinus2Jets_WToLNu -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_EWKWPlus2Jets_WToLNu  -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_EWKZ2Jets_ZToLL       -c config/skim_Legacy2016_mib.cfg
+
+
+# SingleTop
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ST_tW_antitop        -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ST_tW_top            -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ST_t_channel_antitop -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ST_t_channel_top     -c config/skim_Legacy2016_mib.cfg
+
+
+# TT+X
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTWJetsToLNu -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTWJetsToQQ  -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTWW         -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTWZ         -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTZToLLNuNu  -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTZZ         -c config/skim_Legacy2016_mib.cfg
+
+
+# TT
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TT_fullyHad -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TT_fullyLep -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TT_semiLep  -c config/skim_Legacy2016_mib.cfg
+
+
+# W+Jets
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_0_70      -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_70_100    -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_100_200   -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_200_400   -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_400_600   -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_600_800   -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_800_1200  -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_1200_2500 -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_2500_Inf  -c config/skim_Legacy2016_mib.cfg
+
+
+# WW
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WWTo2L2Nu -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WWTo4Q    -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WWToLNuQQ -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WWW       -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WWZ       -c config/skim_Legacy2016_mib.cfg
+
+
+# WZ
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WZTo1L1Nu2Q -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WZTo1L3Nu   -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WZTo2L2Q    -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WZTo3LNu    -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WZZ         -c config/skim_Legacy2016_mib.cfg
+
+
+# Single Higgs
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WminusHTauTau -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WplusHTauTau  -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZH_HBB_ZLL    -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZH_HBB_ZQQ    -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZH_HTauTau    -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_VBFHTauTau    -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ggHTauTau     -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ttHJetToBB    -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ttHJetTononBB -c config/skim_Legacy2016_mib.cfg
+
+
+# ZZ
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZZTo2L2Nu -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZZTo2L2Q  -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZZTo2Q2Nu -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZZTo4L    -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZZTo4Q    -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZZZ       -c config/skim_Legacy2016_mib.cfg
+
+
+# GGF HH
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_HHRew_SM       -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_HHRew_cHHH0    -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_HHRew_cHHH2p45 -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_HHRew_cHHH5    -c config/skim_Legacy2016_mib.cfg
+
+
+# VBF HH
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1   -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1 -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1 -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0   -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2   -c config/skim_Legacy2016_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1   -c config/skim_Legacy2016_mib.cfg
+
+
+COMMENT1

--- a/scripts/submit_syst2017.sh
+++ b/scripts/submit_syst2017.sh
@@ -1,0 +1,145 @@
+# LOG
+OUTDIRR="Skims_Legacy2016_1June2020"
+
+# WORKDIR
+WORKDIR="/gwteraz/users/brivio/SKIMMED_Legacy2016_1June2020"
+
+# ENVIRONMENT
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+source scripts/setup.sh
+mkdir $OUTDIRR
+
+################################################################################################################################
+################################################################################################################################
+
+
+<<COMMENT1
+
+# DY
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_0j0b -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_1j0b -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_1j1b -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_2j0b -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_2j1b -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_2j2b -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_3j0b -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_3j1b -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_3j2b -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_3j3b -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_4j0b -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_4j1b -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_4j2b -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_4j3b -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_4j4b -c config/skim_Legacy2017_mib.cfg
+
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_M_10_50_Not_PU_Safe -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_DYJets_M_10_50_PU_Safe     -c config/skim_Legacy2017_mib.cfg
+
+
+# EWK
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_EWKWMinus2Jets_WToLNu -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_EWKWPlus2Jets_WToLNu  -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_EWKZ2Jets_ZToLL       -c config/skim_Legacy2017_mib.cfg
+
+
+# SingleTop
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ST_tW_antitop        -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ST_tW_top            -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ST_tchannel_antitop  -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ST_tchannel_top      -c config/skim_Legacy2017_mib.cfg
+
+
+# TT+X
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTWJetsToLNu -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTWJetsToQQ  -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTWW         -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTWZ         -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTZToLLNuNu  -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTZZ         -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTZToQQ         -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTWH         -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TTZH         -c config/skim_Legacy2017_mib.cfg
+
+
+# TT
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TT_fullyHad -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TT_fullyLep -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_TT_semiLep  -c config/skim_Legacy2017_mib.cfg
+
+
+# W+Jets
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_0_70      -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_70_100    -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_100_200   -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_200_400   -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_400_600   -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_600_800   -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_800_1200  -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_1200_2500 -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WJets_HT_2500_Inf  -c config/skim_Legacy2017_mib.cfg
+
+
+# WW
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WWTo2L2Nu -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WWTo4Q    -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WWToLNuQQ -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WWW       -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WWZ       -c config/skim_Legacy2017_mib.cfg
+
+
+# WZ
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WZTo1L1Nu2Q -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WZTo1L3Nu   -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WZTo2L2Q    -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WZTo3LNu    -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WZZ         -c config/skim_Legacy2017_mib.cfg
+
+
+# Single Higgs
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WminusHTauTau -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_WplusHTauTau  -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZH_HBB_ZLL    -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZH_HBB_ZQQ    -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZH_HTauTau    -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_VBFHTauTau    -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ggHTauTau     -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ttHJetToBB    -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ttHJetTononBB -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ttHToTauTau   -c config/skim_Legacy2017_mib.cfg
+
+
+# ZZ
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZZTo2L2Nu -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZZTo2L2Q  -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZZTo2Q2Nu -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZZTo4L    -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_ZZZ       -c config/skim_Legacy2017_mib.cfg
+
+
+# GGF HH NLO
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_GGHH_node_cHHH0    -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_GGHH_node_cHHH1    -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_GGHH_node_cHHH2p45 -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_GGHH_node_cHHH5    -c config/skim_Legacy2017_mib.cfg
+
+
+# GGF HH LO
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_GGHHSM        -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_GGHH_node_2   -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_GGHH_node_3   -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_GGHH_node_4   -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_GGHH_node_7   -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_GGHH_node_9   -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_GGHH_node_12  -c config/skim_Legacy2017_mib.cfg
+
+
+# VBF HH
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_VBFHHSM                 -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_VBFHH_CV_1_5_C2V_1_C3_1 -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_VBFHH_CV_1_C2V_0_C3_2   -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_VBFHH_CV_1_C2V_1_C3_0   -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_VBFHH_CV_1_C2V_1_C3_2   -c config/skim_Legacy2017_mib.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -w $WORKDIR/SKIM_VBFHH_CV_1_C2V_2_C3_1   -c config/skim_Legacy2017_mib.cfg
+
+
+COMMENT1

--- a/scripts/submit_syst2018.sh
+++ b/scripts/submit_syst2018.sh
@@ -1,0 +1,139 @@
+# LOG
+OUTDIRR="SKIMS_1June2020"
+
+# WORKDIR
+WORKDIR="/data_CMS/cms/amendola/HHLegacy_2018_v2"
+
+# ENVIRONMENT
+source scripts/setup.sh
+source /opt/exp_soft/cms/t3/t3setup
+mkdir $OUTDIRR
+
+
+################################################################################################################################
+################################################################################################################################
+
+
+<<COMMENT1
+
+# DY
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_DY         -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_DY_lowMass -c config/skim_Legacy2018.cfg
+
+
+# EWK
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_EWKWMinus2Jets_WToLNu -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_EWKWPlus2Jets_WToLNu  -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_EWKZ2Jets_ZToLL       -c config/skim_Legacy2018.cfg
+
+
+# SingleTop
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ST_tW_antitop        -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ST_tW_top            -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ST_tchannel_antitop  -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ST_tchannel_top      -c config/skim_Legacy2018.cfg
+
+
+# TT+X
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_TTWJetsToLNu -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_TTWJetsToQQ  -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_TTWW         -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_TTWZ         -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_TTZToLLNuNu  -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_TTZZ         -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_TTZToQQ      -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_TTWH         -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_TTZH         -c config/skim_Legacy2018.cfg
+
+
+# TT
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_TT_fullyHad -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_TT_fullyLep -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_TT_semiLep  -c config/skim_Legacy2018.cfg
+
+
+# W+Jets
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WJets_HT_0_100     -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WJets_HT_100_200   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WJets_HT_200_400   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WJets_HT_400_600   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WJets_HT_600_800   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WJets_HT_800_1200  -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WJets_HT_1200_2500 -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WJets_HT_2500_Inf  -c config/skim_Legacy2018.cfg
+
+
+# WW
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WWTo2L2Nu -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WWTo4Q    -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WWToLNuQQ -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WWW       -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WWZ       -c config/skim_Legacy2018.cfg        
+
+
+# WZ
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WZTo1L1Nu2Q -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WZTo1L3Nu   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WZTo2L2Q    -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WZTo3LNu    -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WZZ         -c config/skim_Legacy2018.cfg
+
+
+# Single Higgs
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WminusHTauTau  -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_WplusHTauTau   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ZH_HBB_ZLL     -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ZH_HBB_ZQQ     -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ZH_HTauTau     -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_VBFHTauTau     -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ggHTauTau      -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ttHJetToBB     -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ttHJetTononBB  -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ttHJetToTauTau -c config/skim_Legacy2018.cfg
+
+
+# ZZ
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ZZTo2L2Nu -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ZZTo2L2Q  -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ZZTo2Q2Nu -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ZZTo4L    -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_ZZZ       -c config/skim_Legacy2018.cfg
+
+
+# GGF HH NLO
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_NLO_cHHH0    -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_NLO_SM       -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_NLO_cHHH2p45 -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_NLO_cHHH5    -c config/skim_Legacy2018.cfg
+
+
+# GGF HH LO
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_SM       -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_node_2   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_node_3   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_node_4   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_node_5   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_node_6   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_node_7   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_node_8   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_node_9   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_node_10  -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_node_11  -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_GGHH_node_12  -c config/skim_Legacy2018.cfg
+
+
+# GGF HH Rew
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_HHRew_SM  -c config/skim_Legacy2018.cfg
+
+
+# VBF HH
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_VBFHH_CV_1_C2V_1_C3_1   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_VBFHH_CV_0_5_C2V_1_C3_1 -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_VBFHH_CV_1_5_C2V_1_C3_1 -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_VBFHH_CV_1_C2V_1_C3_0   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_VBFHH_CV_1_C2V_1_C3_2   -c config/skim_Legacy2018.cfg
+python scripts/systNtuple_mib.py -T $OUTDIRR -q long -w $WORKDIR/$OUTDIRR/SKIM_VBFHH_CV_1_C2V_2_C3_1   -c config/skim_Legacy2018.cfg
+
+
+
+COMMENT1

--- a/scripts/systNtuple.py
+++ b/scripts/systNtuple.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+import os,sys
+import optparse
+import fileinput
+import commands
+import time
+import glob
+import subprocess
+from os.path import basename
+import ROOT
+
+
+
+if __name__ == "__main__":
+
+    usage = 'usage: %prog [options]'
+    parser = optparse.OptionParser(usage)
+    parser.add_option ('-w', '--workdir', dest='workdir', help='skim location folder', default='none')
+    parser.add_option ('-T', '--tag'    , dest='tag'    , help='folder tag name'     , default='')
+    parser.add_option ('-c', '--config' , dest='config' , help='skim config file'    , default='none')
+    parser.add_option ('-s', '--sleep'  , dest='sleep'  , help='sleep in submission' , default=False)
+    parser.add_option ('-q', '--queue'  , dest='queue'  , help='batch queue'         , default='short')
+
+    (opt, args) = parser.parse_args()
+
+    currFolder = os.getcwd ()
+
+
+    # Setup checks
+    # ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+    # Input/output folder exists
+    if not os.path.exists (opt.workdir) :
+        print 'Input skim folder', opt.workdir, 'not existing, exiting'
+        sys.exit (1)
+
+    # Config is provided
+    if opt.config == 'none' :
+        print 'Config file missing, exiting'
+        sys.exit (1)
+
+    # Input/output folder already contains systematics files
+    if os.path.isfile(opt.workdir + "/syst_output_0.log"):
+        print 'A file named', opt.workdir+'/syst_output_0.log', 'is already present in the directory, exiting'
+        sys.exit(1)
+
+
+    # Input/Output setup
+    # ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+    # List all files in the working dir
+    allthings = os.listdir(opt.workdir)
+    onlyfiles = [f for f in os.listdir(opt.workdir) if os.path.isfile(os.path.join(opt.workdir, f))]
+
+    # Get output_*.root from skims to be used as input for syst
+    inputfiles = [f for f in onlyfiles if f[0:6]=='output' and f[-4:]=='root']
+
+    # Append full path
+    inputfiles = [os.path.join(opt.workdir, f) for f in inputfiles]
+
+
+    # Submit the jobs
+    # ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+    skimmer = 'skimOutputter.exe'
+
+    tagname = "/" + opt.tag if opt.tag else ''
+    jobsDir = currFolder + tagname + '/SYST_' + basename(opt.workdir)
+    if os.path.exists (jobsDir) : os.system ('rm -f ' + jobsDir + '/*')
+    else                        : os.system ('mkdir -p ' + jobsDir)
+
+    n = int (0)
+    commandFile = open (jobsDir + '/submit.sh', 'w')
+    for inputfile in inputfiles : 
+
+        scriptFile = open ('%s/systJob_%d.sh'% (jobsDir,n), 'w')
+        scriptFile.write ('#!/bin/bash\n')
+        scriptFile.write ('export X509_USER_PROXY=~/.t3/proxy.cert\n')
+        scriptFile.write ('source /cvmfs/cms.cern.ch/cmsset_default.sh\n')
+        scriptFile.write ('cd %s\n'%currFolder)
+        scriptFile.write ('eval `scram r -sh`\n')
+        scriptFile.write ('source scripts/setup.sh\n')
+        command  = skimmer + ' ' + inputfile
+        command += (" " + opt.workdir + "/Syst_output_"+str(n)+".root")
+        command += (" " + opt.config)
+        command += (" " + ">& " + opt.workdir + "/Syst_output_"+str(n)+".log\n")
+        scriptFile.write(command)
+        scriptFile.write ('touch ' + jobsDir + '/done_%d\n'%n)
+        scriptFile.write ('echo "All done for job %d" \n'%n)
+        scriptFile.close ()
+        os.system ('chmod u+rwx %s/systJob_%d.sh'% (jobsDir,n))
+
+        command = '/home/llr/cms/amendola/t3submit_el7 -' + opt.queue + ' ' + jobsDir + '/systJob_' + str (n) + '.sh'
+        if opt.sleep : time.sleep (0.1)
+        os.system (command)
+        commandFile.write (command + '\n')
+        n = n + 1
+    commandFile.close ()
+
+

--- a/scripts/systNtuple.py
+++ b/scripts/systNtuple.py
@@ -79,9 +79,9 @@ if __name__ == "__main__":
         scriptFile.write ('eval `scram r -sh`\n')
         scriptFile.write ('source scripts/setup.sh\n')
         command  = skimmer + ' ' + inputfile
-        command += (" " + opt.workdir + "/Syst_output_"+str(n)+".root")
+        command += (" " + opt.workdir + "/syst_output_"+str(n)+".root")
         command += (" " + opt.config)
-        command += (" " + ">& " + opt.workdir + "/Syst_output_"+str(n)+".log\n")
+        command += (" " + ">& " + opt.workdir + "/syst_output_"+str(n)+".log\n")
         scriptFile.write(command)
         scriptFile.write ('touch ' + jobsDir + '/done_%d\n'%n)
         scriptFile.write ('echo "All done for job %d" \n'%n)

--- a/scripts/systNtuple_mib.py
+++ b/scripts/systNtuple_mib.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+
+import os,sys
+import optparse
+import fileinput
+import commands
+import time
+import glob
+import subprocess
+from os.path import basename
+import ROOT
+
+
+
+if __name__ == "__main__":
+
+    usage = 'usage: %prog [options]'
+    parser = optparse.OptionParser(usage)
+    parser.add_option ('-w', '--workdir', dest='workdir', help='skim location folder', default='none')
+    parser.add_option ('-T', '--tag'    , dest='tag'    , help='folder tag name'     , default='')
+    parser.add_option ('-c', '--config' , dest='config' , help='skim config file'    , default='none')
+    parser.add_option ('-s', '--sleep'  , dest='sleep'  , help='sleep in submission' , default=False)
+
+    (opt, args) = parser.parse_args()
+
+    currFolder = os.getcwd ()
+
+
+    # Setup checks
+    # ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+    # Input/output folder exists
+    if not os.path.exists (opt.workdir) :
+        print 'Input skim folder', opt.workdir, 'not existing, exiting'
+        sys.exit (1)
+
+    # Config is provided
+    if opt.config == 'none' :
+        print 'Config file missing, exiting'
+        sys.exit (1)
+
+    # Input/output folder already contains systematics files
+    if os.path.isfile(opt.workdir + "/syst_output_0.log"):
+        print 'A file named', opt.workdir+'/syst_output_0.log', 'is already present in the directory, exiting'
+        sys.exit(1)
+
+
+    # Input/Output setup
+    # ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+    # List all files in the working dir
+    allthings = os.listdir(opt.workdir)
+    onlyfiles = [f for f in os.listdir(opt.workdir) if os.path.isfile(os.path.join(opt.workdir, f))]
+
+    # Get output_*.root from skims to be used as input for syst
+    inputfiles = [f for f in onlyfiles if f[0:6]=='output' and f[-4:]=='root']
+
+    # Append full path
+    inputfiles = [os.path.join(opt.workdir, f) for f in inputfiles]
+
+
+    # Submit the jobs
+    # ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
+    skimmer = 'skimOutputter.exe'
+
+    tagname = "/" + opt.tag if opt.tag else ''
+    jobsDir = currFolder + tagname + '/SYST_' + basename(opt.workdir)
+    if os.path.exists (jobsDir) : os.system ('rm -f ' + jobsDir + '/*')
+    else                        : os.system ('mkdir -p ' + jobsDir)
+
+    n = int (0)
+    commandFile = open (jobsDir + '/submit.sh', 'w')
+    for inputfile in inputfiles : 
+
+        scriptFile = open ('%s/systJob_%d.sh'% (jobsDir,n), 'w')
+        scriptFile.write ('#!/bin/bash\n')
+        scriptFile.write ('echo $HOSTNAME\n')
+        scriptFile.write ('source /cvmfs/cms.cern.ch/cmsset_default.sh\n')
+        scriptFile.write ('eval `scram r -sh`\n')
+        scriptFile.write ('cd %s\n'%currFolder)
+        scriptFile.write ('eval `scram r -sh`\n')
+        scriptFile.write ('source scripts/setup.sh\n')
+        command  = skimmer + ' ' + inputfile
+        command += (" " + opt.workdir + "/Syst_output_"+str(n)+".root")
+        command += (" " + opt.config)
+        command += (" " + ">& " + opt.workdir + "/Syst_output_"+str(n)+".log\n")
+        scriptFile.write(command)
+        scriptFile.write ('touch ' + jobsDir + '/done_%d\n'%n)
+        scriptFile.write ('echo "All done for job %d" \n'%n)
+        scriptFile.close ()
+        os.system ('chmod u+rwx %s/systJob_%d.sh'% (jobsDir,n))
+
+        condorFile = open ('%s/condorLauncher_%d.sh'% (jobsDir,n), 'w')
+        condorFile.write ('Universe = vanilla\n')
+        condorFile.write ('Executable  = '+jobsDir + '/systJob_' + str (n) + '.sh\n')
+        condorFile.write ('Log         = condor_job_$(ProcId).log\n')
+        condorFile.write ('Output      = condor_job_$(ProcId).out\n')
+        condorFile.write ('Error       = condor_job_$(ProcId).error\n')
+        condorFile.write ('queue 1\n')
+        condorFile.close ()
+
+        command = 'condor_submit '+ jobsDir + '/condorLauncher_' + str (n) + '.sh'
+        if opt.sleep : time.sleep (0.1)
+        os.system (command)
+        commandFile.write (command + '\n')
+        n = n + 1
+    commandFile.close ()
+
+

--- a/scripts/systNtuple_mib.py
+++ b/scripts/systNtuple_mib.py
@@ -79,9 +79,9 @@ if __name__ == "__main__":
         scriptFile.write ('eval `scram r -sh`\n')
         scriptFile.write ('source scripts/setup.sh\n')
         command  = skimmer + ' ' + inputfile
-        command += (" " + opt.workdir + "/Syst_output_"+str(n)+".root")
+        command += (" " + opt.workdir + "/syst_output_"+str(n)+".root")
         command += (" " + opt.config)
-        command += (" " + ">& " + opt.workdir + "/Syst_output_"+str(n)+".log\n")
+        command += (" " + ">& " + opt.workdir + "/syst_output_"+str(n)+".log\n")
         scriptFile.write(command)
         scriptFile.write ('touch ' + jobsDir + '/done_%d\n'%n)
         scriptFile.write ('echo "All done for job %d" \n'%n)


### PR DESCRIPTION
Added scripts to run the new module as a standalone, _i.e._ on already existing skimmed ntuples.

The main scripts are `scripts/systNtuple.py` and `scripts/systNtuple_mib.py` which are basically copied from `scripts/skimNtuple.py`. The mandatory inputs to these scripts are: 
- skim ntuples directory
- config file (same used for the skims)

The scripts will list from the skim directory all the `output_*.root` files (which are the output of the skims) and will use them as input files for the systematics new module: one batch job for each root file is submitted.

I also created three files for submitting multiple jobs, `scripts/submit_syst201*.sh`, which are very similar to the submit skims scripts.

@dzuolo for the MIB scripts I was able to test them, so everything should be ok.
@camendola for the LLR scripts I was not able to test them, but they are just copied from other scripts, so they should be fine. The only line that you should check is [this](https://github.com/LLRCMS/KLUBAnalysis/compare/VBF_legacy...francescobrivio:VBF_legacy?expand=1#diff-3ddcc53de6ee60785af82be40503adefR91).
