### PR TITLE
limits update

### DIFF
--- a/config/mainCfg_ETau_Legacy2018_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2018_limits.cfg
@@ -5,26 +5,27 @@ lumi = 59970 # pb^-1 CMS2018LUMI PASSING ANALYSIS QUALITY REQUIREMENT
 # approximate to only one decimal digit
 lumi_fb = 60.0 # fb^-1
 
-outputFolder = analysis_TauTau_synch_11June2020_syst_prova
+outputFolder = analysis_ETau_synch_11June2020_limits_prova
 
-data = DTauA, DTauB, DTauC, DTauD
+data = DsingleEleA, DsingleEleB, DsingleEleC, DsingleEleD
 
-signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH0_xs, GGHH_NLO_cHHH5_xs, VBFHH_CV_1_C2V_1_C3_1_xs , VBFHH_CV_0p5_C2V_1_C3_1_xs, VBFHH_CV_1p5_C2V_1_C3_1_xs, VBFHH_CV_1_C2V_1_C3_0_xs  ,VBFHH_CV_1_C2V_1_C3_2_xs ,VBFHH_CV_1_C2V_2_C3_1_xs  
+signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH0_xs, GGHH_NLO_cHHH5_xs , VBFHH_CV_1_C2V_1_C3_1_xs ,VBFHH_CV_0p5_C2V_1_C3_1_xs,VBFHH_CV_1p5_C2V_1_C3_1_xs, VBFHH_CV_1_C2V_1_C3_0_xs  ,VBFHH_CV_1_C2V_1_C3_2_xs ,VBFHH_CV_1_C2V_2_C3_1_xs  
 
 backgrounds = DY_HM #, TTfullyLep, TTsemiLep, DY_HM,WJets_HT_0_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZH_HBB_ZLL, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, WWW, WWZ, WZZ, ZZZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ, ttHJetToTauTau, DY_LM
 
-variables = DNNoutSM_kl_1
-#tauH_pt , dau1_eta, dau2_eta, ditau_deltaR, tauH_mass, tauH_SVFIT_mass, DNNoutSM_kl_1, bH_mass, bH_pt
 
-selections = s1b1jresolvedMcut_nominal, s2b0jresolvedMcut_nominal, sboostedLLMcut_nominal   , VBFloose_nominal         , s1b1jresolvedMcut_tesUp_DM0  , s1b1jresolvedMcut_tesDown_DM0, s2b0jresolvedMcut_tesUp_DM0  , s2b0jresolvedMcut_tesDown_DM0, sboostedLLMcut_tesUp_DM0     , sboostedLLMcut_tesDown_DM0   , VBFloose_tesUp_DM0           , VBFloose_tesDown_DM0         , s1b1jresolvedMcut_tesUp_DM1  , s1b1jresolvedMcut_tesDown_DM1, s2b0jresolvedMcut_tesUp_DM1  , s2b0jresolvedMcut_tesDown_DM1, sboostedLLMcut_tesUp_DM1     , sboostedLLMcut_tesDown_DM1   , VBFloose_tesUp_DM1           , VBFloose_tesDown_DM1         , s1b1jresolvedMcut_tesUp_DM10 , s1b1jresolvedMcut_tesDown_DM1, s2b0jresolvedMcut_tesUp_DM10 , s2b0jresolvedMcut_tesDown_DM1, sboostedLLMcut_tesUp_DM10    , sboostedLLMcut_tesDown_DM10  , VBFloose_tesUp_DM10          , VBFloose_tesDown_DM10        , s1b1jresolvedMcut_tesUp_DM11 , s1b1jresolvedMcut_tesDown_DM1, s2b0jresolvedMcut_tesUp_DM11 , s2b0jresolvedMcut_tesDown_DM1, sboostedLLMcut_tesUp_DM11    , sboostedLLMcut_tesDown_DM11  , VBFloose_tesUp_DM11          , VBFloose_tesDown_DM11        , s1b1jresolvedMcut_eesUp_DM0  , s1b1jresolvedMcut_eesDown_DM0, s2b0jresolvedMcut_eesUp_DM0  , s2b0jresolvedMcut_eesDown_DM0, sboostedLLMcut_eesUp_DM0     , sboostedLLMcut_eesDown_DM0   , VBFloose_eesUp_DM0           , VBFloose_eesDown_DM0         , s1b1jresolvedMcut_eesUp_DM1  , s1b1jresolvedMcut_eesDown_DM1, s2b0jresolvedMcut_eesUp_DM1  , s2b0jresolvedMcut_eesDown_DM1, sboostedLLMcut_eesUp_DM1     , sboostedLLMcut_eesDown_DM1   , VBFloose_eesUp_DM1           , VBFloose_eesDown_DM1         , s1b1jresolvedMcut_mesUp  , s1b1jresolvedMcut_mesDown, s2b0jresolvedMcut_mesUp  , s2b0jresolvedMcut_mesDown, sboostedLLMcut_mesUp     , sboostedLLMcut_mesDown   , VBFloose_mesUp           , VBFloose_mesDown         , s1b1jresolvedMcut_jesUp_Tot  , s1b1jresolvedMcut_jesDown_Tot, s2b0jresolvedMcut_jesUp_Tot  , s2b0jresolvedMcut_jesDown_Tot, sboostedLLMcut_jesUp_Tot     , sboostedLLMcut_jesDown_Tot   , VBFloose_jesUp_Tot           , VBFloose_jesDown_Tot
+variables = DNNoutSM_kl_1, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot,
+#dau1_pt, dau2_pt, dau1_eta, dau2_eta, ditau_deltaR, bjet1_pt, bjet1_bID_deepFlavor, bjet2_pt, bjet2_bID_deepFlavor, tauH_mass, tauH_SVFIT_mass, tauH_pt, bH_mass, bH_pt, HH_mass_raw, HH_pt, BDToutSM_kl_1
 
-regions    = SR
+selections = s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose
+
+regions    = SR, SStight, OSinviso, SSinviso
 
 
 [configs]
 sampleCfg = config/sampleCfg_Legacy2018.cfg
+cutCfg    = config/selectionCfg_ETau_Legacy2018.cfg
 pattern   = goodsystfiles
-cutCfg    = config/selectionCfg_TauTau_Legacy2018_syst.cfg
 
 
 [merge]
@@ -42,7 +43,7 @@ cutCfg    = config/selectionCfg_TauTau_Legacy2018_syst.cfg
 #limits_test
 #TT        = TTfullyHad
 DY        = DY_HM
-data_obs  = DTauA, DTauB, DTauC, DTauD
+data_obs  = DsingleEleA, DsingleEleB, DsingleEleC, DsingleEleD
 
 
 ############################################################################################

--- a/config/mainCfg_ETau_Legacy2018_syst.cfg
+++ b/config/mainCfg_ETau_Legacy2018_syst.cfg
@@ -5,9 +5,9 @@ lumi = 59970 # pb^-1 CMS2018LUMI PASSING ANALYSIS QUALITY REQUIREMENT
 # approximate to only one decimal digit
 lumi_fb = 60.0 # fb^-1
 
-outputFolder = analysis_TauTau_synch_11June2020_syst_prova
+outputFolder = analysis_ETau_synch_11June2020_syst_prova
 
-data = DTauA, DTauB, DTauC, DTauD
+data = DsingleEleA, DsingleEleB, DsingleEleC, DsingleEleD
 
 signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH0_xs, GGHH_NLO_cHHH5_xs, VBFHH_CV_1_C2V_1_C3_1_xs , VBFHH_CV_0p5_C2V_1_C3_1_xs, VBFHH_CV_1p5_C2V_1_C3_1_xs, VBFHH_CV_1_C2V_1_C3_0_xs  ,VBFHH_CV_1_C2V_1_C3_2_xs ,VBFHH_CV_1_C2V_2_C3_1_xs  
 
@@ -24,7 +24,7 @@ regions    = SR
 [configs]
 sampleCfg = config/sampleCfg_Legacy2018.cfg
 pattern   = goodsystfiles
-cutCfg    = config/selectionCfg_TauTau_Legacy2018_syst.cfg
+cutCfg    = config/selectionCfg_ETau_Legacy2018_syst.cfg
 
 
 [merge]
@@ -42,7 +42,7 @@ cutCfg    = config/selectionCfg_TauTau_Legacy2018_syst.cfg
 #limits_test
 #TT        = TTfullyHad
 DY        = DY_HM
-data_obs  = DTauA, DTauB, DTauC, DTauD
+data_obs  = DsingleEleA, DsingleEleB, DsingleEleC, DsingleEleD
 
 
 ############################################################################################

--- a/config/mainCfg_MuTau_Legacy2018_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2018_limits.cfg
@@ -5,26 +5,26 @@ lumi = 59970 # pb^-1 CMS2018LUMI PASSING ANALYSIS QUALITY REQUIREMENT
 # approximate to only one decimal digit
 lumi_fb = 60.0 # fb^-1
 
-outputFolder = analysis_TauTau_synch_11June2020_syst_prova
+outputFolder = analysis_MuTau_synch_11June2020_limits_prova
 
-data = DTauA, DTauB, DTauC, DTauD
+data = DsingleMuA, DsingleMuB, DsingleMuC, DsingleMuD
 
-signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH0_xs, GGHH_NLO_cHHH5_xs, VBFHH_CV_1_C2V_1_C3_1_xs , VBFHH_CV_0p5_C2V_1_C3_1_xs, VBFHH_CV_1p5_C2V_1_C3_1_xs, VBFHH_CV_1_C2V_1_C3_0_xs  ,VBFHH_CV_1_C2V_1_C3_2_xs ,VBFHH_CV_1_C2V_2_C3_1_xs  
+signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH0_xs, GGHH_NLO_cHHH5_xs , VBFHH_CV_1_C2V_1_C3_1_xs ,VBFHH_CV_0p5_C2V_1_C3_1_xs,VBFHH_CV_1p5_C2V_1_C3_1_xs, VBFHH_CV_1_C2V_1_C3_0_xs  ,VBFHH_CV_1_C2V_1_C3_2_xs ,VBFHH_CV_1_C2V_2_C3_1_xs  
 
 backgrounds = DY_HM #, TTfullyLep, TTsemiLep, DY_HM,WJets_HT_0_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZH_HBB_ZLL, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, WWW, WWZ, WZZ, ZZZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ, ttHJetToTauTau, DY_LM
 
-variables = DNNoutSM_kl_1
-#tauH_pt , dau1_eta, dau2_eta, ditau_deltaR, tauH_mass, tauH_SVFIT_mass, DNNoutSM_kl_1, bH_mass, bH_pt
+variables = DNNoutSM_kl_1, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot,
+#dau1_pt, dau2_pt, dau1_eta, dau2_eta, ditau_deltaR, bjet1_pt, bjet1_bID_deepFlavor, bjet2_pt, bjet2_bID_deepFlavor, tauH_mass, tauH_SVFIT_mass, tauH_pt, bH_mass, bH_pt, HH_mass_raw, HH_pt, BDToutSM_kl_1
 
-selections = s1b1jresolvedMcut_nominal, s2b0jresolvedMcut_nominal, sboostedLLMcut_nominal   , VBFloose_nominal         , s1b1jresolvedMcut_tesUp_DM0  , s1b1jresolvedMcut_tesDown_DM0, s2b0jresolvedMcut_tesUp_DM0  , s2b0jresolvedMcut_tesDown_DM0, sboostedLLMcut_tesUp_DM0     , sboostedLLMcut_tesDown_DM0   , VBFloose_tesUp_DM0           , VBFloose_tesDown_DM0         , s1b1jresolvedMcut_tesUp_DM1  , s1b1jresolvedMcut_tesDown_DM1, s2b0jresolvedMcut_tesUp_DM1  , s2b0jresolvedMcut_tesDown_DM1, sboostedLLMcut_tesUp_DM1     , sboostedLLMcut_tesDown_DM1   , VBFloose_tesUp_DM1           , VBFloose_tesDown_DM1         , s1b1jresolvedMcut_tesUp_DM10 , s1b1jresolvedMcut_tesDown_DM1, s2b0jresolvedMcut_tesUp_DM10 , s2b0jresolvedMcut_tesDown_DM1, sboostedLLMcut_tesUp_DM10    , sboostedLLMcut_tesDown_DM10  , VBFloose_tesUp_DM10          , VBFloose_tesDown_DM10        , s1b1jresolvedMcut_tesUp_DM11 , s1b1jresolvedMcut_tesDown_DM1, s2b0jresolvedMcut_tesUp_DM11 , s2b0jresolvedMcut_tesDown_DM1, sboostedLLMcut_tesUp_DM11    , sboostedLLMcut_tesDown_DM11  , VBFloose_tesUp_DM11          , VBFloose_tesDown_DM11        , s1b1jresolvedMcut_eesUp_DM0  , s1b1jresolvedMcut_eesDown_DM0, s2b0jresolvedMcut_eesUp_DM0  , s2b0jresolvedMcut_eesDown_DM0, sboostedLLMcut_eesUp_DM0     , sboostedLLMcut_eesDown_DM0   , VBFloose_eesUp_DM0           , VBFloose_eesDown_DM0         , s1b1jresolvedMcut_eesUp_DM1  , s1b1jresolvedMcut_eesDown_DM1, s2b0jresolvedMcut_eesUp_DM1  , s2b0jresolvedMcut_eesDown_DM1, sboostedLLMcut_eesUp_DM1     , sboostedLLMcut_eesDown_DM1   , VBFloose_eesUp_DM1           , VBFloose_eesDown_DM1         , s1b1jresolvedMcut_mesUp  , s1b1jresolvedMcut_mesDown, s2b0jresolvedMcut_mesUp  , s2b0jresolvedMcut_mesDown, sboostedLLMcut_mesUp     , sboostedLLMcut_mesDown   , VBFloose_mesUp           , VBFloose_mesDown         , s1b1jresolvedMcut_jesUp_Tot  , s1b1jresolvedMcut_jesDown_Tot, s2b0jresolvedMcut_jesUp_Tot  , s2b0jresolvedMcut_jesDown_Tot, sboostedLLMcut_jesUp_Tot     , sboostedLLMcut_jesDown_Tot   , VBFloose_jesUp_Tot           , VBFloose_jesDown_Tot
+selections = s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose
 
-regions    = SR
+regions    = SR, SStight, OSinviso, SSinviso
 
 
 [configs]
 sampleCfg = config/sampleCfg_Legacy2018.cfg
+cutCfg    = config/selectionCfg_MuTau_Legacy2018.cfg
 pattern   = goodsystfiles
-cutCfg    = config/selectionCfg_TauTau_Legacy2018_syst.cfg
 
 
 [merge]
@@ -42,7 +42,7 @@ cutCfg    = config/selectionCfg_TauTau_Legacy2018_syst.cfg
 #limits_test
 #TT        = TTfullyHad
 DY        = DY_HM
-data_obs  = DTauA, DTauB, DTauC, DTauD
+data_obs  = DsingleMuA, DsingleMuB, DsingleMuC, DsingleMuD
 
 
 ############################################################################################

--- a/config/mainCfg_MuTau_Legacy2018_syst.cfg
+++ b/config/mainCfg_MuTau_Legacy2018_syst.cfg
@@ -5,9 +5,9 @@ lumi = 59970 # pb^-1 CMS2018LUMI PASSING ANALYSIS QUALITY REQUIREMENT
 # approximate to only one decimal digit
 lumi_fb = 60.0 # fb^-1
 
-outputFolder = analysis_TauTau_synch_11June2020_syst_prova
+outputFolder = analysis_MuTau_synch_11June2020_syst_prova
 
-data = DTauA, DTauB, DTauC, DTauD
+data = DsingleMuA, DsingleMuB, DsingleMuC, DsingleMuD
 
 signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH0_xs, GGHH_NLO_cHHH5_xs, VBFHH_CV_1_C2V_1_C3_1_xs , VBFHH_CV_0p5_C2V_1_C3_1_xs, VBFHH_CV_1p5_C2V_1_C3_1_xs, VBFHH_CV_1_C2V_1_C3_0_xs  ,VBFHH_CV_1_C2V_1_C3_2_xs ,VBFHH_CV_1_C2V_2_C3_1_xs  
 
@@ -24,7 +24,7 @@ regions    = SR
 [configs]
 sampleCfg = config/sampleCfg_Legacy2018.cfg
 pattern   = goodsystfiles
-cutCfg    = config/selectionCfg_TauTau_Legacy2018_syst.cfg
+cutCfg    = config/selectionCfg_MuTau_Legacy2018_syst.cfg
 
 
 [merge]
@@ -42,7 +42,8 @@ cutCfg    = config/selectionCfg_TauTau_Legacy2018_syst.cfg
 #limits_test
 #TT        = TTfullyHad
 DY        = DY_HM
-data_obs  = DTauA, DTauB, DTauC, DTauD
+data_obs  = DsingleMuA, DsingleMuB, DsingleMuC, DsingleMuD
+
 
 
 ############################################################################################

--- a/config/mainCfg_TauTau_Legacy2018_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2018_limits.cfg
@@ -1,0 +1,109 @@
+[general]
+
+lumi = 59970 # pb^-1 CMS2018LUMI PASSING ANALYSIS QUALITY REQUIREMENT
+# the lumi in fb^-1 is used only by the plotting program
+# approximate to only one decimal digit
+lumi_fb = 60.0 # fb^-1
+
+outputFolder = analysis_TauTau_synch_11June2020_limits_prova
+
+data = DTauA, DTauB, DTauC, DTauD
+
+signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH2p45_xs, GGHH_NLO_cHHH5_xs #VBFHHSM_CV_1_C2V_1_C3_1_xs ,VBFHHSM_CV_0_5_C2V_1_C3_1_xs,VBFHHSM_CV_1_5_C2V_1_C3_1_xs,VBFHHSM_CV_1_C2V_1_C3_0_xs  ,VBFHHSM_CV_1_C2V_1_C3_2_xs ,VBFHHSM_CV_1_C2V_2_C3_1_xs  
+
+backgrounds = DY_HM #, TTfullyLep, TTsemiLep, DY_HM,WJets_HT_0_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZH_HBB_ZLL, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, WWW, WWZ, WZZ, ZZZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ, ttHJetToTauTau, DY_LM
+
+variables = DNNoutSM_kl_1, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0 
+
+#tauH_pt , dau1_eta, dau2_eta, ditau_deltaR, tauH_mass, tauH_SVFIT_mass, DNNoutSM_kl_1, bH_mass, bH_pt
+
+# SELECTIONS W/O MASS CUT
+selections = s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose
+
+regions    = SR, SStight, OSinviso, SSinviso
+
+[configs]
+sampleCfg = config/sampleCfg_Legacy2018.cfg
+pattern   = goodsystfiles
+cutCfg    = config/selectionCfg_TauTau_Legacy2018.cfg
+
+
+[merge]
+#limits
+#TT        = TTfullyHad, TTfullyLep, TTsemiLep
+#WJets     = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
+#EWK       = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL
+#singleT   = TWtop, TWantitop, singleTop_top, singleTop_antitop
+#ZH        = ZH_HBB_ZLL, ZH_HTauTau
+#WW        = WWTo2L2Nu, WWTo4Q, WWToLNuQQ
+#WZ        = WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L
+#others        = WWW, WWZ, WZZ, ZZZ, TTZZ, TTWW, TTWZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, ggHTauTau, VBFHTauTau,  ttHJetTononBB, ttHJetToBB, ttHJetToTauTau
+#DY  = DY_LM, DY_HM
+
+#limits_test
+#TT        = TTfullyHad
+DY        = DY_HM
+data_obs  = DTauA, DTauB, DTauC, DTauD
+
+
+############################################################################################
+############################################################################################
+# the following lines are used for postprocessing (pp_), i.e. not read from AnalysisHelper
+# but used in subsequent steps of the analysis to combine histos, compute QCD etc..
+# we keep them here to have everything at hand
+
+[pp_merge]
+
+
+## in case some histos must be rebinned. Pass as
+## uniqueid = varToRebin , condition, newBinning
+# [pp_rebin]
+# r1 = HHKin_mass_raw         , sboostedLLMcut , 250, 1000 # a unique, big bin
+# r2 = HHKin_mass_raw_tauup   , sboostedLLMcut , 250, 1000 # a unique, big bin
+# r3 = HHKin_mass_raw_taudown , sboostedLLMcut , 250, 1000 # a unique, big bin
+# r4 = HHKin_mass_raw_jetup   , sboostedLLMcut , 250, 1000 # a unique, big bin
+# r5 = HHKin_mass_raw_jetdown , sboostedLLMcut , 250, 1000 # a unique, big bin
+#
+# r6  = MT2         , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+# r7  = MT2_tauup   , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+# r8  = MT2_taudown , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+# r9  = MT2_jetup   , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+# r10 = MT2_jetdown , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+
+## parameters for QCD evaluation
+## doFitIf : condition to be respected to make rlx-to-tight QCD fit. It is used as eval(doFitIf). Use names sel, var
+
+
+[pp_QCD]
+#QCDname      = QCD
+#SR           = SR
+#yieldSB      = SStight
+#shapeSB      = SSrlx
+#SBtoSRfactor = 1
+#regionD = SSinviso
+#regionC = OSinviso
+#doFitIf      = False
+#fitFunc      = [0] + [1]*x
+
+
+#for inverted QCD
+QCDname      = QCD
+SR           = SR
+yieldSB      = OSinviso
+shapeSB      = OSinviso
+SBtoSRfactor = 1
+doFitIf      = False
+fitFunc      = [0] + [1]*x
+regionC      = SStight
+regionD      = SSinviso
+
+
+[VBF_rew]
+# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
+# See the list 'inputSignals' to understand the link node<->couplings
+doReweighting = False
+inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
+target_kl  = 1
+target_cv  = 0, 1
+target_c2v = 1
+target_xs = 1 #[pb]

--- a/config/mainCfg_TauTau_Legacy2018_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2018_limits.cfg
@@ -13,14 +13,13 @@ signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH0_xs, GGHH_NLO_cHHH5_xs , VBFHH_CV_1_C
 
 backgrounds = DY_HM #, TTfullyLep, TTsemiLep, DY_HM,WJets_HT_0_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZH_HBB_ZLL, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, WWW, WWZ, WZZ, ZZZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ, ttHJetToTauTau, DY_LM
 
-variables = DNNoutSM_kl_1, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0 
-
+variables = DNNoutSM_kl_1, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot,
 #tauH_pt , dau1_eta, dau2_eta, ditau_deltaR, tauH_mass, tauH_SVFIT_mass, DNNoutSM_kl_1, bH_mass, bH_pt
 
-# SELECTIONS W/O MASS CUT
 selections = s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose
 
 regions    = SR, SStight, OSinviso, SSinviso
+
 
 [configs]
 sampleCfg = config/sampleCfg_Legacy2018.cfg

--- a/config/mainCfg_TauTau_Legacy2018_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2018_limits.cfg
@@ -9,7 +9,7 @@ outputFolder = analysis_TauTau_synch_11June2020_limits_prova
 
 data = DTauA, DTauB, DTauC, DTauD
 
-signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH2p45_xs, GGHH_NLO_cHHH5_xs #VBFHHSM_CV_1_C2V_1_C3_1_xs ,VBFHHSM_CV_0_5_C2V_1_C3_1_xs,VBFHHSM_CV_1_5_C2V_1_C3_1_xs,VBFHHSM_CV_1_C2V_1_C3_0_xs  ,VBFHHSM_CV_1_C2V_1_C3_2_xs ,VBFHHSM_CV_1_C2V_2_C3_1_xs  
+signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH0_xs, GGHH_NLO_cHHH5_xs , VBFHH_CV_1_C2V_1_C3_1_xs ,VBFHH_CV_0p5_C2V_1_C3_1_xs,VBFHH_CV_1p5_C2V_1_C3_1_xs, VBFHH_CV_1_C2V_1_C3_0_xs  ,VBFHH_CV_1_C2V_1_C3_2_xs ,VBFHH_CV_1_C2V_2_C3_1_xs  
 
 backgrounds = DY_HM #, TTfullyLep, TTsemiLep, DY_HM,WJets_HT_0_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZH_HBB_ZLL, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, WWW, WWZ, WZZ, ZZZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ, ttHJetToTauTau, DY_LM
 

--- a/config/mainCfg_TauTau_Legacy2018_syst.cfg
+++ b/config/mainCfg_TauTau_Legacy2018_syst.cfg
@@ -9,7 +9,7 @@ outputFolder = analysis_TauTau_synch_11June2020_syst_prova
 
 data = DTauA, DTauB, DTauC, DTauD
 
-signals = GGHH_NLO_cHHH1_xs,GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH2p45_xs, GGHH_NLO_cHHH5_xs #VBFHHSM_CV_1_C2V_1_C3_1_xs ,VBFHHSM_CV_0_5_C2V_1_C3_1_xs,VBFHHSM_CV_1_5_C2V_1_C3_1_xs,VBFHHSM_CV_1_C2V_1_C3_0_xs  ,VBFHHSM_CV_1_C2V_1_C3_2_xs ,VBFHHSM_CV_1_C2V_2_C3_1_xs  
+signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH0_xs, GGHH_NLO_cHHH5_xs, VBFHH_CV_1_C2V_1_C3_1_xs , VBFHH_CV_0p5_C2V_1_C3_1_xs, VBFHH_CV_1p5_C2V_1_C3_1_xs, VBFHH_CV_1_C2V_1_C3_0_xs  ,VBFHH_CV_1_C2V_1_C3_2_xs ,VBFHH_CV_1_C2V_2_C3_1_xs  
 
 backgrounds = DY_HM #, TTfullyLep, TTsemiLep, DY_HM,WJets_HT_0_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZH_HBB_ZLL, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, WWW, WWZ, WZZ, ZZZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ, ttHJetToTauTau, DY_LM
 

--- a/config/mainCfg_TauTau_Legacy2018_syst.cfg
+++ b/config/mainCfg_TauTau_Legacy2018_syst.cfg
@@ -1,0 +1,109 @@
+[general]
+
+lumi = 59970 # pb^-1 CMS2018LUMI PASSING ANALYSIS QUALITY REQUIREMENT
+# the lumi in fb^-1 is used only by the plotting program
+# approximate to only one decimal digit
+lumi_fb = 60.0 # fb^-1
+
+outputFolder = analysis_TauTau_synch_11June2020_syst_prova
+
+data = DTauA, DTauB, DTauC, DTauD
+
+signals = GGHH_NLO_cHHH1_xs,GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH2p45_xs, GGHH_NLO_cHHH5_xs #VBFHHSM_CV_1_C2V_1_C3_1_xs ,VBFHHSM_CV_0_5_C2V_1_C3_1_xs,VBFHHSM_CV_1_5_C2V_1_C3_1_xs,VBFHHSM_CV_1_C2V_1_C3_0_xs  ,VBFHHSM_CV_1_C2V_1_C3_2_xs ,VBFHHSM_CV_1_C2V_2_C3_1_xs  
+
+backgrounds = DY_HM #, TTfullyLep, TTsemiLep, DY_HM,WJets_HT_0_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZH_HBB_ZLL, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, WWW, WWZ, WZZ, ZZZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ, ttHJetToTauTau, DY_LM
+
+variables = DNNoutSM_kl_1
+
+#tauH_pt , dau1_eta, dau2_eta, ditau_deltaR, tauH_mass, tauH_SVFIT_mass, DNNoutSM_kl_1, bH_mass, bH_pt
+
+# SELECTIONS W/O MASS CUT
+selections = s1b1jresolvedMcut_nominal, s2b0jresolvedMcut_nominal, sboostedLLMcut_nominal, VBFloose_nominal, s1b1jresolvedMcut_tesUp_DM0, s2b0jresolvedMcut_tesUp_DM0, sboostedLLMcut_tesUp_DM0, VBFloose_tesUp_DM0, s1b1jresolvedMcut_tesDown_DM0, s2b0jresolvedMcut_tesDown_DM0, sboostedLLMcut_tesDown_DM0, VBFloose_tesDown_DM0
+
+regions    = SR
+
+[configs]
+sampleCfg = config/sampleCfg_Legacy2018.cfg
+pattern   = goodsystfiles
+cutCfg    = config/selectionCfg_TauTau_Legacy2018_syst.cfg
+
+
+[merge]
+#limits
+#TT        = TTfullyHad, TTfullyLep, TTsemiLep
+#WJets     = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
+#EWK       = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL
+#singleT   = TWtop, TWantitop, singleTop_top, singleTop_antitop
+#ZH        = ZH_HBB_ZLL, ZH_HTauTau
+#WW        = WWTo2L2Nu, WWTo4Q, WWToLNuQQ
+#WZ        = WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L
+#others        = WWW, WWZ, WZZ, ZZZ, TTZZ, TTWW, TTWZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, ggHTauTau, VBFHTauTau,  ttHJetTononBB, ttHJetToBB, ttHJetToTauTau
+#DY  = DY_LM, DY_HM
+
+#limits_test
+#TT        = TTfullyHad
+DY        = DY_HM
+data_obs  = DTauA, DTauB, DTauC, DTauD
+
+
+############################################################################################
+############################################################################################
+# the following lines are used for postprocessing (pp_), i.e. not read from AnalysisHelper
+# but used in subsequent steps of the analysis to combine histos, compute QCD etc..
+# we keep them here to have everything at hand
+
+[pp_merge]
+
+
+## in case some histos must be rebinned. Pass as
+## uniqueid = varToRebin , condition, newBinning
+# [pp_rebin]
+# r1 = HHKin_mass_raw         , sboostedLLMcut , 250, 1000 # a unique, big bin
+# r2 = HHKin_mass_raw_tauup   , sboostedLLMcut , 250, 1000 # a unique, big bin
+# r3 = HHKin_mass_raw_taudown , sboostedLLMcut , 250, 1000 # a unique, big bin
+# r4 = HHKin_mass_raw_jetup   , sboostedLLMcut , 250, 1000 # a unique, big bin
+# r5 = HHKin_mass_raw_jetdown , sboostedLLMcut , 250, 1000 # a unique, big bin
+#
+# r6  = MT2         , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+# r7  = MT2_tauup   , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+# r8  = MT2_taudown , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+# r9  = MT2_jetup   , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+# r10 = MT2_jetdown , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+
+## parameters for QCD evaluation
+## doFitIf : condition to be respected to make rlx-to-tight QCD fit. It is used as eval(doFitIf). Use names sel, var
+
+
+[pp_QCD]
+#QCDname      = QCD
+#SR           = SR
+#yieldSB      = SStight
+#shapeSB      = SSrlx
+#SBtoSRfactor = 1
+#regionD = SSinviso
+#regionC = OSinviso
+#doFitIf      = False
+#fitFunc      = [0] + [1]*x
+
+
+#for inverted QCD
+QCDname      = QCD
+SR           = SR
+yieldSB      = OSinviso
+shapeSB      = OSinviso
+SBtoSRfactor = 1
+doFitIf      = False
+fitFunc      = [0] + [1]*x
+regionC      = SStight
+regionD      = SSinviso
+
+
+[VBF_rew]
+# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
+# See the list 'inputSignals' to understand the link node<->couplings
+doReweighting = False
+inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
+target_kl  = 1
+target_cv  = 0, 1
+target_c2v = 1
+target_xs = 1 #[pb]

--- a/config/sampleCfg_Legacy2018.cfg
+++ b/config/sampleCfg_Legacy2018.cfg
@@ -1,99 +1,112 @@
 [samples]
-DsingleMuA   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_SingleMuon2018A
-DsingleMuB   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_SingleMuon2018B
-DsingleMuC   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_SingleMuon2018C
-DsingleMuD   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_SingleMuon2018D
+DsingleMuA   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_SingleMuon2018A
+DsingleMuB   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_SingleMuon2018B
+DsingleMuC   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_SingleMuon2018C
+DsingleMuD   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_SingleMuon2018D
 
-DsingleEleA  =/data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_SingleElectron2018A
-DsingleEleB  =/data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_SingleElectron2018B
-DsingleEleC  =/data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_SingleElectron2018C
-DsingleEleD  =/data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_SingleElectron2018D
+DsingleEleA  =/data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_SingleElectron2018A
+DsingleEleB  =/data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_SingleElectron2018B
+DsingleEleC  =/data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_SingleElectron2018C
+DsingleEleD  =/data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_SingleElectron2018D
 
-DTauA        = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_Tau2018A
-DTauB        = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_Tau2018B
-DTauC        = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_Tau2018C
-DTauD        = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_Tau2018D
+DTauA        = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_Tau2018A
+DTauB        = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_Tau2018B
+DTauC        = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_Tau2018C
+DTauD        = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_Tau2018D
 
 ########
 
-TTfullyHad     = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_TT_fullyHad
-TTfullyLep     = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_TT_fullyLep
-TTsemiLep      = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_TT_semiLep
+TTfullyHad     = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_TT_fullyHad
+TTfullyLep     = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_TT_fullyLep
+TTsemiLep      = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_TT_semiLep
 
 
 #incl
 
-DY = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_DY
-#DY0b = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_DY_allgenjets_0b
-#DY1b = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_DY_allgenjets_1b
-#DY2b = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_DY_allgenjets_2b
-DY_lowMass = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_DY_lowMass
+DY_HM = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_DY
+#DY0b = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_DY_allgenjets_0b
+#DY1b = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_DY_allgenjets_1b
+#DY2b = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_DY_allgenjets_2b
+DY_LM = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_DY_lowMass
 
-WJets_HT_0_100      = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WJets_HT_0_100
-WJets_HT_100_200    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WJets_HT_100_200
-WJets_HT_200_400    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WJets_HT_200_400
-WJets_HT_400_600    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WJets_HT_400_600
-WJets_HT_600_800    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WJets_HT_600_800
-WJets_HT_800_1200   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WJets_HT_800_1200
-WJets_HT_1200_2500  = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WJets_HT_1200_2500
-WJets_HT_2500_Inf   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WJets_HT_2500_Inf
+WJets_HT_0_100      = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WJets_HT_0_100
+WJets_HT_100_200    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WJets_HT_2500_Inf
 
-TWtop                  = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_ST_tW_top
-TWantitop              = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_ST_tW_antitop
-singleTop_top          = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_ST_tchannel_top
-singleTop_antitop      = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_ST_tchannel_antitop
+TWtop                  = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ST_tW_top
+TWantitop              = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ST_tW_antitop
+singleTop_top          = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ST_tchannel_top
+singleTop_antitop      = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ST_tchannel_antitop
 
-EWKWMinus2Jets_WToLNu  = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_EWKWMinus2Jets_WToLNu
-EWKWPlus2Jets_WToLNu   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_EWKWPlus2Jets_WToLNu
-EWKZ2Jets_ZToLL        = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_EWKZ2Jets_ZToLL
-#EWKZ2Jets_ZToNuNu     = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_EWKZ2Jets_ZToNuNu
+EWKWMinus2Jets_WToLNu  = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_EWKZ2Jets_ZToLL
+#EWKZ2Jets_ZToNuNu     = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_EWKZ2Jets_ZToNuNu
 
-WWTo2L2Nu    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WWTo2L2Nu
-WWTo4Q       = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WWTo4Q
-WWToLNuQQ    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WWToLNuQQ
+WWTo2L2Nu    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WWTo2L2Nu
+WWTo4Q       = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WWTo4Q
+WWToLNuQQ    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WWToLNuQQ
 
-WZTo1L1Nu2Q  = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WZTo1L1Nu2Q
-WZTo1L3Nu    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WZTo1L3Nu
-WZTo2L2Q     = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WZTo2L2Q
-WZTo3LNu     = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WZTo3LNu
+WZTo1L1Nu2Q  = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WZTo1L3Nu
+WZTo2L2Q     = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WZTo2L2Q
+WZTo3LNu     = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WZTo3LNu
 
-ZZTo2L2Nu    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_ZZTo2L2Nu
-ZZTo2L2Q     = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_ZZTo2L2Q
-ZZTo2Q2Nu    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_ZZTo2Q2Nu
-ZZTo4L       = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_ZZTo4L
+ZZTo2L2Nu    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ZZTo2L2Nu
+ZZTo2L2Q     = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ZZTo2Q2Nu
+ZZTo4L       = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ZZTo4L
 
-ZH_HBB_ZLL             = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_ZH_HBB_ZLL
+ZH_HBB_ZLL             = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ZH_HBB_ZLL
 #ZH_HBB_ZQQ             = /data_CMS/cms/amendola/HHLegacy_2018_SKIMS/SKIMS_22Jan2020/SKIM_ZH_HBB_ZQQ  # NOT PRODUCED FOR 2018
-ZH_HTauTau             = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_ZH_HTauTau
-ggHTauTau              = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_ggHTauTau
-VBFHTauTau             = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_VBFHTauTau
-WplusHTauTau           = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WplusHTauTau
-WminusHTauTau          = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WminusHTauTau
-ttHJetTononBB          = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_ttHJetTononBB
-ttHJetToBB             = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_ttHJetToBB
+ZH_HTauTau             = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ZH_HTauTau
+ggHTauTau              = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ggHTauTau
+VBFHTauTau             = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_VBFHTauTau
+WplusHTauTau           = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WplusHTauTau
+WminusHTauTau          = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WminusHTauTau
+ttHJetTononBB          = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ttHJetTononBB
+ttHJetToBB             = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ttHJetToBB
+ttHJetToTauTau        = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ttHJetToTauTau
 
-ZZZ                    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_ZZZ
-WWW                    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WWW
-WWZ                    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WWZ
-WZZ                    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_WZZ
+ZZZ                    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_ZZZ
+WWW                    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WWW
+WWZ                    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WWZ
+WZZ                    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_WZZ
 
-TTWJetsToLNu           = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_TTWJetsToLNu
-TTWJetsToQQ            = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_TTWJetsToQQ
-TTWW                   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_TTWW
-TTZToLLNuNu            = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_TTZToLLNuNu
-TTWZ                   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_TTWZ
-TTZZ                   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_TTZZ
+TTWJetsToLNu           = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_TTWJetsToQQ
+TTWW                   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_TTWW
+TTZToLLNuNu            = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_TTZToLLNuNu
+TTWZ                   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_TTWZ
+TTZZ                   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_TTZZ
 
 #########
 
-VBFSM    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_VBFHH_CV_1_C2V_1_C3_1
-GGHHSM   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_GGHH_SM
+VBFSM    = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_VBFHH_CV_1_C2V_1_C3_1
+GGHHSM   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_HHRew_SM
 
-VBFHHSM_CV_0_5_C2V_1_C3_1 = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_VBFHH_CV_0_5_C2V_1_C3_1
-VBFHHSM_CV_1_5_C2V_1_C3_1 = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_VBFHH_CV_1_5_C2V_1_C3_1
-VBFHHSM_CV_1_C2V_1_C3_0   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_VBFHH_CV_1_C2V_1_C3_0
-VBFHHSM_CV_1_C2V_1_C3_2   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_VBFHH_CV_1_C2V_1_C3_2
-VBFHHSM_CV_1_C2V_2_C3_1   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_8May2020/SKIM_VBFHH_CV_1_C2V_2_C3_1
+GGHH_NLO_cHHH1_xs      = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_GGHH_NLO_SM_xs
+GGHH_NLO_cHHH0_xs      = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs      = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_0p5_C2V_1_C3_1 = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_VBFHH_CV_0_5_C2V_1_C3_1
+VBFHH_CV_1p5_C2V_1_C3_1 = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_VBFHH_CV_1_5_C2V_1_C3_1
+VBFHH_CV_1_C2V_1_C3_0   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_VBFHH_CV_1_C2V_1_C3_0
+VBFHH_CV_1_C2V_1_C3_2   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_VBFHH_CV_1_C2V_1_C3_2
+VBFHH_CV_1_C2V_2_C3_1   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_VBFHH_CV_1_C2V_2_C3_1
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_VBFHH_CV_0_5_C2V_1_C3_1_xs
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_VBFHH_CV_0_5_C2V_1_C3_1_xs
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_VBFHH_CV_1_5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_0_xs   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
+VBFHH_CV_1_C2V_1_C3_2_xs   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
+VBFHH_CV_1_C2V_2_C3_1_xs   = /data_CMS/cms/amendola/HHLegacy_2018_v2/SKIMS_1June2020/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
 
 #########
 

--- a/config/selectionCfg_ETau_Legacy2018.cfg
+++ b/config/selectionCfg_ETau_Legacy2018.cfg
@@ -92,21 +92,21 @@ resBDTCut    = BDTResonant > 0.4
 nonresBDTCut = LepTauKine > -0.134
 
 # ABCD regions used in the analysis - MVA2017v2
-#SR           = isOS != 0 && dau1_iso < 0.1 && dau2_MVAisoNew >= 3
-#SStight      = isOS == 0 && dau1_iso < 0.1 && dau2_MVAisoNew >= 3
-#OSrlx        = isOS != 0 && dau1_iso < 0.1 && dau2_MVAisoNew >= 1
-#SSrlx        = isOS == 0 && dau1_iso < 0.1 && dau2_MVAisoNew >= 1
-#OSinviso     = isOS != 0 && dau1_iso < 0.1 && dau2_MVAisoNew >= 1 && dau2_MVAisoNew < 3
-#SSinviso     = isOS == 0 && dau1_iso < 0.1 && dau2_MVAisoNew >= 1 && dau2_MVAisoNew < 3
+#SR           = isOS != 0 && dau1_eleMVAiso == 1 && dau2_MVAisoNew >= 3
+#SStight      = isOS == 0 && dau1_eleMVAiso == 1 && dau2_MVAisoNew >= 3
+#OSrlx        = isOS != 0 && dau1_eleMVAiso == 1 && dau2_MVAisoNew >= 1
+#SSrlx        = isOS == 0 && dau1_eleMVAiso == 1 && dau2_MVAisoNew >= 1
+#OSinviso     = isOS != 0 && dau1_eleMVAiso == 1 && dau2_MVAisoNew >= 1 && dau2_MVAisoNew < 3
+#SSinviso     = isOS == 0 && dau1_eleMVAiso == 1 && dau2_MVAisoNew >= 1 && dau2_MVAisoNew < 3
 #SRforEff      = SR, genDecMode1 == 1
 
 # ABCD regions used in the analysis - DeepTau
-SR           = isOS != 0 && dau1_iso < 0.1 && dau2_deepTauVsJet >= 5                          # signal region: opposite sign, isolated taus
-SStight      = isOS == 0 && dau1_iso < 0.1 && dau2_deepTauVsJet >= 5			              # B region
-OSrlx        = isOS != 0 && dau1_iso < 0.1 && dau2_deepTauVsJet >= 2
-SSrlx        = isOS == 0 && dau1_iso < 0.1 && dau2_deepTauVsJet >= 2			              # B' region
-OSinviso     = isOS != 0 && dau1_iso < 0.1 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # C region
-SSinviso     = isOS == 0 && dau1_iso < 0.1 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # D region
+SR           = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 5                          # signal region: opposite sign, isolated taus
+SStight      = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 5			              # B region
+OSrlx        = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2
+SSrlx        = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2			              # B' region
+OSinviso     = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # C region
+SSinviso     = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # D region
 
 
 
@@ -333,6 +333,24 @@ BDToutSM_kl_1            = 15,-1,1
 BDToutLM_spin_0_mass_280 = 20,-1,1
 BDToutMM_spin_0_mass_400 = 20,-1,1
 BDToutHM_spin_0_mass_650 = 20,-1,1
+
+DNNoutSM_kl_1              = 35,0,1
+DNNoutSM_kl_1_tauup_DM0    = 35,0,1
+DNNoutSM_kl_1_taudown_DM0  = 35,0,1
+DNNoutSM_kl_1_tauup_DM1    = 35,0,1
+DNNoutSM_kl_1_taudown_DM1  = 35,0,1
+DNNoutSM_kl_1_tauup_DM10   = 35,0,1
+DNNoutSM_kl_1_taudown_DM10 = 35,0,1
+DNNoutSM_kl_1_tauup_DM11   = 35,0,1
+DNNoutSM_kl_1_taudown_DM11 = 35,0,1
+DNNoutSM_kl_1_eleup_DM0    = 35,0,1
+DNNoutSM_kl_1_eledown_DM0  = 35,0,1
+DNNoutSM_kl_1_eleup_DM1    = 35,0,1
+DNNoutSM_kl_1_eledown_DM1  = 35,0,1
+DNNoutSM_kl_1_muup         = 35,0,1
+DNNoutSM_kl_1_mudown       = 35,0,1
+DNNoutSM_kl_1_jetupTot     = 35,0,1
+DNNoutSM_kl_1_jetdownTot   = 35,0,1
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_ETau_Legacy2018_syst.cfg
+++ b/config/selectionCfg_ETau_Legacy2018_syst.cfg
@@ -12,11 +12,12 @@ btagMM       = bjet1_bID_deepFlavor > 0.2770 && bjet2_bID_deepFlavor > 0.2770 #b
 nobtagMM     = bjet1_bID_deepFlavor < 0.2770 && bjet2_bID_deepFlavor < 0.2770 #both jets NOT btagged (medium working point)
 
 # Signal Region: opposite sign, isolated taus
-SR = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 5
+SR = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 5
 
 
 ### -- Selections with tes/mes/ees
 ### when shifting up/down the tauh --> we evaluate acceptance requiring +5 GeV on the threshold
+### dau1 == Electron --> not shifted --> no change in acceptance --> no change in threshold
 ### jets are unshifted by this --> left to the nominal threshold
 ### -- Selections with jes
 ### jets are selected at skim level to have pt > 20
@@ -24,27 +25,27 @@ SR = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 5
 ### taus are unshifted by this --> left to the nominal threshold
 
 ###### baselines
-baseline_nominal      = pairType == 2 && dau1_pt              > 45 && abs (dau1_eta) < 2.1 && dau2_pt              > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_nominal      = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt              > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
 
-baseline_tesUp_DM0    = pairType == 2 && dau1_pt_tauup_DM0    > 45 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM0    > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_tesDown_DM0  = pairType == 2 && dau1_pt_taudown_DM0  > 45 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM0  > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_tesUp_DM1    = pairType == 2 && dau1_pt_tauup_DM1    > 45 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM1    > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_tesDown_DM1  = pairType == 2 && dau1_pt_taudown_DM1  > 45 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM1  > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_tesUp_DM10   = pairType == 2 && dau1_pt_tauup_DM10   > 45 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM10   > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_tesDown_DM10 = pairType == 2 && dau1_pt_taudown_DM10 > 45 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM10 > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_tesUp_DM11   = pairType == 2 && dau1_pt_tauup_DM11   > 45 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM11   > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_tesDown_DM11 = pairType == 2 && dau1_pt_taudown_DM11 > 45 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM11 > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesUp_DM0    = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM0    > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesDown_DM0  = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM0  > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesUp_DM1    = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM1    > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesDown_DM1  = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM1  > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesUp_DM10   = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM10   > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesDown_DM10 = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM10 > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesUp_DM11   = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM11   > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesDown_DM11 = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM11 > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
 
-baseline_eesUp_DM0    = pairType == 2 && dau1_pt_eleup_DM0    > 45 && abs (dau1_eta) < 2.1 && dau2_pt_eleup_DM0    > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_eesDown_DM0  = pairType == 2 && dau1_pt_eledown_DM0  > 45 && abs (dau1_eta) < 2.1 && dau2_pt_eledown_DM0  > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_eesUp_DM1    = pairType == 2 && dau1_pt_eleup_DM1    > 45 && abs (dau1_eta) < 2.1 && dau2_pt_eleup_DM1    > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_eesDown_DM1  = pairType == 2 && dau1_pt_eledown_DM1  > 45 && abs (dau1_eta) < 2.1 && dau2_pt_eledown_DM1  > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_eesUp_DM0    = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_eleup_DM0    > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_eesDown_DM0  = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_eledown_DM0  > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_eesUp_DM1    = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_eleup_DM1    > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_eesDown_DM1  = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_eledown_DM1  > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
 
-baseline_mesUp        = pairType == 2 && dau1_pt_muup         > 45 && abs (dau1_eta) < 2.1 && dau2_pt_muup         > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_mesDown      = pairType == 2 && dau1_pt_mudown       > 45 && abs (dau1_eta) < 2.1 && dau2_pt_mudown       > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_mesUp        = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_muup         > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_mesDown      = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_mudown       > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
 
-baseline_jesUp_Tot    = pairType == 2 && dau1_pt              > 40 && abs (dau1_eta) < 2.1 && dau2_pt              > 40 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt_raw_jetupTot   > 25 && bjet2_pt_raw_jetupTot   > 25 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_jesDown_Tot  = pairType == 2 && dau1_pt              > 40 && abs (dau1_eta) < 2.1 && dau2_pt              > 40 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt_raw_jetdownTot > 25 && bjet1_pt_raw_jetdownTot > 25 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_jesUp_Tot    = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt              > 20 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt_raw_jetupTot   > 25 && bjet2_pt_raw_jetupTot   > 25 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_jesDown_Tot  = pairType == 1 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt              > 20 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt_raw_jetdownTot > 25 && bjet1_pt_raw_jetdownTot > 25 && isVBFtrigger == 0 && nbjetscand > 1
 
 
 ###### masscuts

--- a/config/selectionCfg_MuTau_Legacy2018.cfg
+++ b/config/selectionCfg_MuTau_Legacy2018.cfg
@@ -433,6 +433,24 @@ BDToutLM_spin_0_mass_280 = 20,-1,1
 BDToutMM_spin_0_mass_400 = 20,-1,1
 BDToutHM_spin_0_mass_650 = 20,-1,1
 
+DNNoutSM_kl_1              = 35,0,1
+DNNoutSM_kl_1_tauup_DM0    = 35,0,1
+DNNoutSM_kl_1_taudown_DM0  = 35,0,1
+DNNoutSM_kl_1_tauup_DM1    = 35,0,1
+DNNoutSM_kl_1_taudown_DM1  = 35,0,1
+DNNoutSM_kl_1_tauup_DM10   = 35,0,1
+DNNoutSM_kl_1_taudown_DM10 = 35,0,1
+DNNoutSM_kl_1_tauup_DM11   = 35,0,1
+DNNoutSM_kl_1_taudown_DM11 = 35,0,1
+DNNoutSM_kl_1_eleup_DM0    = 35,0,1
+DNNoutSM_kl_1_eledown_DM0  = 35,0,1
+DNNoutSM_kl_1_eleup_DM1    = 35,0,1
+DNNoutSM_kl_1_eledown_DM1  = 35,0,1
+DNNoutSM_kl_1_muup         = 35,0,1
+DNNoutSM_kl_1_mudown       = 35,0,1
+DNNoutSM_kl_1_jetupTot     = 35,0,1
+DNNoutSM_kl_1_jetdownTot   = 35,0,1
+
 #########################################################################
 #########################################################################
 

--- a/config/selectionCfg_MuTau_Legacy2018_syst.cfg
+++ b/config/selectionCfg_MuTau_Legacy2018_syst.cfg
@@ -12,11 +12,12 @@ btagMM       = bjet1_bID_deepFlavor > 0.2770 && bjet2_bID_deepFlavor > 0.2770 #b
 nobtagMM     = bjet1_bID_deepFlavor < 0.2770 && bjet2_bID_deepFlavor < 0.2770 #both jets NOT btagged (medium working point)
 
 # Signal Region: opposite sign, isolated taus
-SR = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 5
+SR = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 5
 
 
 ### -- Selections with tes/mes/ees
 ### when shifting up/down the tauh --> we evaluate acceptance requiring +5 GeV on the threshold
+### dau1 == Muon --> not shifted --> no change in acceptance --> no change in threshold
 ### jets are unshifted by this --> left to the nominal threshold
 ### -- Selections with jes
 ### jets are selected at skim level to have pt > 20
@@ -24,27 +25,27 @@ SR = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 5
 ### taus are unshifted by this --> left to the nominal threshold
 
 ###### baselines
-baseline_nominal      = pairType == 2 && dau1_pt              > 45 && abs (dau1_eta) < 2.1 && dau2_pt              > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_nominal      = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt              > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
 
-baseline_tesUp_DM0    = pairType == 2 && dau1_pt_tauup_DM0    > 45 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM0    > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_tesDown_DM0  = pairType == 2 && dau1_pt_taudown_DM0  > 45 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM0  > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_tesUp_DM1    = pairType == 2 && dau1_pt_tauup_DM1    > 45 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM1    > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_tesDown_DM1  = pairType == 2 && dau1_pt_taudown_DM1  > 45 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM1  > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_tesUp_DM10   = pairType == 2 && dau1_pt_tauup_DM10   > 45 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM10   > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_tesDown_DM10 = pairType == 2 && dau1_pt_taudown_DM10 > 45 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM10 > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_tesUp_DM11   = pairType == 2 && dau1_pt_tauup_DM11   > 45 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM11   > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_tesDown_DM11 = pairType == 2 && dau1_pt_taudown_DM11 > 45 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM11 > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesUp_DM0    = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM0    > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesDown_DM0  = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM0  > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesUp_DM1    = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM1    > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesDown_DM1  = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM1  > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesUp_DM10   = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM10   > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesDown_DM10 = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM10 > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesUp_DM11   = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM11   > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_tesDown_DM11 = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM11 > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
 
-baseline_eesUp_DM0    = pairType == 2 && dau1_pt_eleup_DM0    > 45 && abs (dau1_eta) < 2.1 && dau2_pt_eleup_DM0    > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_eesDown_DM0  = pairType == 2 && dau1_pt_eledown_DM0  > 45 && abs (dau1_eta) < 2.1 && dau2_pt_eledown_DM0  > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_eesUp_DM1    = pairType == 2 && dau1_pt_eleup_DM1    > 45 && abs (dau1_eta) < 2.1 && dau2_pt_eleup_DM1    > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_eesDown_DM1  = pairType == 2 && dau1_pt_eledown_DM1  > 45 && abs (dau1_eta) < 2.1 && dau2_pt_eledown_DM1  > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_eesUp_DM0    = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_eleup_DM0    > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_eesDown_DM0  = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_eledown_DM0  > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_eesUp_DM1    = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_eleup_DM1    > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_eesDown_DM1  = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_eledown_DM1  > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
 
-baseline_mesUp        = pairType == 2 && dau1_pt_muup         > 45 && abs (dau1_eta) < 2.1 && dau2_pt_muup         > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_mesDown      = pairType == 2 && dau1_pt_mudown       > 45 && abs (dau1_eta) < 2.1 && dau2_pt_mudown       > 45 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_mesUp        = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_muup         > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_mesDown      = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt_mudown       > 25 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt > 20 && bjet2_pt > 20 && isVBFtrigger == 0 && nbjetscand > 1
 
-baseline_jesUp_Tot    = pairType == 2 && dau1_pt              > 40 && abs (dau1_eta) < 2.1 && dau2_pt              > 40 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt_raw_jetupTot   > 25 && bjet2_pt_raw_jetupTot   > 25 && isVBFtrigger == 0 && nbjetscand > 1
-baseline_jesDown_Tot  = pairType == 2 && dau1_pt              > 40 && abs (dau1_eta) < 2.1 && dau2_pt              > 40 && abs (dau2_eta) < 2.1 && nleps == 0 && bjet1_pt_raw_jetdownTot > 25 && bjet1_pt_raw_jetdownTot > 25 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_jesUp_Tot    = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt              > 20 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt_raw_jetupTot   > 25 && bjet2_pt_raw_jetupTot   > 25 && isVBFtrigger == 0 && nbjetscand > 1
+baseline_jesDown_Tot  = pairType == 0 && dau1_pt > 20 && abs (dau1_eta) < 2.1 && dau2_pt              > 20 && abs (dau2_eta) < 2.3 && nleps == 0 && bjet1_pt_raw_jetdownTot > 25 && bjet1_pt_raw_jetdownTot > 25 && isVBFtrigger == 0 && nbjetscand > 1
 
 
 ###### masscuts

--- a/config/selectionCfg_TauTau_Legacy2018.cfg
+++ b/config/selectionCfg_TauTau_Legacy2018.cfg
@@ -781,6 +781,23 @@ dau2_decayMode = 11, 0, 11
 
 trigSF = 40, 0.5, 1.5
 
+DNNoutSM_kl_1              = 35,0,1
+DNNoutSM_kl_1_tauup_DM0    = 35,0,1
+DNNoutSM_kl_1_taudown_DM0  = 35,0,1
+DNNoutSM_kl_1_tauup_DM1    = 35,0,1
+DNNoutSM_kl_1_taudown_DM1  = 35,0,1
+DNNoutSM_kl_1_tauup_DM10   = 35,0,1
+DNNoutSM_kl_1_taudown_DM10 = 35,0,1
+DNNoutSM_kl_1_tauup_DM11   = 35,0,1
+DNNoutSM_kl_1_taudown_DM11 = 35,0,1
+DNNoutSM_kl_1_eleup_DM0    = 35,0,1
+DNNoutSM_kl_1_eledown_DM0  = 35,0,1
+DNNoutSM_kl_1_eleup_DM1    = 35,0,1
+DNNoutSM_kl_1_eledown_DM1  = 35,0,1
+DNNoutSM_kl_1_muup         = 35,0,1
+DNNoutSM_kl_1_mudown       = 35,0,1
+DNNoutSM_kl_1_jetupTot     = 35,0,1
+DNNoutSM_kl_1_jetdownTot   = 35,0,1
 
 
 #########################################################################

--- a/config/selectionCfg_TauTau_Legacy2018_syst.cfg
+++ b/config/selectionCfg_TauTau_Legacy2018_syst.cfg
@@ -1,0 +1,139 @@
+# the definition of composed selections. Can contain as well TCut style selections, e.g.:
+# resolved = baseline, btagMM, massCut
+# resolvedHighPt = baseline, btagMM, massCut, dau1_pt > 150
+# use comma separated lists
+[selections]
+
+### some selections with tes up/down
+### note: jets are selected at skim level to have pt > 20
+### so I am raising the pt value to 25 just to test the change in the acceptance
+
+jetsVBFloose_nominal = isVBF && VBFjj_mass > 500 && VBFjj_deltaEta > 3
+jetsVBFloose_jesUp = isVBF && VBFjj_mass_jetup > 500 && VBFjj_deltaEta > 3 && VBFjet2_pt_jetup > 30
+jetsVBFloose_jesDown = isVBF && VBFjj_mass_jetdown > 500 && VBFjj_deltaEta > 3 && VBFjet2_pt_jetdown > 30
+
+noVBFloose_nominal = !(isVBF && VBFjj_mass > 500 && VBFjj_deltaEta > 3)
+noVBFloose_jesUp = !(isVBF && VBFjj_mass_jetup > 500 && VBFjj_deltaEta > 3 && VBFjet2_pt_jetup > 30)
+noVBFloose_jesDown = !(isVBF && VBFjj_mass_jetdown > 500 && VBFjj_deltaEta > 3 && VBFjet2_pt_jetdown > 30)
+
+
+baseline_nominal     = pairType == 2 && dau1_pt > 40 && abs (dau1_eta) < 2.1 && dau2_pt > 40 && abs (dau2_eta) < 2.1 && nleps == 0 && nbjetscand > 1 && isVBFtrigger == 0 && bjet1_pt > 25 && bjet2_pt > 25
+
+baseline_tesUp_DM0       = pairType == 2 && dau1_pt_tauup_DM0 > 40   && abs (dau1_eta) < 2.1 && dau2_pt_tauup_DM0 > 40   && abs (dau2_eta) < 2.1 && nleps == 0       && bjet1_pt > 25         && bjet2_pt > 25 && isVBFtrigger == 0
+baseline_tesDown_DM0     = pairType == 2 && dau1_pt_taudown_DM0 > 40 && abs (dau1_eta) < 2.1 && dau2_pt_taudown_DM0 > 40 && abs (dau2_eta) < 2.1 && nleps == 0       && bjet1_pt > 25         && bjet2_pt > 25 && isVBFtrigger == 0
+
+baseline_jesUp       = pairType == 2 && dau1_pt > 40         && abs (dau1_eta) < 2.1 && dau2_pt > 40         && abs (dau2_eta) < 2.1 && nleps == 0       && bjet1_pt_raw_jetup > 25   && bjet2_pt_raw_jetup > 25 && isVBFtrigger == 0
+baseline_jesDown     = pairType == 2 && dau1_pt > 40         && abs (dau1_eta) < 2.1 && dau2_pt > 40         && abs (dau2_eta) < 2.1 && nleps == 0       && bjet1_pt_raw_jetdown > 25 && bjet2_pt_raw_jetdown > 25 && isVBFtrigger == 0
+
+ellypsMassCut_tesUp_DM0    = ((tauH_SVFIT_mass_tauup_DM0-116.)*(tauH_SVFIT_mass_tauup_DM0-116.))/(35.*35.) + ((bH_mass_raw-111.)*(bH_mass_raw-111.))/(45.*45.) <  1.0
+ellypsMassCut_tesDown_DM0  = ((tauH_SVFIT_mass_taudown_DM0-116.)*(tauH_SVFIT_mass_taudown_DM0-116.))/(35.*35.) + ((bH_mass_raw-111.)*(bH_mass_raw-111.))/(45.*45.) <  1.0
+ellypsMassCut_jesUp    = ((tauH_SVFIT_mass_METup-116.)*(tauH_SVFIT_mass_METup-116.))/(35.*35.) + ((bH_mass_raw_jetup-111.)*(bH_mass_raw_jetup-111.))/(45.*45.) <  1.0
+ellypsMassCut_jesDown  = ((tauH_SVFIT_mass_METdown-116.)*(tauH_SVFIT_mass_METdown-116.))/(35.*35.) + ((bH_mass_raw_jetdown-111.)*(bH_mass_raw_jetdown-111.))/(45.*45.) <  1.0
+
+s1b1jresolvedMcut_nominal = baseline_nominal , btagM, isBoosted != 1 ,  ellypsMassCut, noVBFloose_nominal
+s2b0jresolvedMcut_nominal = baseline_nominal , btagMM, isBoosted != 1 , ellypsMassCut, noVBFloose_nominal
+sboostedLLMcut_nominal    = baseline_nominal , btagLL, isBoosted == 1 , ellypsMassCut, noVBFloose_nominal #CHIA ellypsMassCut-> boostMassCut
+VBFloose_nominal          = baseline_nominal , jetsVBFloose_nominal, tauH_SVFIT_mass > 50
+
+
+s1b1jresolvedMcut_tesUp_DM0   = baseline_tesUp_DM0 , btagM,  isBoosted != 1 , ellypsMassCut_tesUp_DM0, noVBFloose_nominal
+s2b0jresolvedMcut_tesUp_DM0   = baseline_tesUp_DM0 , btagMM, isBoosted != 1 , ellypsMassCut_tesUp_DM0, noVBFloose_nominal
+sboostedLLMcut_tesUp_DM0      = baseline_tesUp_DM0 , btagLL, isBoosted == 1 , ellypsMassCut_tesUp_DM0, noVBFloose_nominal #CHIA ellypsMassCut-> boostMassCut 
+VBFloose_tesUp_DM0            = baseline_tesUp_DM0 , jetsVBFloose_nominal, tauH_SVFIT_mass_tauup_DM0 > 50
+
+s1b1jresolvedMcut_tesDown_DM0 = baseline_tesDown_DM0 , btagM,  isBoosted != 1 , ellypsMassCut_tesDown_DM0, noVBFloose_nominal
+s2b0jresolvedMcut_tesDown_DM0 = baseline_tesDown_DM0 , btagMM, isBoosted != 1 , ellypsMassCut_tesDown_DM0, noVBFloose_nominal
+sboostedLLMcut_tesDown_DM0    = baseline_tesDown_DM0 , btagLL, isBoosted == 1 , ellypsMassCut_tesDown_DM0, noVBFloose_nominal  #CHIA ellypsMassCut-> boostMassCut
+VBFloose_tesDown_DM0          = baseline_tesDown_DM0 , jetsVBFloose_nominal, tauH_SVFIT_mass_taudown_DM0 > 50
+
+s1b1jresolvedMcut_jesUp   = baseline_jesUp, btagM, isBoosted != 1 , ellypsMassCut_jesUp, noVBFloose_jesUp
+s2b0jresolvedMcut_jesUp   = baseline_jesUp, btagMM, isBoosted != 1 , ellypsMassCut_jesUp , noVBFloose_jesUp
+sboostedLLMcut_jesUp      = baseline_jesUp, btagLL, isBoosted == 1 , boostMassCut, noVBFloose_jesUp
+VBFloose_jesUp            = baseline_jesUp, jetsVBFloose_jesUp, tauH_SVFIT_mass_METup > 50
+
+s1b1jresolvedMcut_jesDown = baseline_jesDown , btagM, isBoosted != 1 , ellypsMassCut_jesDown, noVBFloose_jesDown
+s2b0jresolvedMcut_jesDown = baseline_jesDown , btagMM, isBoosted != 1 , ellypsMassCut_jesDown, noVBFloose_jesDown
+sboostedLLMcut_jesDown    = baseline_jesDown , btagLL, isBoosted == 1 , boostMassCut, noVBFloose_jesDown
+VBFloose_jesDown          = baseline_jesDown, jetsVBFloose_jesDown, tauH_SVFIT_mass_METdown > 50
+
+
+# btag requirements - DeepFlavor WPs={0.0494, 0.2770, 0.7264}; // L,M,T -- Legacy 2018 DeepFlavor
+btagL        = bjet1_bID_deepFlavor > 0.0494 && bjet2_bID_deepFlavor < 0.0494 #only 1 jet with loose btag working point
+btagM        = bjet1_bID_deepFlavor > 0.2770 && bjet2_bID_deepFlavor < 0.2770 #only 1 jet with medium btag working point
+btagMfirst   = bjet1_bID_deepFlavor > 0.2770                                  #at least 1 jet with medium btag working point
+btagLL       = bjet1_bID_deepFlavor > 0.0494 && bjet2_bID_deepFlavor > 0.0494 #both jets with loose btag working point
+btagMM       = bjet1_bID_deepFlavor > 0.2770 && bjet2_bID_deepFlavor > 0.2770 #both jets with medium btag working point
+nobtagMM     = bjet1_bID_deepFlavor < 0.2770 && bjet2_bID_deepFlavor < 0.2770 #both jets NOT btagged (medium working point)
+
+
+
+boostMassCut = tauH_SVFIT_mass > 79.5 && tauH_SVFIT_mass < 152.5 && fatjet_softdropMass > 90 && fatjet_softdropMass < 160 
+ellypsMassCut  = ((tauH_SVFIT_mass-116.)*(tauH_SVFIT_mass-116.))/(35.*35.) + ((bH_mass_raw-111.)*(bH_mass_raw-111.))/(45.*45.) <  1.0 # mass cut centered on the Hbb Htt masses, applied in the final selections 
+
+SR           = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 5                   # signal region: opposite sign, isolated taus
+
+
+#########################################################################
+#########################################################################
+
+## weights to be applied for a certain selections when calling Fill()
+## multiple weights are passed as list and are multiplied together
+## NOTE: no weight is applied for data (the simple Fill() is used)
+[selectionWeights]
+#baseline         = MC_weight, PUReweight, PUjetID_SF, trigSF, FakeRateSF_deep, DYscale_MTT
+baseline          = MC_weight, PUReweight, PUjetID_SF, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
+
+# remove DY weights, they are already taken into account in baseline weights
+btagLL         = bTagweightL
+btagMM         = bTagweightM
+nobtagMM       = bTagweightM
+btagL          = bTagweightL
+btagM         = bTagweightM
+
+
+[selectionWeights_ext] # beta feature! use with care!
+#weights decay mode dependent computed with QCD backgrond estimation, DY LO weights, old DY weights, on top of decay mode dependend trigger weights, m_vis > 55 #11 Mar 2019 #used for testing, already saved in the skims
+
+# tauIDSF 8May2020
+#baseline = (dau1_decayMode == 0 && isTau1real ): 1.182, (dau2_decayMode == 0 && isTau2real ): 1.182, (dau1_decayMode == 1 && isTau1real): 1.146, (dau2_decayMode == 1 && isTau2real ): 1.146, (dau1_decayMode == 10 && isTau1real ): 1.149, (dau2_decayMode == 10 && isTau2real ): 1.149, (dau1_decayMode == 11 && isTau1real ): 0.811, (dau2_decayMode == 11 && isTau2real ): 0.811
+
+
+#########################################################################
+#########################################################################
+
+[sampleWeights]
+TTfullyHad = TTtopPtreweight #, IdAndIsoSF
+TTfullyLep = TTtopPtreweight #, IdAndIsoSF
+TTsemiLep  = TTtopPtreweight #, IdAndIsoSF
+
+#########################################################################
+#########################################################################
+
+# define alternative weights to be tested instead of the nominal one
+[systematics]
+TTtopPtreweight  = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
+# trigSF         = trigUP:trigSF_up , trigDOWN:trigSF_down
+# turnOnreweight = rewUP:turnOnreweight_tauup, rewDO:turnOnreweight_taudown
+
+#########################################################################
+#########################################################################
+
+# ROOT-like definition of the binning
+[histos]
+DNNoutSM_kl_1            = 35,0,1
+
+
+#########################################################################
+#########################################################################
+
+# user defined binning for a variable - has precedence on [histos]
+[binning]
+
+#########################################################################
+#########################################################################
+
+[histos2D]
+
+[binning2D]
+
+

--- a/limits/ConfigReader.py
+++ b/limits/ConfigReader.py
@@ -1,0 +1,90 @@
+### parser of the config used for the analysis ###
+import re
+import sys
+
+class ConfigReader:
+    def __init__  (self, cfgInputFile) :
+        self.cfgName = cfgInputFile
+        self.lines = []
+        self.config = {}
+        self.parseInputFileList()
+        self.makeConfig()
+    
+    def parseInputFileList (self) :
+        """ removes all comments and return cleaned list of lines"""
+        filelist = []
+        try :
+            with open (self.cfgName) as fIn:
+                for line in fIn:
+                    line = (line.split("#")[0]).strip()
+                    if line:
+                        self.lines.append(line)
+        except IOError:
+            print "*** WARNING: cfg file " , self.cfgName , " not found"
+            return
+
+        #return filelist
+    def processOption (self, line) :
+        """ processes an option line and returns a pair (name, value) """
+        ll = line.split ('=', 1)
+        if len (ll) < 2:
+            print "Cannot parse option " , line
+            sys.exit()
+        result = (ll[0].strip() , ll[1].strip())
+        return result
+
+    def makeConfig (self) :
+        """ creates the dictionary organized as section::option --> VALUE (all strings!) """
+        section = None
+        for line in self.lines:
+            m = re.search ('\[(.*)\]', line)
+            if m and not '=' in line: # declaration of a new section. If a '=' is also found, it is considered as an assignment
+                section = m.group(1)
+                #print "new section: " , section
+                self.config[section] = {}
+            else: # is an option
+                if not section: # protection
+                    print "Cannot parse config: there are entries outside a [section]"
+                    sys.exit()
+                pair = self.processOption (line)
+                self.config[section][pair[0]] = pair[1]
+
+    def readOption (self, optName) :
+        """ read the config with the c++ style section::option ; also removes any non-alphanumeric symbol in optName """
+        name = optName.split ('::')
+        if len (name) < 2:
+            print "readOption(): pleae pass option as section::option"
+            return None
+        # name[1] = re.sub('[\W_]+', '', name[1]) # removes all non-alphanumeric characters, not needed for latest parser
+        sec = name[0]
+        opt = name[1]
+        if not sec in self.config:
+            print "NO SEC" , sec , "in CONFIG"
+            return None
+        if not opt in self.config[sec]:
+            print "NO OPT" , opt , "in CONFIG at" , sec
+            return None
+        return self.config[sec][opt]
+
+    def readListOption (self, optName) :
+        """ read the config with the c++ style section::option and return a list of arguments (string) """
+        result = self.readOption (optName)
+        if not result:
+            return None
+        line = result.split(',')
+        for i in range (0, len(line)) : line[i] = line[i].strip()
+        return line
+
+    def hasOption (self, optName) :
+        opt = self.readOption (optName)
+        if not opt:
+            return False
+        else:
+            return True
+
+    def hasSection (self, secName) :
+        if not secName in self.config:
+            return False
+        else:
+            return True
+

--- a/limits/compute_scales.py
+++ b/limits/compute_scales.py
@@ -1,0 +1,61 @@
+from ROOT import *
+
+#MClist  = ['DY', 'GGHH_NLO_cHHH1_xs', 'GGHH_NLO_cHHH0_xs', 'GGHH_NLO_cHHH2p45_xs','GGH_NLO_cHHH5_xs']
+MClist  = ['DY', 'GGHH_NLO_cHHH1_xs', 'GGHH_NLO_cHHH2p45_xs','GGHH_NLO_cHHH5_xs']
+
+#channels = ['TauTau', 'ETau', 'MuTau']
+channels = ['TauTau']
+selections = ['s1b1jresolvedMcut', 's2b0jresolvedMcut', 'sboostedLLMcut','VBFloose']
+
+var = "DNNoutSM_kl_1"
+#var = {'s1b1jresolvedMcut':'DNNoutSM_kl_1', 
+#       's2b0jresolvedMcut':'DNNoutSM_kl_1', 
+#       'sboostedLLMcut'   :'DNNoutSM_kl_1', 
+#       'VBFloose'         :'DNNoutSM_kl_1' 
+#}
+
+year = 2018
+
+#toscan = ['tes', 'jes'] ## will append "Up/Down"
+
+toscan = ['tesXXX_DM0']
+
+
+for channel in channels:
+	print "doing channel: ", channel 
+	inputFile = '../analysis_%s_synch_11June2020_syst_prova/outPlotter.root' % channel
+	print inputFile	
+	fIn = TFile.Open(inputFile)
+	
+	## retrieve histograms
+	for sel in selections:
+	    for scale in toscan:
+	        histos_nominal = {}
+	        histos_up      = {}
+	        histos_down    = {}
+	        fout = open ("scales2018/"+channel + '_' + sel + '_' + scale.replace('XXX','') + '.txt', 'w')
+	        for proc in MClist:
+	            hname_nominal = proc + '_' + sel + '_nominal_SR_' + var 
+	            hname_up      = proc + '_' + sel + '_' + scale.replace('XXX','Up') + '_SR_'   + var 
+	            hname_down    = proc + '_' + sel + '_' + scale.replace('XXX','Down') + '_SR_' + var  
+	            
+	            histos_nominal[proc] = fIn.Get(hname_nominal)
+	            histos_up[proc]      = fIn.Get(hname_up)
+	            histos_down[proc]    = fIn.Get(hname_down)
+	            
+	            print sel, var, proc,scale
+	            ynom  = histos_nominal[proc].Integral()
+	            yup   = histos_up[proc].Integral()
+	            ydown = histos_down[proc].Integral()
+	
+	            shiftUp   = 1.0
+	            shiftDown = 1.0
+	            if ynom > 0 and histos_nominal[proc].GetEntries() > 10:
+	                shiftUp = 1.*yup/ynom
+	                shiftDown = 1.*ydown/ynom
+	
+	            fout.write('%20s     ' % proc)
+	            fout.write('%.3f     ' % shiftUp)
+	            fout.write('%.3f'      % shiftDown)
+	            fout.write('\n')
+	        fout.close()

--- a/limits/make_cards.sh
+++ b/limits/make_cards.sh
@@ -1,1 +1,3 @@
-python write_card.py -f analyzedOutPlotter_TauTau_prova.root -o prova -c TauTau -y 1 -u 1 -t -i ../analysis_TauTau_synch_11June2020_limits_prova/mainCfg_TauTau_Legacy2018_limits.cfg
+PYTHONPATH=$PWD/physicsModels:$PYTHONPATH
+python write_card.py -f analyzedOutPlotter_TauTau_prova.root -o prova -c TauTau -y 1 -u 1 -t -i ../analysis_TauTau_synch_11June2020_limits_prova/mainCfg_TauTau_Legacy2018_limits.cfg 
+

--- a/limits/make_cards.sh
+++ b/limits/make_cards.sh
@@ -1,0 +1,1 @@
+python write_card.py -f analyzedOutPlotter_TauTau_prova.root -o prova -c TauTau -y 1 -u 1 -t -i ../analysis_TauTau_synch_11June2020_limits_prova/mainCfg_TauTau_Legacy2018_limits.cfg

--- a/limits/make_workspace.sh
+++ b/limits/make_workspace.sh
@@ -1,0 +1,12 @@
+var="DNNoutSM_kl_1"
+selections="s1b1jresolvedMcut s2b0jresolvedMcut sboostedLLMcut VBFloose"
+tag="cards_TauTauprova" 
+
+for sel in $selections
+do 
+cd $tag/$sel$var
+rm comb.txt
+combineCards.py -S hh_*.txt >> comb.txt
+cd -
+text2workspace.py $tag/$sel$var/comb.txt -P HHModel:HHdefault -o $tag/$sel$var/comb.root
+done

--- a/limits/physicsModels/HHModel.py
+++ b/limits/physicsModels/HHModel.py
@@ -1,0 +1,462 @@
+###################################
+# Author : L. Cadamuro (UF)
+# Date   : 11/03/2020
+# Brief  : code that implements the HH model in combine
+# structure of the code :
+# xxHHSample  -> defines the interface to the user, that will pass the xs and the coupling setups
+# xxHHFormula -> implements the matrix component representation, that calculates the symbolic scalings
+# HHModel     -> implements the interfaces to combine
+###################################
+
+
+from HiggsAnalysis.CombinedLimit.PhysicsModel import *
+from sympy import *
+from numpy import matrix
+from numpy import linalg
+from sympy import Matrix
+
+
+class VBFHHSample:
+    def __init__(self, val_CV, val_C2V, val_kl, val_xs, label):
+        self.val_CV  = val_CV
+        self.val_C2V = val_C2V
+        self.val_kl  = val_kl
+        self.val_xs  = val_xs
+        self.label   = label
+
+####################
+
+class GGFHHSample:
+    def __init__(self, val_kl, val_kt, val_xs, label):
+        self.val_kl  = val_kl
+        self.val_kt  = val_kt
+        self.val_xs  = val_xs
+        self.label   = label
+
+####################
+
+class VBFHHFormula:
+    def __init__(self, sample_list):
+        self.sample_list = sample_list
+        self.build_matrix()
+        self.calculatecoeffients()        
+
+    def build_matrix(self):    
+        """ create the matrix M in this object """
+
+        if len(self.sample_list) != 6:
+            print "[ERROR] : expecting 6 samples in input"
+            raise RuntimeError("malformed vbf input sample list")
+        M_tofill = [
+            [None,None,None,None,None,None],
+            [None,None,None,None,None,None],
+            [None,None,None,None,None,None],
+            [None,None,None,None,None,None],
+            [None,None,None,None,None,None],
+            [None,None,None,None,None,None]
+        ]
+
+        for isample, sample in enumerate(self.sample_list):
+            # print isample, " CV, C2V, kl = ", sample.val_CV, sample.val_C2V, sample.val_kl
+            
+            ## implement the 6 scalings
+            M_tofill[isample][0] = sample.val_CV**2 * sample.val_kl**2
+            M_tofill[isample][1] = sample.val_CV**4
+            M_tofill[isample][2] = sample.val_C2V**2
+            M_tofill[isample][3] = sample.val_CV**3 * sample.val_kl
+            M_tofill[isample][4] = sample.val_CV    * sample.val_C2V    * sample.val_kl
+            M_tofill[isample][5] = sample.val_CV**2 * sample.val_C2V
+        
+        # print M_tofill
+        self.M = Matrix(M_tofill)
+
+    def calculatecoeffients(self):
+        """ create the function sigma and the six coefficients in this object """
+
+        try: self.M
+        except AttributeError: self.build_matrix()
+        
+        ##############################################    
+        CV, C2V, kl, a, b, c, iab, iac, ibc, s1, s2, s3, s4, s5, s6 = symbols('CV C2V kl a b c iab iac ibc s1 s2 s3 s4 s5 s6')    
+        ### the vector of couplings
+        c = Matrix([
+            [CV**2 * kl**2] ,
+            [CV**4]         ,
+            [C2V**2]        ,
+            [CV**3 * kl]    ,
+            [CV * C2V * kl] ,
+            [CV**2 * C2V]   
+        ])
+        ### the vector of components
+        v = Matrix([
+            [a]   ,
+            [b]   ,
+            [c]   ,
+            [iab] ,
+            [iac] ,
+            [ibc]  
+        ])    
+        ### the vector of samples (i.e. cross sections)
+        s = Matrix([
+            [s1] ,
+            [s2] ,
+            [s3] ,
+            [s4] ,
+            [s5] ,
+            [s6] 
+        ])    
+        ####    
+        Minv   = self.M.inv()
+        self.coeffs = c.transpose() * Minv # coeffs * s is the sigma, accessing per component gives each sample scaling
+        self.sigma  = self.coeffs*s
+
+####################
+
+class GGFHHFormula:
+    def __init__(self, sample_list):
+        self.sample_list = sample_list
+        self.build_matrix()
+        self.calculatecoeffients()        
+
+    def build_matrix(self):    
+        """ create the matrix M in this object """
+
+        if len(self.sample_list) != 3:
+            print "[ERROR] : expecting 3 samples in input"
+            raise RuntimeError("malformed ggf input sample list")
+        M_tofill = [
+            [None,None,None],
+            [None,None,None],
+            [None,None,None],
+        ]
+
+        for isample, sample in enumerate(self.sample_list):
+            
+            ## implement the 3 scalings - box, triangle, interf
+            M_tofill[isample][0] = sample.val_kt**4
+            M_tofill[isample][1] = sample.val_kt**2 * sample.val_kl**2
+            M_tofill[isample][2] = sample.val_kt**3 * sample.val_kl
+
+        # print M_tofill
+        self.M = Matrix(M_tofill)
+
+    def calculatecoeffients(self):
+        """ create the function sigma and the six coefficients in this object """
+
+        try: self.M
+        except AttributeError: self.build_matrix()
+
+        ##############################################    
+        kl, kt, box, tri, interf, s1, s2, s3 = symbols('kl kt box tri interf s1 s2 s3')
+        
+        ### the vector of couplings
+        c = Matrix([
+            [kt**4]         ,
+            [kt**2 * kl**2] ,
+            [kt**3 * kl]    ,
+        ])
+        ### the vector of components
+        v = Matrix([
+            [box]   ,
+            [tri]   ,
+            [interf],
+        ])    
+        ### the vector of samples (i.e. cross sections)
+        s = Matrix([
+            [s1] ,
+            [s2] ,
+            [s3]
+        ])    
+        ####    
+        Minv   = self.M.inv()
+        self.coeffs = c.transpose() * Minv # coeffs * s is the sigma, accessing per component gives each sample scaling
+        self.sigma  = self.coeffs*s
+
+####################
+
+class HHModel(PhysicsModel):
+    """ Models the HH production as linear sum of 6 components (VBF) and 3 components (GGF) """
+    
+    def __init__(self, ggf_sample_list, vbf_sample_list, name):
+        PhysicsModel.__init__(self)
+
+        self.name            = name
+
+        self.check_validity_ggf(ggf_sample_list)
+        self.check_validity_vbf(vbf_sample_list)
+
+        self.ggf_formula = GGFHHFormula(ggf_sample_list)
+        self.vbf_formula = VBFHHFormula(vbf_sample_list)
+
+        self.dump_inputs()
+
+    def check_validity_ggf(self, ggf_sample_list):
+        if len(ggf_sample_list) != 3:
+            raise RuntimeError("%s : malformed GGF input sample list - expect 3 samples" % self.name)
+        if not isinstance(ggf_sample_list, list) and not isinstance(ggf_sample_list, tuple):
+            raise RuntimeError("%s : malformed GGF input sample list - expect list or tuple" % self.name)
+        for s in ggf_sample_list:
+            if not isinstance(s, GGFHHSample):
+                raise RuntimeError("%s : malformed GGF input sample list - each element must be a GGFHHSample" % self.name)
+
+    def check_validity_vbf(self, vbf_sample_list):
+        if len(vbf_sample_list) != 6:
+            raise RuntimeError("%s : malformed VBF input sample list - expect 6 samples" % self.name)
+        if not isinstance(vbf_sample_list, list) and not isinstance(vbf_sample_list, tuple):
+            raise RuntimeError("%s : malformed VBF input sample list - expect list or tuple" % self.name)
+        for s in vbf_sample_list:
+            if not isinstance(s, VBFHHSample):
+                raise RuntimeError("%s : malformed VBF input sample list - each element must be a VBFHHSample" % self.name)
+
+    def dump_inputs(self):
+        print "[INFO]  HH model : " , self.name
+        print "......  GGF configuration"
+        for i,s in enumerate(self.ggf_formula.sample_list):
+            print "        {0:<3} ... kl : {1:<3}, kt : {2:<3}, xs : {3:<3.8f} pb, label : {4}".format(i, s.val_kl, s.val_kt, s.val_xs, s.label)
+        print "......  VBF configuration"
+        for i,s in enumerate(self.vbf_formula.sample_list):
+            print "        {0:<3} ... CV : {1:<3}, C2V : {2:<3}, kl : {3:<3}, xs : {4:<3.8f} pb, label : {5}".format(i, s.val_CV, s.val_C2V, s.val_kl, s.val_xs, s.label)
+
+    def doParametersOfInterest(self):
+        
+        ## the model is built with:
+        ## r x [GGF + VBF]
+        ## GGF = r_GGF x [sum samples(kl, kt)] 
+        ## VBF = r_VBF x [sum samples(kl, CV, C2V)] 
+        
+        POIs = "r,r_gghh,r_qqhh,CV,C2V,kl,kt"
+        
+        self.modelBuilder.doVar("r[1,0,10]")
+        self.modelBuilder.doVar("r_gghh[1,0,10]")
+        self.modelBuilder.doVar("r_qqhh[1,0,10]")
+        self.modelBuilder.doVar("CV[1,-10,10]")
+        self.modelBuilder.doVar("C2V[1,-10,10]")
+        self.modelBuilder.doVar("kl[1,-30,30]")
+        self.modelBuilder.doVar("kt[1,-10,10]")
+        
+        self.modelBuilder.doSet("POI",POIs)
+
+        self.modelBuilder.out.var("r_gghh") .setConstant(True)
+        self.modelBuilder.out.var("r_qqhh") .setConstant(True)
+        self.modelBuilder.out.var("CV")     .setConstant(True)
+        self.modelBuilder.out.var("C2V")    .setConstant(True)
+        self.modelBuilder.out.var("kl")     .setConstant(True)
+        self.modelBuilder.out.var("kt")     .setConstant(True)
+
+        self.create_scalings()
+
+    def create_scalings(self):
+        """ create the functions that scale the six components of vbf and the 3 components of ggf """
+
+        self.f_r_vbf_names = [] # the RooFormulae that scale the components (VBF)
+        self.f_r_ggf_names = [] # the RooFormulae that scale the components (GGF)
+
+        def pow_to_mul_string(expr):
+            """ Convert integer powers in an expression to Muls, like a**2 => a*a. Returns a string """
+            pows = list(expr.atoms(Pow))
+            if any(not e.is_Integer for b, e in (i.as_base_exp() for i in pows)):
+                raise ValueError("A power contains a non-integer exponent")
+            s = str(expr)
+            repl = zip(pows, (Mul(*[b]*e,evaluate=False) for b,e in (i.as_base_exp() for i in pows)))
+            for fr, to in repl:
+                s = s.replace(str(fr), str(to))
+            return s
+
+        ### loop on the GGF scalings
+        for i, s in enumerate(self.ggf_formula.sample_list):
+            f_name = 'f_ggfhhscale_sample_{0}'.format(i)
+            f_expr = self.ggf_formula.coeffs[i] # the function that multiplies each sample
+
+            # print f_expr
+            # for ROOFit, this will convert expressions as a**2 to a*a
+            s_expr = pow_to_mul_string(f_expr)
+
+            couplings_in_expr = []
+            if 'kl'  in s_expr: couplings_in_expr.append('kl')
+            if 'kt'  in s_expr: couplings_in_expr.append('kt')
+
+            # no constant expressions are expected
+            if len(couplings_in_expr) == 0:
+                raise RuntimeError('GGF HH : scaling expression has no coefficients')
+            
+            for idx, ce in enumerate(couplings_in_expr):
+                # print '..replacing', ce
+                symb = '@{}'.format(idx)
+                s_expr = s_expr.replace(ce, symb)
+
+            arglist = ','.join(couplings_in_expr)
+            exprname = 'expr::{}(\"{}\" , {})'.format(f_name, s_expr, arglist)
+            # print exprname
+            self.modelBuilder.factory_(exprname) # the function that scales each VBF sample
+
+            f_prod_name_pmode = f_name + '_r_gghh'
+            prodname_pmode = 'prod::{}(r_gghh,{})'.format(f_prod_name_pmode, f_name)
+            self.modelBuilder.factory_(prodname_pmode)  ## the function that scales this production mode
+            # self.modelBuilder.out.function(f_prod_name).Print("") ## will just print out the values
+
+            f_prod_name = f_prod_name_pmode + '_r'
+            prodname = 'prod::{}(r,{})'.format(f_prod_name, f_prod_name_pmode)
+            self.modelBuilder.factory_(prodname)  ## the function that scales this production mode
+            # self.modelBuilder.out.function(f_prod_name).Print("") ## will just print out the values
+
+            self.f_r_ggf_names.append(f_prod_name) #bookkeep the scaling that has been created
+
+        ### loop on the VBF scalings
+        for i, s in enumerate(self.vbf_formula.sample_list):
+            f_name = 'f_vbfhhscale_sample_{0}'.format(i)
+            f_expr = self.vbf_formula.coeffs[i] # the function that multiplies each sample
+
+            # print f_expr
+            # for ROOFit, this will convert expressions as a**2 to a*a
+            s_expr = pow_to_mul_string(f_expr)
+
+            couplings_in_expr = []
+            if 'CV'  in s_expr: couplings_in_expr.append('CV')
+            if 'C2V' in s_expr: couplings_in_expr.append('C2V')
+            if 'kl'  in s_expr: couplings_in_expr.append('kl')
+
+            # no constant expressions are expected
+            if len(couplings_in_expr) == 0:
+                raise RuntimeError('VBF HH : scaling expression has no coefficients')
+            
+            for idx, ce in enumerate(couplings_in_expr):
+                # print '..replacing', ce
+                symb = '@{}'.format(idx)
+                s_expr = s_expr.replace(ce, symb)
+
+            arglist = ','.join(couplings_in_expr)
+            exprname = 'expr::{}(\"{}\" , {})'.format(f_name, s_expr, arglist)
+            # print exprname
+            self.modelBuilder.factory_(exprname) # the function that scales each VBF sample
+
+            f_prod_name_pmode = f_name + '_r_qqhh'
+            prodname_pmode = 'prod::{}(r_qqhh,{})'.format(f_prod_name_pmode, f_name)
+            self.modelBuilder.factory_(prodname_pmode)  ## the function that scales this production mode
+            # self.modelBuilder.out.function(f_prod_name_pmode).Print("") ## will just print out the values
+
+            f_prod_name = f_prod_name_pmode + '_r'
+            prodname = 'prod::{}(r,{})'.format(f_prod_name, f_prod_name_pmode)
+            self.modelBuilder.factory_(prodname)  ## the function that scales this production mode
+            # self.modelBuilder.out.function(f_prod_name).Print("") ## will just print out the values
+
+            self.f_r_vbf_names.append(f_prod_name) #bookkeep the scaling that has been created
+
+    def getYieldScale(self,bin,process):
+        
+        ## my control to verify for a unique association between process <-> scaling function
+        try:
+            self.scalingMap
+        except AttributeError:
+            self.scalingMap = {}
+
+        if not self.DC.isSignal[process]: return 1
+        # match the process name in the datacard to the input sample of the calculation
+        # this is the only point where the two things must be matched
+
+        if not process in self.scalingMap:
+            self.scalingMap[process] = []
+
+        imatched_ggf = []
+        imatched_vbf = []
+
+        for isample, sample in enumerate(self.ggf_formula.sample_list):
+            if process.startswith(sample.label):
+                # print self.name, ": {:>40}  ===> {:>40}".format(process, sample.label)
+                imatched_ggf.append(isample)
+
+        for isample, sample in enumerate(self.vbf_formula.sample_list):
+            if process.startswith(sample.label):
+                # print self.name, ": {:>40}  ===> {:>40}".format(process, sample.label)
+                imatched_vbf.append(isample)
+
+        ## this checks that a process finds a unique scaling
+        if len(imatched_ggf) + len(imatched_vbf) != 1:
+            print "[ERROR] : in HH model named", self.name, "there are", len(imatched_ggf), "GGF name matches and", len(imatched_vbf), "VBF name matches"
+            raise RuntimeError('HHModel : could not uniquely match the process %s to the expected sample list' % process)
+
+        if len(imatched_ggf) == 1:
+            isample = imatched_ggf[0]
+            self.scalingMap[process].append((isample, 'GGF'))
+            return self.f_r_ggf_names[isample]
+        
+        if len(imatched_vbf) == 1:
+            isample = imatched_vbf[0]
+            self.scalingMap[process].append((isample, 'VBF'))
+            return self.f_r_vbf_names[isample]
+
+        raise RuntimeError('HHModel : fatal error in getYieldScale - this should never happen')
+
+    def done(self):
+        ## this checks that a scaling has been attached to a unique process
+        scalings = {}
+        for k, i in self.scalingMap.items(): ## key -> process, item -> [(isample, 'type')]
+            samples = list(set(i)) # remove duplicates
+            for s in samples:
+                if not s in scalings:
+                    scalings[s] = []
+                scalings[s].append(k)
+
+        for key, val in scalings.items():
+            if len(val) > 1:
+                print "[ERROR] : in HH model named", self.name, "there is a double assignment of a scaling : ", key, " ==> ", val
+                raise RuntimeError('HHModel : coudl not uniquely match the scaling to the process')
+
+        ## now check that, if a VBF/GGF scaling exists, there are actually 6/3 samples in the card
+        n_VBF = 0
+        n_GGF = 0
+        for k, i in self.scalingMap.items():
+            # the step above ensured me that the list contains a single element -> i[0]
+            if i[0][1] == "GGF":
+                n_GGF += 1
+            elif i[0][1] == "VBF":
+                n_VBF += 1
+            else:
+                raise RuntimeError("HHModel : unrecognised type %s - should never happen" % i[0][1])
+
+        if n_GGF > 0 and n_GGF != 3:
+            raise RuntimeError("HHModel : you did not pass all the 3 samples needed to build the GGF HH model")
+        
+        if n_VBF > 0 and n_VBF != 6:
+            raise RuntimeError("HHModel : you did not pass all the 6 samples needed to build the VBF HH model")
+
+########################################################
+# definition of the model inputs
+
+## NOTE : the scaling functions are not sensitive to global scalings of the xs of each sample
+## so by convention use val_xs of the samples *without* the decay BR
+
+## NOTE 2 : the xs *must* correspond to the generator one
+
+# VBF : val_CV, val_C2V, val_kl
+VBF_sample_list = [
+    VBFHHSample(1,1,1,   val_xs = 0.00054/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_1'  ),
+    VBFHHSample(1,2,1,   val_xs = 0.00472/(0.3364), label = 'qqHH_CV_1_C2V_2_kl_1'  ),
+    VBFHHSample(1,1,2,   val_xs = 0.00044/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_2'  ),
+    VBFHHSample(1,1,0,   val_xs = 0.00145/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_0'  ),
+    VBFHHSample(0.5,1,1, val_xs = 0.00353/(0.3364), label = 'qqHH_CV_0p5_C2V_1_kl_1'),
+    VBFHHSample(1.5,1,1, val_xs = 0.02149/(0.3364), label = 'qqHH_CV_1p5_C2V_1_kl_1'),
+]
+
+# VBF : val_kl, val_kt
+GGF_sample_list = [
+    GGFHHSample(1,1,      val_xs = 0.02675, label = 'ggHH_kl_1_kt_1'  ),
+    #GGFHHSample(0,1,      val_xs = 0.06007, label = 'ggHH_kl_0_kt_1'  ),
+    GGFHHSample(5,1,      val_xs = 0.07903, label = 'ggHH_kl_5_kt_1'  ),
+    GGFHHSample(2.45,1,   val_xs = 0.01133, label = 'ggHH_kl_2p45_kt_1'  ),
+]
+
+HHdefault = HHModel(
+    ggf_sample_list = GGF_sample_list,
+    vbf_sample_list = VBF_sample_list,
+    name            = 'HHdefault'
+)
+
+# g = GGFHHFormula(GGF_sample_list)
+# print g.sigma
+# print g.sigma.evalf(subs = {
+#     kl : 2.45,
+#     kt : 1.0,
+#     s1 : s.sample_list[0].val_xs,
+#     s2 : s.sample_list[1].val_xs,
+#     s3 : s.sample_list[2].val_xs,
+# })

--- a/limits/prepare_histos.py
+++ b/limits/prepare_histos.py
@@ -1,0 +1,121 @@
+import sys, pwd, commands, optparse
+from ROOT import *
+
+def parseOptions():
+
+    usage = ('usage: %prog [options] datasetList\n'
+             + '%prog -h for help')
+    parser = optparse.OptionParser(usage)
+    
+    parser.add_option('-f', '--filename',   dest='filename',   type='string', default="",  help='input plots')
+    parser.add_option('-o', '--outfile',   dest='outName',   type='string', default="w",  help='output suffix')
+    parser.add_option('-c', '--channel',   dest='channel',   type='string', default="TauTau",  help='channel')
+
+    # store options and arguments as global variables
+    global opt, args
+    (opt, args) = parser.parse_args()
+
+
+listHistos = []
+systNamesOUT=["CMS_scale_t_13TeV_DM0"] #,"CMS_scale_j_13TeV"]
+systNames=["tesXXX_DM0"] #<--- to fix
+
+
+
+parseOptions()
+print "Running"
+inFile = TFile.Open(opt.filename)
+ih = 0
+toth = len (inFile.GetListOfKeys())
+
+histos_syst_up = []
+histos_syst_down = []
+
+yieldFolder = "scales2018/"
+
+#procnames = [ "TT", "WJets", "TW","EWK", "WW", "WW", "WZ", "ZH","other", "ZZ", "DY0b","DY1b", "DY2b","GGHH_NLO_"]
+procnames = ["DY","GGHH_NLO_"]
+
+ih = 0
+
+
+
+for key in inFile.GetListOfKeys() :
+	ih = ih + 1
+	if (ih%100 == 0) : print key,ih,"/",toth
+	kname = key.GetName()
+	template = inFile.Get(kname)
+
+	if "GGHH_NLO" in kname: kname = kname.replace("GGHH_NLO","ggHH").replace("_xs","_kt_1_bbtt").replace("cHHH", "kl_")
+        if "VBFHH"    in kname: kname = kname.replace("VBFHH","qqHH").replace("C3","kl") #write 1_5 as 1p5 from the beginning
+
+        print kname
+	#protection against empty bins
+	changedInt = False
+	for ibin in range(1,template.GetNbinsX()+1) :
+		integral = template.Integral()
+		if template.GetBinContent(ibin) <= 0 :
+			changedInt = True
+			template.SetBinContent(ibin,0.000001)
+			template.SetBinError(ibin,0.000001)
+
+                    
+	if template.Integral()>0 and changedInt : template.Scale(integral/template.Integral())
+	if "TH1" in template.ClassName(): 
+		for isyst in range(len(systNames)):
+			lineToCheckDown = systNames[isyst].replace('XXX',"down").replace("tes","tau")
+			lineToCheckUp = systNames[isyst].replace('XXX',"up").replace("tes","tau")
+			found = -1
+                        print '---->', lineToCheckDown
+			if lineToCheckDown in kname :
+				appString = "Down"
+				remString = "down"
+				found = 1
+			elif lineToCheckUp in kname:
+				appString = "Up"
+				remString = "up"
+				found =0
+			if found>=0 :
+				names = kname.split("_")
+                                for i in range(0,len(names)):
+                                    print names[i]
+                                    if (names[i].startswith('s') or names[i].startswith('VBFloose')):
+					for j in range(1, i):
+                                            names[0] += "_"+str(names[j])
+                                        names[1] = names[i]
+                                        break
+				proc = names[0]
+				#print names
+				yieldName=yieldFolder+"/"+opt.channel+"_"+names[1]
+				yieldName =yieldName+'_'+systNames[isyst].replace('XXX','')+".txt"
+				infile = open(yieldName)
+				scale = 1.000
+				for line in infile :
+					words = line.split()
+					if words[0] == proc :
+						#print "found ",words, proc,float(words[1+found])
+						scale = float(words[1+found])
+						break
+				template.Scale(scale)
+				#print proc,scale,yieldName
+				#if abs(1-scale)>0.02 : print "correct",yieldName, proc,scale
+				kname = kname.replace("_"+systNames[isyst].replace('XXX',remString).replace("tes","tau"),"")
+				#print "toReplace:",systNames[isyst]+remString,"temporary:", newName
+				kname = kname + "_"+ systNamesOUT[isyst] + appString
+				print kname
+		template.SetName(kname)
+		template.SetTitle(kname)
+		listHistos.append(template.Clone())
+
+outFile = TFile.Open("analyzedOutPlotter_{0}_{1}.root".format(opt.channel, opt.outName),"RECREATE")
+outFile.cd()
+
+for h in listHistos :
+	h.Write()
+for h in histos_syst_up:
+	h.Write()
+for h in histos_syst_down:
+	h.Write()
+
+outFile.Close()
+

--- a/limits/prepare_histos.sh
+++ b/limits/prepare_histos.sh
@@ -1,0 +1,6 @@
+input='../analysis_TauTau_synch_11June2020_limits_prova'
+
+# prepare files with yield variations
+python compute_scales.py
+# prepare histograms with systematics 
+python prepare_histos.py -f ../analysis_TauTau_synch_11June2020_limits_prova/analyzedOutPlotter.root -o prova -c TauTau

--- a/limits/systReader.py
+++ b/limits/systReader.py
@@ -1,0 +1,133 @@
+#!/usr/bin/python
+import os
+import re
+import math
+import collections
+from ROOT import *
+from array import array
+
+class systReader:
+
+    def __init__(self, inputTextFile,signalList,backgroundList,outputFile):
+
+        if not os.path.exists(inputTextFile):
+            raise RuntimeError, "File {0} does not exist!!!".format(inputTextFile)
+        
+        # input file
+        self.theInput = [inputTextFile]
+        self.channels = signalList+backgroundList
+        self.theOutputFile = outputFile
+        #self.OutputLines = []
+        self.writeOut = True
+        self.printResult = True
+
+        self.SystNames = []
+        self.SystTypes = []
+        self.SystProcesses = []
+        self.SystValues = []
+
+    def addSystFile(self, theOtherFile):
+        self.theInput.append(theOtherFile)
+
+    def writeSystematics(self):
+        print "reading systematics"
+        section = ""
+        outputLine = ""
+        OutputLines = []
+        activeProc = []
+        activeVal = []
+        systLine={'ggH':"- "}
+        for chan in self.channels :
+            systLine[chan] = "- "
+
+        #varYname = ""
+        #varnames = []
+        for ifile in range(len(self.theInput)):
+            print "reading systematics"
+            section = ""
+            outputLine = ""
+            activeProc = []
+            activeVal = []
+            for chan in self.channels :
+                systLine[chan] = "- "
+            for line in open(self.theInput[ifile],'r'):
+                f = line.split()
+                #print f
+                if len(f) < 1: continue
+                if f[0].startswith("#"): continue
+
+                if f[0].startswith('['):
+                    f = re.split('\W+',line)
+                    section = f[1]
+                    newSection = True
+
+                    #print "before ",outputLine
+                    if outputLine is not "" :
+                        #OutputLines.append(outputLine)
+                        for chan in self.channels :
+                            outputLine += systLine[chan]
+                            systLine[chan] = "- "
+
+                        OutputLines.append(outputLine)
+                        if self.printResult : print outputLine
+                        outputLine = ""
+                        self.SystProcesses.append(activeProc)
+                        self.SystValues.append(activeVal)
+                        activeProc = []
+                        activeVal = []
+
+                    if self.printResult : print "writing syst for ", section
+                    self.SystNames.append(section)
+                    continue
+                
+                if f[0] == "type":
+                    #print "TYPE: ",f
+                    outputLine+=section+" "+f[2]+" "
+                    self.SystTypes.append(f[2])
+                    continue
+                elif f[0] == "param":
+                    outputLine=section+" "+line
+                    continue
+                for chan in self.channels:
+                    #print "SYST: ",f
+                    if chan == f[0]: 
+                        systLine[chan] = " "+f[2]+" "
+                        activeProc.append(f[0])
+                        activeVal.append(f[2])
+            #indent qui
+            for chan in self.channels :
+                if not "param" in outputLine: 
+                    outputLine += systLine[chan]
+            OutputLines.append(outputLine)
+            if self.printResult : print outputLine
+            self.SystProcesses.append(activeProc)
+            self.SystValues.append(activeVal)
+        if self.printResult : 
+            for line in OutputLines:
+                print outputLine
+        if self.writeOut:
+            for line in OutputLines:
+                self.theOutputFile.write(line+"\n")
+
+    def writeOneLine(self,channel,string,value=1):
+        outputLine = string
+        #print "channels:", channel
+        for chan in self.channels :
+            #print chan
+            if (chan in channel) or ("bkg_"+chan in channel) :
+                outputLine += str(value)+" "
+            else:
+                outputLine += "- "
+        self.theOutputFile.write(outputLine+"\n")
+
+    def writeOutput(self,doWrite) :
+        self.writeOut = doWrite
+
+    def verbose(self, v) :
+        self.printResult = v
+
+
+
+
+
+

--- a/limits/write_card.py
+++ b/limits/write_card.py
@@ -1,0 +1,368 @@
+#! /usr/bin/env python
+import sys, pwd, commands, optparse
+import os
+import re
+import math
+import string
+from scipy.special import erf
+from ROOT import *
+import ROOT
+from ConfigReader import *
+from systReader import *
+
+
+def parseOptions():
+
+    usage = ('usage: %prog [options] datasetList\n'
+             + '%prog -h for help')
+    parser = optparse.OptionParser(usage)
+    
+    parser.add_option('-f', '--filename',   dest='filename',   type='string', default="",  help='input plots')
+    parser.add_option('-o', '--dir', dest='outDir', type='string', default='', help='outdput dir')
+    parser.add_option('-c', '--channel',   dest='channel', type='string', default='TauTau',  help='final state')
+    parser.add_option('-i', '--config',   dest='config', type='string', default='',  help='config file')
+    parser.add_option('-s', '--selection', dest='overSel', type='string', default='', help='overwrite selection string')
+    parser.add_option('-r', '--resonant',  action="store_true",  dest='isResonant', help='is Resonant analysis')
+    parser.add_option('-y', '--binbybin',  action="store_true", dest='binbybin', help='add bin by bins systematics')
+    parser.add_option('-t', '--theory',  action="store_true", dest='theory', help='add theory systematics')
+    parser.add_option('-u', '--shape', dest='shapeUnc', type='int', default=1, help='1:add 0:disable shape uncertainties')
+    parser.add_option('--ws', dest='makeworkspace', default=False, action = 'store_true')
+
+
+    # store options and arguments as global variables
+    global opt, args
+    (opt, args) = parser.parse_args()
+
+def  writeCard(backgrounds,signals, select,region=-1) :
+
+        variable = 'DNNoutSM_kl_1'
+
+	theOutputDir = "{0}{1}".format(select,variable)
+	dname = "_"+opt.channel+opt.outDir
+	out_dir = "cards{1}/{0}/".format(theOutputDir,dname)
+
+	cmd = "mkdir -p {0}".format(out_dir)
+        
+        regionName = ["","regB","regC","regD"]
+	regionSuffix = ["SR","SStight","OSinviso","SSinviso"]
+	status, output = commands.getstatusoutput(cmd)   
+	thechannel = "2"
+	if opt.channel == "ETau" : thechannel="1"
+	elif opt.channel == "MuTau" : thechannel = "0"
+
+	if "0b0j" in select : theCat = "0"
+	if "2b0j" in select : theCat = "2"
+	elif "1b1j" in select : theCat = "1"
+	elif "boosted" in select : theCat = "3"
+	elif "VBFloose" in select : theCat = "4"
+
+
+	outFile = "hh_{0}_C{1}_13TeV.txt".format(thechannel,theCat)
+
+	file = open(out_dir+outFile, "wb")
+
+
+	#read config
+	categories = []
+	categories.append((0,select))
+	MCbackgrounds=[]
+	processes=[]
+	inRoot = TFile.Open(opt.filename)
+	for bkg in backgrounds:
+		#Add protection against empty processes => If I remove this I could build all bins at once instead of looping on the selections
+		templateName = "{0}_{1}_SR_{2}".format(bkg,select,variable)
+		template = inRoot.Get(templateName)
+		if template.Integral()>0.000001 :
+			processes.append(bkg)
+			if bkg is not "QCD" :
+                            MCbackgrounds.append(bkg)
+
+	allQCD = False
+	allQCDs = [0,0,0,0]
+	for regionsuff in range(len(regionSuffix)) :
+		for ichan in range(len(backgrounds)):
+			if "QCD" in backgrounds[ichan] :
+				fname = "data_obs"
+				if regionSuffix[regionsuff] == "SR" :
+					fname="QCD"
+				templateName = "{0}_{1}_{3}_{2}".format(fname,select,variable,regionSuffix[regionsuff])
+				template = inRoot.Get(templateName)
+				#allQCDs.append(template.Integral())
+				allQCDs[regionsuff]= allQCDs[regionsuff]+template.Integral()
+				iQCD = ichan
+			elif regionSuffix[regionsuff] is not "SR" :
+				templateName = "{0}_{1}_{3}_{2}".format(backgrounds[ichan],select,variable,regionSuffix[regionsuff])
+				template = inRoot.Get(templateName)
+				allQCDs[regionsuff] = allQCDs[regionsuff] - template.Integral()
+
+	if allQCDs[0]>0 and allQCDs[1]>0 and allQCDs[2]>0 and allQCDs[3]>0 : allQCD = True
+	for i in range(4) : print allQCDs[i]
+
+        rates = []
+        iQCD = -1
+        totRate = 0
+        templateName = "data_obs_{0}_{2}_{1}".format(select,variable,regionSuffix[region])
+        template = inRoot.Get(templateName)
+        obs = template.GetEntries()
+
+        for proc in range(len(backgrounds)):
+            if "QCD" in backgrounds[proc] :
+                rates.append(-1)
+                iQCD = proc
+            else :
+                templateName = "{0}_{1}_{3}_{2}".format(backgrounds[proc],select,variable,regionSuffix[region])
+                template = inRoot.Get(templateName)
+
+                brate = template.Integral()
+                rates.append(brate)
+                totRate = totRate + brate
+        if iQCD >= 0 : rates[iQCD] = TMath.Max(0.0000001,obs-totRate)
+
+        for proc in range(len(signals)):
+            templateName = "{0}_{1}_{3}_{2}".format(signals[proc],select,variable,regionSuffix[region])
+            template = inRoot.Get(templateName)
+
+            srate = template.Integral()
+            rates.append(srate)
+        if region == 0 :
+            syst = systReader("../config/systematics.cfg",signals,backgrounds,file)
+            syst.writeOutput(False)
+            syst.verbose(True)
+            if(opt.channel == "TauTau" ): 
+                syst.addSystFile("../config/systematics_tautau.cfg")
+            elif(opt.channel == "MuTau" ): 
+                syst.addSystFile("../config/systematics_mutau.cfg")
+            elif(opt.channel == "ETau" ): 
+                syst.addSystFile("../config/systematics_etau.cfg")
+            if opt.theory : syst.addSystFile("../config/syst_th.cfg")
+            syst.writeSystematics()
+            proc_syst = {} # key = proc name; value = {systName: [systType, systVal]] } # too nested? \_(``)_/
+            for proc in backgrounds:
+                proc_syst[proc] = {}
+            for proc in signals:
+                proc_syst[proc] = {}
+
+
+            for isy in range(len(syst.SystNames)) :
+                if "CMS_scale_t" in syst.SystNames[isy] or "CMS_scale_j" in syst.SystNames[isy]: continue
+                for iproc in range(len(syst.SystProcesses[isy])) :
+                    if "/" in syst.SystValues[isy][iproc] :
+                        f = syst.SystValues[isy][iproc].split("/")
+                        systVal = (float(f[0]),float(f[1]))
+                    else :
+                        systVal = float(syst.SystValues[isy][iproc])
+                        print "adding Syst",systVal,syst.SystNames[isy],syst.SystTypes[isy],"to",syst.SystProcesses[isy][iproc]                        
+                        proc_syst[syst.SystProcesses[isy][iproc]][syst.SystNames[isy]] = [syst.SystTypes[isy], systVal]
+
+            if opt.shapeUnc > 0:
+                for proc in MCbackgrounds:    #applying jes or tes to all MC backgrounds
+                    proc_syst[proc]["CMS_scale_t_13TeV_DM0"] = ["shape", 1.]
+                for proc in signals:          #applying jes or tes to all signals backgrounds
+                    proc_syst[proc]["CMS_scale_t_13TeV_DM0"] = ["shape", 1.]
+            #proc_syst["TT"]["top"] = ["shape", 1]
+            
+
+        col1 = '{: <35}'
+        cols = '{: >25}'
+        ratecols = '{0: > 25.4f}'
+
+        shapes_lines_toWrite = []
+        lnN_lines_toWrite     = []
+
+	for proc in backgrounds:
+            if region == 0:	    
+                for systName, systL in proc_syst[proc].items():
+                    if systL == "shape": 
+                        shapes_lines_toWrite.append(col1.format(proc+"_"+select+"_"+variable+"_"+regionSuffix[region]))
+                        shapes_lines_toWrite.append(cols.format("shape"))
+                        for lineproc in backgrounds: shapes_lines_toWrite.append(cols.format("1" if lineproc == proc else "-"))
+                        for lineproc in signals:     shapes_lines_toWrite.append(cols.format("-"))
+                        shapes_lines_toWrite.append("\n")
+                    else: 
+                        lnN_lines_toWrite.append(col1.format(proc+"_"+select+"_"+variable+"_"+regionSuffix[region]))
+                        lnN_lines_toWrite.append(cols.format("lnN"))
+                        for lineproc in backgrounds: lnN_lines_toWrite.append(cols.format(systL[1] if lineproc == proc else "-"))
+                        for lineproc in signals:     lnN_lines_toWrite.append(cols.format("-"))
+                        lnN_lines_toWrite.append("\n")
+        for proc in signals:
+            if region == 0:
+                for systName, systL in proc_syst[proc].items():
+                    if systL[0] == "shape":
+                        shapes_lines_toWrite.append(col1.format(proc+"_"+select+"_"+variable+"_"+regionSuffix[region]))
+                        shapes_lines_toWrite.append(cols.format("shape"))
+                        for lineproc in backgrounds: shapes_lines_toWrite.append(cols.format("-"))
+                        for lineproc in signals:     shapes_lines_toWrite.append(cols.format("1" if lineproc == proc else "-"))
+                        shapes_lines_toWrite.append("\n")
+                    else: 
+                        lnN_lines_toWrite.append(col1.format(proc+"_"+select+"_"+variable+"_"+regionSuffix[region]))
+                        lnN_lines_toWrite.append(cols.format("shape"))
+                        for lineproc in backgrounds: lnN_lines_toWrite.append(cols.format("-"))
+                        for lineproc in signals:     lnN_lines_toWrite.append(cols.format(systL[1] if lineproc == proc else "-"))
+                        lnN_lines_toWrite.append("\n")
+
+        ########################
+
+        file.write    ('imax *  number of channels\n')
+        file.write    ('jmax *  number of processes minus 1\n')
+        file.write    ('kmax *  number of nuisance parameters\n')
+        file.write    ('----------------------------------------------------------------------------------------------------------------------------------\n')
+        ## shapes
+
+        file.write    ('shapes * %s %s $PROCESS $PROCESS_$SYSTEMATIC\n'%(select, opt.filename))
+        file.write    ('----------------------------------------------------------------------------------------------------------------------------------\n')
+
+        file.write    ((col1+cols+'\n').format('bin', select)) ### blind for now
+        ## observation
+        file.write    ((col1+cols+'\n').format('observation', '-1')) ### blind for now
+
+        file.write    ('----------------------------------------------------------------------------------------------------------------------------------\n')
+        ## processes 
+        file.write    ('# list the expected events for signal and all backgrounds in that bin\n')
+        file.write    ('# the second process line must have a positive number for backgrounds, and 0 or neg for signal\n')
+        file.write    (col1.format('bin'))
+        for i in range(0,len(backgrounds)+len(signals)): 
+            file.write(cols.format(select))
+        file.write    ("\n")
+        file.write    (col1.format('process'))
+        for proc in backgrounds: 
+            file.write(cols.format(proc))
+        for proc in signals: 
+            file.write(cols.format(proc))
+        file.write    ("\n")
+        file.write    (col1.format("process"))
+        for i in range(1,len(backgrounds)+1): 
+            file.write(cols.format(i))
+        for i in range(0,len(signals)): 
+            file.write(cols.format(str(-int(i))))
+        file.write    ("\n")
+        file.write    (col1.format("rate"))
+        for proc in range(len(backgrounds)+len(signals)):
+            file.write(ratecols.format(rates[proc]))
+        file.write    ("\n")
+        file.write    ('----------------------------------------------------------------------------------------------------------------------------------\n')
+
+        if region ==0:        
+            for line in shapes_lines_toWrite:
+                file.write(line)
+            for line in lnN_lines_toWrite:
+                file.write(line)
+
+            file.write    ('----------------------------------------------------------------------------------------------------------------------------------\n')            
+
+                
+            file.write    ('theory group = HH_BR_Hbb HH_BR_Htt QCDscale_ggHH pdf_ggHH\n')
+                        
+            file.write("alpha rateParam {0} QCD (@0*@1/@2) QCD_regB,QCD_regC,QCD_regD\n".format(select))
+             
+            if (opt.binbybin): file.write('\n* autoMCStats 10')
+
+            file.close()
+	elif allQCD :
+		outFile = "hh_{0}_C{1}_13TeV_{2}.txt".format(thechannel,theCat,regionName[region])
+
+		file = open( out_dir+outFile, "wb")
+
+		file.write("imax 1\n")
+		file.write("jmax {0}\n".format(len(backgrounds)-1))
+		file.write("kmax *\n")
+
+		file.write("------------\n")
+		file.write("shapes * * FAKE\n".format(opt.channel,regionName[region]))
+		file.write("------------\n")
+
+		templateName = "data_obs_{1}_{3}_{2}".format(bkg,select,variable,regionSuffix[region])
+		template = inRoot.Get(templateName)        
+		file.write("bin {0} \n".format(select))
+		obs = template.GetEntries()
+		file.write("observation {0} \n".format(obs))
+
+		file.write("------------\n")
+
+		file.write("bin ")        
+		for chan in backgrounds:
+			file.write("{0}\t ".format(select))
+		file.write("\n")      
+
+		file.write("process ")
+		for chan in backgrounds:
+			file.write("{0}\t ".format(chan))
+
+		file.write("\n")
+
+		file.write("process ")
+		for chan in range(len(backgrounds)): #+1 for the QCD
+			file.write("{0}\t ".format(chan+1))
+		file.write("\n")
+
+		file.write("rate ")
+		rates = []
+		iQCD = -1
+		totRate = 0
+		for ichan in range(len(backgrounds)):
+			if "QCD" in backgrounds[ichan] :
+				rates.append(-1)
+				iQCD = ichan
+			else :
+				templateName = "{0}_{1}_{3}_{2}".format(backgrounds[ichan],select,variable,regionSuffix[region])
+				template = inRoot.Get(templateName)
+				brate = template.Integral()
+				rates.append(brate)
+				totRate = totRate + brate
+		if iQCD >= 0 : rates[iQCD] = TMath.Max(0.0000001,obs-totRate)
+		for ichan in range(len(backgrounds)):
+			file.write("{0:.4f}\t".format(rates[ichan]))
+		file.write("\n")
+		file.write("------------\n")
+		file.write("QCD_{0} rateParam  {1} QCD 1 \n".format(regionName[region],select))
+
+        return (out_dir+outFile)
+
+ROOT.gSystem.AddIncludePath("-I$ROOFITSYS/include/")
+ROOT.gSystem.AddIncludePath("-Iinclude/")
+ROOT.gSystem.Load("libRooFit")
+ROOT.gSystem.Load("libHiggsAnalysisCombinedLimit.so")
+
+parseOptions()
+datacards = []
+configname = opt.config
+print configname
+input = ConfigReader(configname)
+
+
+
+if opt.overSel == "" :
+	allSel = ["s1b1jresolvedMcut", "s2b0jresolvedMcut", "sboostedLLMcut", "VBFloose"]
+else : allSel = [opt.overSel]
+
+data     = input.readListOption("general::data")
+signals     = input.readListOption("general::signals")
+backgrounds = input.readListOption("general::backgrounds")
+
+## replace what was merged
+if input.hasSection("merge"):
+    for groupname in input.config['merge']:
+        mergelist = input.readListOption('merge::'+groupname)
+        mergelistA = input.readOption('merge::'+groupname)
+        theList = None
+        if   mergelist[0] in data: theList = data
+        elif mergelist[0] in signals:  theList = signals
+        elif mergelist[0] in backgrounds:  theList = backgrounds
+        for x in mergelist: theList.remove(x)
+        theList.append(groupname)
+
+backgrounds.append("QCD")
+
+# rename signals following model convention
+for i,sig in enumerate(signals):
+        if "GGHH_NLO" in sig: signals[i] = sig.replace("GGHH_NLO","ggHH").replace("_xs","_kt_1_bbtt").replace("cHHH", "kl_")
+        if "VBFHH"in sig:     signals[i] = sig.replace("VBFHH","qqHH").replace("C3","kl") #write 1_5 as 1p5 from the beginning
+
+datacards = []
+
+for sel in allSel : 
+    for ireg in range(0,4) :
+         card = writeCard(backgrounds,signals, sel,ireg)
+         datacards.append(card)
+
+if opt.makeworkspace:
+    for card in datacards: os.system('text2workspace.py %s -D %s -P HHModel:HHdefault &'%card)


### PR DESCRIPTION
Cleaning of limits scripts, to make it a bit easier to find the way
(a) outPlotter.root files (no need to make analyzedOutPlotter.root) need to be produced containing nominal and up/down selections -> needed to evaluate the acceptance variation due to syst shifts 
    * see ```config/*_syst.cfg```
(b) analyzedOutPlotter.root files should be produced with the nominal selections (if possible, using the nominal discriminant output and it's shifted versions) 
    * see ```config/mainCfg*_limits.cfg```

To prepare the histograms:
1. compute_scales.py uses the outPlotter.root (a) to create txt files containing the acceptance variations for each process
2. prepare_histos.py picks up the txt files created at 1. and prepare correctly normalized and correctly named up/down histograms using the analyzedOutPlotter.root (b)
3. write cards: example for launching write_cards.py in make_cards.sh 
4. make workspaces: example in make_workspaces.sh

example of running combine:
```combine -M AsymptoticLimits --run blind comb.root --redefineSignalPOIs r --setParameters r_gghh=1,kt=1,kl=1```
(tested with ggHH only for now, see [slide 13](https://github.com/camendola/KLUBAnalysis/blob/VBF_legacy/limits/make_workspace.sh) for other examples)

they are working, but still dummy: only tested with tesDM0 up/down, small subset of processes (it should be clear how to replicate with the rest of them though)

missing: commands for combining and feeding the cards to combine


