### PR TITLE
Multiclass updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ cd cms_runII_dnn_models/models/test/
 mv test.cc test.cc_x
 cd -
 
+# Multiclassifier
+git clone https://gitlab.cern.ch/hh/bbtautau/MulticlassInference.git
+
 # HHbtag package
 git clone git@github.com:hh-italian-group/HHbtag.git HHTools/HHbtag
 

--- a/config/skim_Legacy2016_mib.cfg
+++ b/config/skim_Legacy2016_mib.cfg
@@ -148,6 +148,7 @@ doKinFit   = true
 doSVfit    = true
 doDNN      = true
 doBDT      = true
+doMult     = true
 
 doNominal  = false
 doMES      = true

--- a/config/skim_Legacy2016_mib.cfg
+++ b/config/skim_Legacy2016_mib.cfg
@@ -137,6 +137,8 @@ inputFile = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/s
 histoName = allHHNodeMap
 coeffFile = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/coefficientsByBin_extended_3M_costHHSim_19-4.txt
 
+[Multiclass]
+computeMVA = true
 
 [outPutter]
 nMaxEvts = -1 # use -1 to analyze all events

--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -140,6 +140,8 @@ inputFile = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src
 histoName = allHHNodeMap
 coeffFile = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/coefficientsByBin_extended_3M_costHHSim_19-4.txt
 
+[Multiclass]
+computeMVA = true
 
 [outPutter]
 nMaxEvts = -1 # use -1 to analyze all events

--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -151,6 +151,7 @@ doKinFit   = true
 doSVfit    = true
 doDNN      = true
 doBDT      = true
+doMult     = true
 
 doNominal  = false
 doMES      = true

--- a/config/skim_Legacy2018.cfg
+++ b/config/skim_Legacy2018.cfg
@@ -148,6 +148,8 @@ inputFile = /home/llr/cms/amendola/HHLegacy/CMSSW_11_1_0_pre6/src/KLUBAnalysis/w
 histoName = allHHNodeMap
 coeffFile = /home/llr/cms/amendola/HHLegacy/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/coefficientsByBin_extended_3M_costHHSim_19-4.txt
 
+[Multiclass]
+computeMVA = true
 
 [outPutter]
 nMaxEvts = -1 # use -1 to analyze all events

--- a/config/skim_Legacy2018.cfg
+++ b/config/skim_Legacy2018.cfg
@@ -159,6 +159,7 @@ doKinFit   = true
 doSVfit    = true
 doDNN      = true
 doBDT      = true
+doMult     = true
 
 doNominal  = false
 doMES      = true

--- a/test/skimOutputter.cpp
+++ b/test/skimOutputter.cpp
@@ -634,8 +634,8 @@ int main (int argc, char** argv)
   // MES variations
   Float_t tauH_SVFIT_mass_muup, DNNoutSM_kl_1_muup, BDToutSM_kl_1_muup;
   Float_t tauH_SVFIT_mass_mudown, DNNoutSM_kl_1_mudown, BDToutSM_kl_1_mudown;
-  std::vector<Float_t> mdnnSM0_output_muup(mdnnSM0_size), mdnnSM0_output_mudown(mdnnSM0_size);
-  std::vector<Float_t> mdnnSM1_output_muup(mdnnSM1_size), mdnnSM1_output_mudown(mdnnSM1_size);
+  std::vector<Float_t> mdnnSM0_output_muup (mdnnSM0_size) , mdnnSM0_output_mudown (mdnnSM0_size);
+  std::vector<Float_t> mdnnSM1_output_muup (mdnnSM1_size) , mdnnSM1_output_mudown (mdnnSM1_size);
   std::vector<Float_t> mdnnBSM0_output_muup(mdnnBSM0_size), mdnnBSM0_output_mudown(mdnnBSM0_size);
   TBranch* b_tauH_SVFIT_mass_muup   = outTree->Branch("tauH_SVFIT_mass_muup"  , &tauH_SVFIT_mass_muup);
   TBranch* b_DNNoutSM_kl_1_muup     = outTree->Branch("DNNoutSM_kl_1_muup"    , &DNNoutSM_kl_1_muup);
@@ -643,14 +643,15 @@ int main (int argc, char** argv)
   TBranch* b_tauH_SVFIT_mass_mudown = outTree->Branch("tauH_SVFIT_mass_mudown", &tauH_SVFIT_mass_mudown);
   TBranch* b_DNNoutSM_kl_1_mudown   = outTree->Branch("DNNoutSM_kl_1_mudown"  , &DNNoutSM_kl_1_mudown);
   TBranch* b_BDToutSM_kl_1_mudown   = outTree->Branch("BDToutSM_kl_1_mudown"  , &BDToutSM_kl_1_mudown);
-  std::vector<TBranch*> b_mdnnSM0_muup  , b_mdnnSM1_muup  , b_mdnnBSM0_muup;
-  std::vector<TBranch*> b_mdnnSM0_mudown, b_mdnnSM1_mudown, b_mdnnBSM0_mudown;
-  boost::format mdnnSM0name_muup  ("mdnn__v0__kl1_c2v1_c31__%1%_muup");
-  boost::format mdnnSM1name_muup  ("mdnn__v1__kl1_c2v1_c31__%1%_muup");
-  boost::format mdnnBSM0name_muup ("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_muup");
-  boost::format mdnnSM0name_mudown  ("mdnn__v0__kl1_c2v1_c31__%1%_mudown");
-  boost::format mdnnSM1name_mudown  ("mdnn__v1__kl1_c2v1_c31__%1%_mudown");
-  boost::format mdnnBSM0name_mudown ("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_mudown");
+  std::vector<TBranch*> b_mdnnSM0_muup , b_mdnnSM0_mudown;
+  std::vector<TBranch*> b_mdnnSM1_muup , b_mdnnSM1_mudown;
+  std::vector<TBranch*> b_mdnnBSM0_muup, b_mdnnBSM0_mudown;
+  boost::format mdnnSM0name_muup   ("mdnn__v0__kl1_c2v1_c31__%1%_muup");
+  boost::format mdnnSM0name_mudown ("mdnn__v0__kl1_c2v1_c31__%1%_mudown");
+  boost::format mdnnSM1name_muup   ("mdnn__v1__kl1_c2v1_c31__%1%_muup");
+  boost::format mdnnSM1name_mudown ("mdnn__v1__kl1_c2v1_c31__%1%_mudown");
+  boost::format mdnnBSM0name_muup  ("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_muup");
+  boost::format mdnnBSM0name_mudown("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_mudown");
   for (int i=0; i<mdnnSM0_size; i++)
   {
     std::string tmp_mdnnSM0_branch_name_up   = boost::str( mdnnSM0name_muup   % (mci.getNodeNames(0)).at(i) );
@@ -680,8 +681,11 @@ int main (int argc, char** argv)
   }
 
   // EES variations
-  std::vector<Float_t> tauH_SVFIT_mass_eleup(2), DNNoutSM_kl_1_eleup(2), BDToutSM_kl_1_eleup(2);
-  std::vector<Float_t> tauH_SVFIT_mass_eledown(2), DNNoutSM_kl_1_eledown(2), BDToutSM_kl_1_eledown(2);
+  std::vector<Float_t> tauH_SVFIT_mass_eleup(N_tauhDM_EES), DNNoutSM_kl_1_eleup(N_tauhDM_EES), BDToutSM_kl_1_eleup(N_tauhDM_EES);
+  std::vector<Float_t> tauH_SVFIT_mass_eledown(N_tauhDM_EES), DNNoutSM_kl_1_eledown(N_tauhDM_EES), BDToutSM_kl_1_eledown(N_tauhDM_EES);
+  std::vector<std::vector<Float_t>> mdnnSM0_output_eleup (N_tauhDM_EES, std::vector<Float_t>(mdnnSM0_size)) , mdnnSM0_output_eledown (N_tauhDM_EES, std::vector<Float_t>(mdnnSM0_size));
+  std::vector<std::vector<Float_t>> mdnnSM1_output_eleup (N_tauhDM_EES, std::vector<Float_t>(mdnnSM1_size)) , mdnnSM1_output_eledown (N_tauhDM_EES, std::vector<Float_t>(mdnnSM1_size));
+  std::vector<std::vector<Float_t>> mdnnBSM0_output_eleup(N_tauhDM_EES, std::vector<Float_t>(mdnnBSM0_size)), mdnnBSM0_output_eledown(N_tauhDM_EES, std::vector<Float_t>(mdnnBSM0_size));
   TBranch* b_tauH_SVFIT_mass_eleup_DM0   = outTree->Branch("tauH_SVFIT_mass_eleup_DM0"  , &tauH_SVFIT_mass_eleup.at(0));    // DM 0
   TBranch* b_DNNoutSM_kl_1_eleup_DM0     = outTree->Branch("DNNoutSM_kl_1_eleup_DM0"    , &DNNoutSM_kl_1_eleup.at(0));
   TBranch* b_BDToutSM_kl_1_eleup_DM0     = outTree->Branch("BDToutSM_kl_1_eleup_DM0"    , &BDToutSM_kl_1_eleup.at(0));
@@ -694,10 +698,73 @@ int main (int argc, char** argv)
   TBranch* b_tauH_SVFIT_mass_eledown_DM1 = outTree->Branch("tauH_SVFIT_mass_eledown_DM1", &tauH_SVFIT_mass_eledown.at(1));
   TBranch* b_DNNoutSM_kl_1_eledown_DM1   = outTree->Branch("DNNoutSM_kl_1_eledown_DM1"  , &DNNoutSM_kl_1_eledown.at(1));
   TBranch* b_BDToutSM_kl_1_eledown_DM1   = outTree->Branch("BDToutSM_kl_1_eledown_DM1"  , &BDToutSM_kl_1_eledown.at(1));
+  std::vector<TBranch*> b_mdnnSM0_eleup_DM0 , b_mdnnSM0_eledown_DM0;
+  std::vector<TBranch*> b_mdnnSM0_eleup_DM1 , b_mdnnSM0_eledown_DM1;
+  std::vector<TBranch*> b_mdnnSM1_eleup_DM0 , b_mdnnSM1_eledown_DM0;
+  std::vector<TBranch*> b_mdnnSM1_eleup_DM1 , b_mdnnSM1_eledown_DM1;
+  std::vector<TBranch*> b_mdnnBSM0_eleup_DM0, b_mdnnBSM0_eledown_DM0;
+  std::vector<TBranch*> b_mdnnBSM0_eleup_DM1, b_mdnnBSM0_eledown_DM1;
+  boost::format mdnnSM0name_eleup_DM0   ("mdnn__v0__kl1_c2v1_c31__%1%_eleup_DM0");
+  boost::format mdnnSM0name_eledown_DM0 ("mdnn__v0__kl1_c2v1_c31__%1%_eledown_DM0");
+  boost::format mdnnSM0name_eleup_DM1   ("mdnn__v0__kl1_c2v1_c31__%1%_eleup_DM1");
+  boost::format mdnnSM0name_eledown_DM1 ("mdnn__v0__kl1_c2v1_c31__%1%_eledown_DM1");
+  boost::format mdnnSM1name_eleup_DM0   ("mdnn__v1__kl1_c2v1_c31__%1%_eleup_DM0");
+  boost::format mdnnSM1name_eledown_DM0 ("mdnn__v1__kl1_c2v1_c31__%1%_eledown_DM0");
+  boost::format mdnnSM1name_eleup_DM1   ("mdnn__v1__kl1_c2v1_c31__%1%_eleup_DM1");
+  boost::format mdnnSM1name_eledown_DM1 ("mdnn__v1__kl1_c2v1_c31__%1%_eledown_DM1");
+  boost::format mdnnBSM0name_eleup_DM0  ("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_eleup_DM0");
+  boost::format mdnnBSM0name_eledown_DM0("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_eledown_DM0");
+  boost::format mdnnBSM0name_eleup_DM1  ("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_eleup_DM1");
+  boost::format mdnnBSM0name_eledown_DM1("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_eledown_DM1");
+  for (int i=0; i<mdnnSM0_size; i++)
+  {
+    std::string tmp_mdnnSM0_branch_name_up_DM0   = boost::str( mdnnSM0name_eleup_DM0   % (mci.getNodeNames(0)).at(i) );
+    std::string tmp_mdnnSM0_branch_name_down_DM0 = boost::str( mdnnSM0name_eledown_DM0 % (mci.getNodeNames(0)).at(i) );
+    std::string tmp_mdnnSM0_branch_name_up_DM1   = boost::str( mdnnSM0name_eleup_DM1   % (mci.getNodeNames(0)).at(i) );
+    std::string tmp_mdnnSM0_branch_name_down_DM1 = boost::str( mdnnSM0name_eledown_DM1 % (mci.getNodeNames(0)).at(i) );
+    TBranch* tmp_mdnnSM0_branch_up_DM0   = outTree->Branch(tmp_mdnnSM0_branch_name_up_DM0.c_str()  , &mdnnSM0_output_eleup  [0].at(i));
+    TBranch* tmp_mdnnSM0_branch_down_DM0 = outTree->Branch(tmp_mdnnSM0_branch_name_down_DM0.c_str(), &mdnnSM0_output_eledown[0].at(i));
+    TBranch* tmp_mdnnSM0_branch_up_DM1   = outTree->Branch(tmp_mdnnSM0_branch_name_up_DM1.c_str()  , &mdnnSM0_output_eleup  [1].at(i));
+    TBranch* tmp_mdnnSM0_branch_down_DM1 = outTree->Branch(tmp_mdnnSM0_branch_name_down_DM1.c_str(), &mdnnSM0_output_eledown[1].at(i));
+    b_mdnnSM0_eleup_DM0  .push_back(tmp_mdnnSM0_branch_up_DM0);
+    b_mdnnSM0_eledown_DM0.push_back(tmp_mdnnSM0_branch_down_DM0);
+    b_mdnnSM0_eleup_DM1  .push_back(tmp_mdnnSM0_branch_up_DM1);
+    b_mdnnSM0_eledown_DM1.push_back(tmp_mdnnSM0_branch_down_DM1);
+  }
+  for (int i=0; i<mdnnSM1_size; i++)
+  {
+    std::string tmp_mdnnSM1_branch_name_up_DM0   = boost::str( mdnnSM1name_eleup_DM0   % (mci.getNodeNames(1)).at(i) );
+    std::string tmp_mdnnSM1_branch_name_down_DM0 = boost::str( mdnnSM1name_eledown_DM0 % (mci.getNodeNames(1)).at(i) );
+    std::string tmp_mdnnSM1_branch_name_up_DM1   = boost::str( mdnnSM1name_eleup_DM1   % (mci.getNodeNames(1)).at(i) );
+    std::string tmp_mdnnSM1_branch_name_down_DM1 = boost::str( mdnnSM1name_eledown_DM1 % (mci.getNodeNames(1)).at(i) );
+    TBranch* tmp_mdnnSM1_branch_up_DM0   = outTree->Branch(tmp_mdnnSM1_branch_name_up_DM0.c_str()  , &mdnnSM1_output_eleup  [0].at(i));
+    TBranch* tmp_mdnnSM1_branch_down_DM0 = outTree->Branch(tmp_mdnnSM1_branch_name_down_DM0.c_str(), &mdnnSM1_output_eledown[0].at(i));
+    TBranch* tmp_mdnnSM1_branch_up_DM1   = outTree->Branch(tmp_mdnnSM1_branch_name_up_DM1.c_str()  , &mdnnSM1_output_eleup  [1].at(i));
+    TBranch* tmp_mdnnSM1_branch_down_DM1 = outTree->Branch(tmp_mdnnSM1_branch_name_down_DM1.c_str(), &mdnnSM1_output_eledown[1].at(i));
+    b_mdnnSM1_eleup_DM0  .push_back(tmp_mdnnSM1_branch_up_DM0);
+    b_mdnnSM1_eledown_DM0.push_back(tmp_mdnnSM1_branch_down_DM0);
+    b_mdnnSM1_eleup_DM1  .push_back(tmp_mdnnSM1_branch_up_DM1);
+    b_mdnnSM1_eledown_DM1.push_back(tmp_mdnnSM1_branch_down_DM1);
+  }
+  for (int i=0; i<mdnnBSM0_size; i++)
+  {
+    std::string tmp_mdnnBSM0_branch_name_up_DM0   = boost::str( mdnnBSM0name_eleup_DM0   % (mci.getNodeNames(2)).at(i) );
+    std::string tmp_mdnnBSM0_branch_name_down_DM0 = boost::str( mdnnBSM0name_eledown_DM0 % (mci.getNodeNames(2)).at(i) );
+    std::string tmp_mdnnBSM0_branch_name_up_DM1   = boost::str( mdnnBSM0name_eleup_DM1   % (mci.getNodeNames(2)).at(i) );
+    std::string tmp_mdnnBSM0_branch_name_down_DM1 = boost::str( mdnnBSM0name_eledown_DM1 % (mci.getNodeNames(2)).at(i) );
+    TBranch* tmp_mdnnBSM0_branch_up_DM0   = outTree->Branch(tmp_mdnnBSM0_branch_name_up_DM0.c_str()  , &mdnnBSM0_output_eleup  [0].at(i));
+    TBranch* tmp_mdnnBSM0_branch_down_DM0 = outTree->Branch(tmp_mdnnBSM0_branch_name_down_DM0.c_str(), &mdnnBSM0_output_eledown[0].at(i));
+    TBranch* tmp_mdnnBSM0_branch_up_DM1   = outTree->Branch(tmp_mdnnBSM0_branch_name_up_DM1.c_str()  , &mdnnBSM0_output_eleup  [1].at(i));
+    TBranch* tmp_mdnnBSM0_branch_down_DM1 = outTree->Branch(tmp_mdnnBSM0_branch_name_down_DM1.c_str(), &mdnnBSM0_output_eledown[1].at(i));
+    b_mdnnBSM0_eleup_DM0  .push_back(tmp_mdnnBSM0_branch_up_DM0);
+    b_mdnnBSM0_eledown_DM0.push_back(tmp_mdnnBSM0_branch_down_DM0);
+    b_mdnnBSM0_eleup_DM1  .push_back(tmp_mdnnBSM0_branch_up_DM1);
+    b_mdnnBSM0_eledown_DM1.push_back(tmp_mdnnBSM0_branch_down_DM1);
+  }
 
   // TES variations
-  std::vector<Float_t> tauH_SVFIT_mass_tauup(4), DNNoutSM_kl_1_tauup(4), BDToutSM_kl_1_tauup(4);
-  std::vector<Float_t> tauH_SVFIT_mass_taudown(4), DNNoutSM_kl_1_taudown(4), BDToutSM_kl_1_taudown(4);
+  std::vector<Float_t> tauH_SVFIT_mass_tauup(N_tauhDM), DNNoutSM_kl_1_tauup(N_tauhDM), BDToutSM_kl_1_tauup(N_tauhDM);
+  std::vector<Float_t> tauH_SVFIT_mass_taudown(N_tauhDM), DNNoutSM_kl_1_taudown(N_tauhDM), BDToutSM_kl_1_taudown(N_tauhDM);
   TBranch* b_tauH_SVFIT_mass_tauup_DM0    = outTree->Branch("tauH_SVFIT_mass_tauup_DM0"   , &tauH_SVFIT_mass_tauup.at(0));    // DM 0
   TBranch* b_DNNoutSM_kl_1_tauup_DM0      = outTree->Branch("DNNoutSM_kl_1_tauup_DM0"     , &DNNoutSM_kl_1_tauup.at(0));
   TBranch* b_BDToutSM_kl_1_tauup_DM0      = outTree->Branch("BDToutSM_kl_1_tauup_DM0"     , &BDToutSM_kl_1_tauup.at(0));

--- a/test/skimOutputter.cpp
+++ b/test/skimOutputter.cpp
@@ -2161,10 +2161,13 @@ int main (int argc, char** argv)
     for (int i=0; i<mdnnSM0_size; i++)
     {
       b_mdnnSM0_new.at(i)->Fill();
-      b_mdnnSM1_new.at(i)->Fill();
       b_mdnnSM0_muup.at(i)->Fill();
-      b_mdnnSM1_muup.at(i)->Fill();
       b_mdnnSM0_mudown.at(i)->Fill();
+    }
+    for (int i=0; i<mdnnSM1_size; i++)
+    {
+      b_mdnnSM1_new.at(i)->Fill();
+      b_mdnnSM1_muup.at(i)->Fill();
       b_mdnnSM1_mudown.at(i)->Fill();
     }
     for (int i=0; i<mdnnBSM0_size; i++)

--- a/test/skimOutputter.cpp
+++ b/test/skimOutputter.cpp
@@ -1109,9 +1109,9 @@ int main (int argc, char** argv)
 
         // VBF multiclass
         mci.clearInputs();
-        for (uint i=0; i<mci.getNumberOfModels(); i++)
+        for (uint j=0; j<mci.getNumberOfModels(); j++)
         {
-          mci.setInputs(i,
+          mci.setInputs(j,
           {
             {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
             {"bjet1_pt", bjet1_pt}, {"bjet1_eta", bjet1_eta}, {"bjet1_phi", bjet1_phi}, {"bjet1_e", bjet1_e},
@@ -1132,12 +1132,12 @@ int main (int argc, char** argv)
         auto mdnnSM0_score_new  = mci.predict(EventNumber, 0);
         auto mdnnSM1_score_new  = mci.predict(EventNumber, 1);
         auto mdnnBSM0_score_new = mci.predict(EventNumber, 2);
-        for (uint i=0; i<mdnnSM0_score_new.size(); i++)
-          mdnnSM0_output_new.at(i) = mdnnSM0_score_new.at(i).second;
-        for (uint i=0; i<mdnnSM1_score_new.size(); i++)
-          mdnnSM1_output_new.at(i) = mdnnSM1_score_new.at(i).second;
-        for (uint i=0; i<mdnnBSM0_score_new.size(); i++)
-          mdnnBSM0_output_new.at(i) = mdnnBSM0_score_new.at(i).second;
+        for (uint k=0; k<mdnnSM0_score_new.size(); k++)
+          mdnnSM0_output_new.at(k) = mdnnSM0_score_new.at(k).second;
+        for (uint k=0; k<mdnnSM1_score_new.size(); k++)
+          mdnnSM1_output_new.at(k) = mdnnSM1_score_new.at(k).second;
+        for (uint k=0; k<mdnnBSM0_score_new.size(); k++)
+          mdnnBSM0_output_new.at(k) = mdnnBSM0_score_new.at(k).second;
       }
       else /*isMC*/
       {
@@ -1215,9 +1215,9 @@ int main (int argc, char** argv)
         if (doMult)
         {
           mci.clearInputs();
-          for (uint i=0; i<mci.getNumberOfModels(); i++)
+          for (uint j=0; j<mci.getNumberOfModels(); j++)
           {
-            mci.setInputs(i,
+            mci.setInputs(j,
             {
               {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
               {"bjet1_pt", bjet1_pt}, {"bjet1_eta", bjet1_eta}, {"bjet1_phi", bjet1_phi}, {"bjet1_e", bjet1_e},
@@ -1238,12 +1238,12 @@ int main (int argc, char** argv)
           auto mdnnSM0_score_new  = mci.predict(EventNumber, 0);
           auto mdnnSM1_score_new  = mci.predict(EventNumber, 1);
           auto mdnnBSM0_score_new = mci.predict(EventNumber, 2);
-          for (uint i=0; i<mdnnSM0_score_new.size(); i++)
-            mdnnSM0_output_new.at(i) = mdnnSM0_score_new.at(i).second;
-          for (uint i=0; i<mdnnSM1_score_new.size(); i++)
-            mdnnSM1_output_new.at(i) = mdnnSM1_score_new.at(i).second;
-          for (uint i=0; i<mdnnBSM0_score_new.size(); i++)
-            mdnnBSM0_output_new.at(i) = mdnnBSM0_score_new.at(i).second;
+          for (uint k=0; k<mdnnSM0_score_new.size(); k++)
+            mdnnSM0_output_new.at(k) = mdnnSM0_score_new.at(k).second;
+          for (uint k=0; k<mdnnSM1_score_new.size(); k++)
+            mdnnSM1_output_new.at(k) = mdnnSM1_score_new.at(k).second;
+          for (uint k=0; k<mdnnBSM0_score_new.size(); k++)
+            mdnnBSM0_output_new.at(k) = mdnnBSM0_score_new.at(k).second;
         }
 
         // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
@@ -1288,9 +1288,9 @@ int main (int argc, char** argv)
 
         // VBF multiclass
         mci.clearInputs();
-        for (uint i=0; i<mci.getNumberOfModels(); i++)
+        for (uint j=0; j<mci.getNumberOfModels(); j++)
         {
-          mci.setInputs(i,
+          mci.setInputs(j,
           {
             {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
             {"bjet1_pt", bjet1_pt}, {"bjet1_eta", bjet1_eta}, {"bjet1_phi", bjet1_phi}, {"bjet1_e", bjet1_e},
@@ -1311,20 +1311,20 @@ int main (int argc, char** argv)
         auto mdnnSM0_score_mes  = mci.predict(EventNumber, 0);
         auto mdnnSM1_score_mes  = mci.predict(EventNumber, 1);
         auto mdnnBSM0_score_mes = mci.predict(EventNumber, 2);
-        for (uint i=0; i<mdnnSM0_score_mes.size(); i++)
+        for (uint k=0; k<mdnnSM0_score_mes.size(); k++)
         {
-          mdnnSM0_output_muup.at(i)   = mdnnSM0_score_mes.at(i).second;
-          mdnnSM0_output_mudown.at(i) = mdnnSM0_score_mes.at(i).second;
+          mdnnSM0_output_muup.at(k)   = mdnnSM0_score_mes.at(k).second;
+          mdnnSM0_output_mudown.at(k) = mdnnSM0_score_mes.at(k).second;
         }
-        for (uint i=0; i<mdnnSM1_score_mes.size(); i++)
+        for (uint k=0; k<mdnnSM1_score_mes.size(); k++)
         {
-          mdnnSM1_output_muup.at(i)   = mdnnSM1_score_mes.at(i).second;
-          mdnnSM1_output_mudown.at(i) = mdnnSM1_score_mes.at(i).second;
+          mdnnSM1_output_muup.at(k)   = mdnnSM1_score_mes.at(k).second;
+          mdnnSM1_output_mudown.at(k) = mdnnSM1_score_mes.at(k).second;
         }
-        for (uint i=0; i<mdnnBSM0_score_mes.size(); i++)
+        for (uint k=0; k<mdnnBSM0_score_mes.size(); k++)
         {
-          mdnnBSM0_output_muup.at(i)   = mdnnBSM0_score_mes.at(i).second;
-          mdnnBSM0_output_mudown.at(i) = mdnnBSM0_score_mes.at(i).second;
+          mdnnBSM0_output_muup.at(k)   = mdnnBSM0_score_mes.at(k).second;
+          mdnnBSM0_output_mudown.at(k) = mdnnBSM0_score_mes.at(k).second;
         }
       }
       else /*isMC*/
@@ -1469,9 +1469,9 @@ int main (int argc, char** argv)
         if (doMult)
         {
           mci.clearInputs();
-          for (uint i=0; i<mci.getNumberOfModels(); i++)
+          for (uint j=0; j<mci.getNumberOfModels(); j++)
           {
-            mci.setInputs(i,
+            mci.setInputs(j,
             {
               {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
               {"bjet1_pt", bjet1_pt}, {"bjet1_eta", bjet1_eta}, {"bjet1_phi", bjet1_phi}, {"bjet1_e", bjet1_e},
@@ -1492,17 +1492,17 @@ int main (int argc, char** argv)
           auto mdnnSM0_score_muup  = mci.predict(EventNumber, 0);
           auto mdnnSM1_score_muup  = mci.predict(EventNumber, 1);
           auto mdnnBSM0_score_muup = mci.predict(EventNumber, 2);
-          for (uint i=0; i<mdnnSM0_score_muup.size(); i++)
-            mdnnSM0_output_muup.at(i) = mdnnSM0_score_muup.at(i).second;
-          for (uint i=0; i<mdnnSM1_score_muup.size(); i++)
-            mdnnSM1_output_muup.at(i) = mdnnSM1_score_muup.at(i).second;
-          for (uint i=0; i<mdnnBSM0_score_muup.size(); i++)
-            mdnnBSM0_output_muup.at(i) = mdnnBSM0_score_muup.at(i).second;
+          for (uint k=0; k<mdnnSM0_score_muup.size(); k++)
+            mdnnSM0_output_muup.at(k) = mdnnSM0_score_muup.at(k).second;
+          for (uint k=0; k<mdnnSM1_score_muup.size(); k++)
+            mdnnSM1_output_muup.at(k) = mdnnSM1_score_muup.at(k).second;
+          for (uint k=0; k<mdnnBSM0_score_muup.size(); k++)
+            mdnnBSM0_output_muup.at(k) = mdnnBSM0_score_muup.at(k).second;
 
           mci.clearInputs();
-          for (uint i=0; i<mci.getNumberOfModels(); i++)
+          for (uint j=0; j<mci.getNumberOfModels(); j++)
           {
-            mci.setInputs(i,
+            mci.setInputs(j,
             {
               {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
               {"bjet1_pt", bjet1_pt}, {"bjet1_eta", bjet1_eta}, {"bjet1_phi", bjet1_phi}, {"bjet1_e", bjet1_e},
@@ -1523,12 +1523,12 @@ int main (int argc, char** argv)
           auto mdnnSM0_score_mudown  = mci.predict(EventNumber, 0);
           auto mdnnSM1_score_mudown  = mci.predict(EventNumber, 1);
           auto mdnnBSM0_score_mudown = mci.predict(EventNumber, 2);
-          for (uint i=0; i<mdnnSM0_score_mudown.size(); i++)
-            mdnnSM0_output_mudown.at(i) = mdnnSM0_score_mudown.at(i).second;
-          for (uint i=0; i<mdnnSM1_score_mudown.size(); i++)
-            mdnnSM1_output_mudown.at(i) = mdnnSM1_score_mudown.at(i).second;
-          for (uint i=0; i<mdnnBSM0_score_mudown.size(); i++)
-            mdnnBSM0_output_mudown.at(i) = mdnnBSM0_score_mudown.at(i).second;
+          for (uint k=0; k<mdnnSM0_score_mudown.size(); k++)
+            mdnnSM0_output_mudown.at(k) = mdnnSM0_score_mudown.at(k).second;
+          for (uint k=0; k<mdnnSM1_score_mudown.size(); k++)
+            mdnnSM1_output_mudown.at(k) = mdnnSM1_score_mudown.at(k).second;
+          for (uint k=0; k<mdnnBSM0_score_mudown.size(); k++)
+            mdnnBSM0_output_mudown.at(k) = mdnnBSM0_score_mudown.at(k).second;
         }
 
         if (doBDT)
@@ -1574,6 +1574,47 @@ int main (int argc, char** argv)
           DNNoutSM_kl_1_eledown.at(i)   = DNNoutSM_kl_1;
           BDToutSM_kl_1_eleup.at(i)     = BDToutSM_kl_1;
           BDToutSM_kl_1_eledown.at(i)   = BDToutSM_kl_1;
+
+          // VBF multiclass
+          mci.clearInputs();
+          for (uint j=0; j<mci.getNumberOfModels(); j++)
+          {
+            mci.setInputs(j,
+            {
+              {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
+              {"bjet1_pt", bjet1_pt}, {"bjet1_eta", bjet1_eta}, {"bjet1_phi", bjet1_phi}, {"bjet1_e", bjet1_e},
+              {"bjet1_deepflavor_b", bjet1_bID_deepFlavor}, {"bjet1_deepflavor_cvsb", CvsB_b1}, {"bjet1_deepflavor_cvsl", CvsL_b1}, {"bjet1_hhbtag", HHbtag_b1},
+              {"bjet2_pt", bjet2_pt}, {"bjet2_eta", bjet2_eta}, {"bjet2_phi", bjet2_phi}, {"bjet2_e", bjet2_e},
+              {"bjet2_deepflavor_b", bjet2_bID_deepFlavor}, {"bjet2_deepflavor_cvsb", CvsB_b2}, {"bjet2_deepflavor_cvsl", CvsL_b2}, {"bjet2_hhbtag", HHbtag_b2},
+              {"vbfjet1_pt", vbfjet1_pt}, {"vbfjet1_eta", vbfjet1_eta}, {"vbfjet1_phi", vbfjet1_phi}, {"vbfjet1_e", vbfjet1_e},
+              {"vbfjet1_deepflavor_b", VBFjet1_btag_deepFlavor}, {"vbfjet1_deepflavor_cvsb", CvsB_vbf1}, {"vbfjet1_deepflavor_cvsl", CvsL_vbf1}, {"vbfjet1_hhbtag", HHbtag_vbf1},
+              {"vbfjet2_pt", vbfjet2_pt}, {"vbfjet2_eta", vbfjet2_eta}, {"vbfjet2_phi", vbfjet2_phi}, {"vbfjet2_e", vbfjet2_e},
+              {"vbfjet2_deepflavor_b", VBFjet2_btag_deepFlavor}, {"vbfjet2_deepflavor_cvsb", CvsB_vbf2}, {"vbfjet2_deepflavor_cvsl", CvsL_vbf2}, {"vbfjet2_hhbtag", HHbtag_vbf2},
+              {"lep1_pt", dau1_pt}, {"lep1_eta", dau1_eta}, {"lep1_phi", dau1_phi}, {"lep1_e", dau1_e},
+              {"lep2_pt", dau2_pt}, {"lep2_eta", dau2_eta}, {"lep2_phi", dau2_phi}, {"lep2_e", dau2_e},
+              {"met_pt", met.Pt()}, {"met_phi", met.Phi()},
+              {"bh_pt", (bjet1+bjet2).Pt()}, {"bh_eta", (bjet1+bjet2).Eta()}, {"bh_phi", (bjet1+bjet2).Phi()}, {"bh_e", (bjet1+bjet2).E()},
+              {"tauh_sv_pt", tauH_SVFIT_pt}, {"tauh_sv_eta", tauH_SVFIT_eta}, {"tauh_sv_phi", tauH_SVFIT_phi}, {"tauh_sv_e", svfit.E()}
+            });
+          }
+          auto mdnnSM0_score_ees  = mci.predict(EventNumber, 0);
+          auto mdnnSM1_score_ees  = mci.predict(EventNumber, 1);
+          auto mdnnBSM0_score_ees = mci.predict(EventNumber, 2);
+          for (uint k=0; k<mdnnSM0_score_ees.size(); k++)
+          {
+            mdnnSM0_output_eleup  [i].at(k) = mdnnSM0_score_ees.at(k).second;
+            mdnnSM0_output_eledown[i].at(k) = mdnnSM0_score_ees.at(k).second;
+          }
+          for (uint k=0; k<mdnnSM1_score_ees.size(); k++)
+          {
+            mdnnSM1_output_eleup  [i].at(k) = mdnnSM1_score_ees.at(k).second;
+            mdnnSM1_output_eledown[i].at(k) = mdnnSM1_score_ees.at(k).second;
+          }
+          for (uint k=0; k<mdnnBSM0_score_ees.size(); k++)
+          {
+            mdnnBSM0_output_eleup  [i].at(k) = mdnnBSM0_score_ees.at(k).second;
+            mdnnBSM0_output_eledown[i].at(k) = mdnnBSM0_score_ees.at(k).second;
+          }
         }
         else /*isMC*/
         {
@@ -1711,6 +1752,71 @@ int main (int argc, char** argv)
                 HHKin_mass_eledown, HHKin_chi2_eledown, KinFitConv_eledown, SVfitConv_eledown, MT2_eledown);
             std::vector<float> outs_eledown = DNNreader.GetPredictions();
             DNNoutSM_kl_1_eledown.at(i) = outs_eledown.at(0);
+          }
+
+          if (doMult)
+          {
+            mci.clearInputs();
+            for (uint j=0; j<mci.getNumberOfModels(); j++)
+            {
+              mci.setInputs(j,
+              {
+                {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
+                {"bjet1_pt", bjet1_pt}, {"bjet1_eta", bjet1_eta}, {"bjet1_phi", bjet1_phi}, {"bjet1_e", bjet1_e},
+                {"bjet1_deepflavor_b", bjet1_bID_deepFlavor}, {"bjet1_deepflavor_cvsb", CvsB_b1}, {"bjet1_deepflavor_cvsl", CvsL_b1}, {"bjet1_hhbtag", HHbtag_b1},
+                {"bjet2_pt", bjet2_pt}, {"bjet2_eta", bjet2_eta}, {"bjet2_phi", bjet2_phi}, {"bjet2_e", bjet2_e},
+                {"bjet2_deepflavor_b", bjet2_bID_deepFlavor}, {"bjet2_deepflavor_cvsb", CvsB_b2}, {"bjet2_deepflavor_cvsl", CvsL_b2}, {"bjet2_hhbtag", HHbtag_b2},
+                {"vbfjet1_pt", vbfjet1_pt}, {"vbfjet1_eta", vbfjet1_eta}, {"vbfjet1_phi", vbfjet1_phi}, {"vbfjet1_e", vbfjet1_e},
+                {"vbfjet1_deepflavor_b", VBFjet1_btag_deepFlavor}, {"vbfjet1_deepflavor_cvsb", CvsB_vbf1}, {"vbfjet1_deepflavor_cvsl", CvsL_vbf1}, {"vbfjet1_hhbtag", HHbtag_vbf1},
+                {"vbfjet2_pt", vbfjet2_pt}, {"vbfjet2_eta", vbfjet2_eta}, {"vbfjet2_phi", vbfjet2_phi}, {"vbfjet2_e", vbfjet2_e},
+                {"vbfjet2_deepflavor_b", VBFjet2_btag_deepFlavor}, {"vbfjet2_deepflavor_cvsb", CvsB_vbf2}, {"vbfjet2_deepflavor_cvsl", CvsL_vbf2}, {"vbfjet2_hhbtag", HHbtag_vbf2},
+                {"lep1_pt", tau1_eleup.Pt()}, {"lep1_eta", tau1_eleup.Eta()}, {"lep1_phi", tau1_eleup.Phi()}, {"lep1_e", tau1_eleup.E()},
+                {"lep2_pt", tau2_eleup.Pt()}, {"lep2_eta", tau2_eleup.Eta()}, {"lep2_phi", tau2_eleup.Phi()}, {"lep2_e", tau2_eleup.E()},
+                {"met_pt", met_eleup.Pt()}, {"met_phi", met_eleup.Phi()},
+                {"bh_pt", (bjet1+bjet2).Pt()}, {"bh_eta", (bjet1+bjet2).Eta()}, {"bh_phi", (bjet1+bjet2).Phi()}, {"bh_e", (bjet1+bjet2).E()},
+                {"tauh_sv_pt", svfit_eleup.Pt()}, {"tauh_sv_eta", svfit_eleup.Eta()}, {"tauh_sv_phi", svfit_eleup.Phi()}, {"tauh_sv_e", svfit_eleup.E()}
+              });
+            }
+            auto mdnnSM0_score_eleup  = mci.predict(EventNumber, 0);
+            auto mdnnSM1_score_eleup  = mci.predict(EventNumber, 1);
+            auto mdnnBSM0_score_eleup = mci.predict(EventNumber, 2);
+            for (uint k=0; k<mdnnSM0_score_eleup.size(); k++)
+              mdnnSM0_output_eleup[i].at(k) = mdnnSM0_score_eleup.at(k).second;
+            for (uint k=0; k<mdnnSM1_score_eleup.size(); k++)
+              mdnnSM1_output_eleup[i].at(k) = mdnnSM1_score_eleup.at(k).second;
+            for (uint k=0; k<mdnnBSM0_score_eleup.size(); k++)
+              mdnnBSM0_output_eleup[i].at(k) = mdnnBSM0_score_eleup.at(k).second;
+
+            mci.clearInputs();
+            for (uint j=0; j<mci.getNumberOfModels(); j++)
+            {
+              mci.setInputs(j,
+              {
+                {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
+                {"bjet1_pt", bjet1_pt}, {"bjet1_eta", bjet1_eta}, {"bjet1_phi", bjet1_phi}, {"bjet1_e", bjet1_e},
+                {"bjet1_deepflavor_b", bjet1_bID_deepFlavor}, {"bjet1_deepflavor_cvsb", CvsB_b1}, {"bjet1_deepflavor_cvsl", CvsL_b1}, {"bjet1_hhbtag", HHbtag_b1},
+                {"bjet2_pt", bjet2_pt}, {"bjet2_eta", bjet2_eta}, {"bjet2_phi", bjet2_phi}, {"bjet2_e", bjet2_e},
+                {"bjet2_deepflavor_b", bjet2_bID_deepFlavor}, {"bjet2_deepflavor_cvsb", CvsB_b2}, {"bjet2_deepflavor_cvsl", CvsL_b2}, {"bjet2_hhbtag", HHbtag_b2},
+                {"vbfjet1_pt", vbfjet1_pt}, {"vbfjet1_eta", vbfjet1_eta}, {"vbfjet1_phi", vbfjet1_phi}, {"vbfjet1_e", vbfjet1_e},
+                {"vbfjet1_deepflavor_b", VBFjet1_btag_deepFlavor}, {"vbfjet1_deepflavor_cvsb", CvsB_vbf1}, {"vbfjet1_deepflavor_cvsl", CvsL_vbf1}, {"vbfjet1_hhbtag", HHbtag_vbf1},
+                {"vbfjet2_pt", vbfjet2_pt}, {"vbfjet2_eta", vbfjet2_eta}, {"vbfjet2_phi", vbfjet2_phi}, {"vbfjet2_e", vbfjet2_e},
+                {"vbfjet2_deepflavor_b", VBFjet2_btag_deepFlavor}, {"vbfjet2_deepflavor_cvsb", CvsB_vbf2}, {"vbfjet2_deepflavor_cvsl", CvsL_vbf2}, {"vbfjet2_hhbtag", HHbtag_vbf2},
+                {"lep1_pt", tau1_eledown.Pt()}, {"lep1_eta", tau1_eledown.Eta()}, {"lep1_phi", tau1_eledown.Phi()}, {"lep1_e", tau1_eledown.E()},
+                {"lep2_pt", tau2_eledown.Pt()}, {"lep2_eta", tau2_eledown.Eta()}, {"lep2_phi", tau2_eledown.Phi()}, {"lep2_e", tau2_eledown.E()},
+                {"met_pt", met_eledown.Pt()}, {"met_phi", met_eledown.Phi()},
+                {"bh_pt", (bjet1+bjet2).Pt()}, {"bh_eta", (bjet1+bjet2).Eta()}, {"bh_phi", (bjet1+bjet2).Phi()}, {"bh_e", (bjet1+bjet2).E()},
+                {"tauh_sv_pt", svfit_eledown.Pt()}, {"tauh_sv_eta", svfit_eledown.Eta()}, {"tauh_sv_phi", svfit_eledown.Phi()}, {"tauh_sv_e", svfit_eledown.E()}
+              });
+            }
+            auto mdnnSM0_score_eledown  = mci.predict(EventNumber, 0);
+            auto mdnnSM1_score_eledown  = mci.predict(EventNumber, 1);
+            auto mdnnBSM0_score_eledown = mci.predict(EventNumber, 2);
+            for (uint k=0; k<mdnnSM0_score_eledown.size(); k++)
+              mdnnSM0_output_eledown[i].at(k) = mdnnSM0_score_eledown.at(k).second;
+            for (uint k=0; k<mdnnSM1_score_eledown.size(); k++)
+              mdnnSM1_output_eledown[i].at(k) = mdnnSM1_score_eledown.at(k).second;
+            for (uint k=0; k<mdnnBSM0_score_eledown.size(); k++)
+              mdnnBSM0_output_eledown[i].at(k) = mdnnBSM0_score_eledown.at(k).second;
           }
 
           if (doBDT)
@@ -2132,9 +2238,9 @@ int main (int argc, char** argv)
 
         // VBF multiclass
         mci.clearInputs();
-        for (uint i=0; i<mci.getNumberOfModels(); i++)
+        for (uint j=0; j<mci.getNumberOfModels(); j++)
         {
-          mci.setInputs(i,
+          mci.setInputs(j,
           {
             {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
             {"bjet1_pt", bjet1_pt}, {"bjet1_eta", bjet1_eta}, {"bjet1_phi", bjet1_phi}, {"bjet1_e", bjet1_e},
@@ -2155,20 +2261,20 @@ int main (int argc, char** argv)
         auto mdnnSM0_score_jetTot  = mci.predict(EventNumber, 0);
         auto mdnnSM1_score_jetTot  = mci.predict(EventNumber, 1);
         auto mdnnBSM0_score_jetTot = mci.predict(EventNumber, 2);
-        for (uint i=0; i<mdnnSM0_score_jetTot.size(); i++)
+        for (uint k=0; k<mdnnSM0_score_jetTot.size(); k++)
         {
-          mdnnSM0_output_jetupTot.at(i)   = mdnnSM0_score_jetTot.at(i).second;
-          mdnnSM0_output_jetdownTot.at(i) = mdnnSM0_score_jetTot.at(i).second;
+          mdnnSM0_output_jetupTot.at(k)   = mdnnSM0_score_jetTot.at(k).second;
+          mdnnSM0_output_jetdownTot.at(k) = mdnnSM0_score_jetTot.at(k).second;
         }
-        for (uint i=0; i<mdnnSM1_score_jetTot.size(); i++)
+        for (uint k=0; k<mdnnSM1_score_jetTot.size(); k++)
         {
-          mdnnSM1_output_jetupTot.at(i)   = mdnnSM1_score_jetTot.at(i).second;
-          mdnnSM1_output_jetdownTot.at(i) = mdnnSM1_score_jetTot.at(i).second;
+          mdnnSM1_output_jetupTot.at(k)   = mdnnSM1_score_jetTot.at(k).second;
+          mdnnSM1_output_jetdownTot.at(k) = mdnnSM1_score_jetTot.at(k).second;
         }
-        for (uint i=0; i<mdnnBSM0_score_jetTot.size(); i++)
+        for (uint k=0; k<mdnnBSM0_score_jetTot.size(); k++)
         {
-          mdnnBSM0_output_jetupTot.at(i)   = mdnnBSM0_score_jetTot.at(i).second;
-          mdnnBSM0_output_jetdownTot.at(i) = mdnnBSM0_score_jetTot.at(i).second;
+          mdnnBSM0_output_jetupTot.at(k)   = mdnnBSM0_score_jetTot.at(k).second;
+          mdnnBSM0_output_jetdownTot.at(k) = mdnnBSM0_score_jetTot.at(k).second;
         }
       }
       else /*isMC*/
@@ -2320,9 +2426,9 @@ int main (int argc, char** argv)
         if (doMult)
         {
           mci.clearInputs();
-          for (uint i=0; i<mci.getNumberOfModels(); i++)
+          for (uint j=0; j<mci.getNumberOfModels(); j++)
           {
-            mci.setInputs(i,
+            mci.setInputs(j,
             {
               {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
               {"bjet1_pt", bjet1_jetupTot.Pt()}, {"bjet1_eta", bjet1_jetupTot.Eta()}, {"bjet1_phi", bjet1_jetupTot.Phi()}, {"bjet1_e", bjet1_jetupTot.E()},
@@ -2343,17 +2449,17 @@ int main (int argc, char** argv)
           auto mdnnSM0_score_jetupTot  = mci.predict(EventNumber, 0);
           auto mdnnSM1_score_jetupTot  = mci.predict(EventNumber, 1);
           auto mdnnBSM0_score_jetupTot = mci.predict(EventNumber, 2);
-          for (uint i=0; i<mdnnSM0_score_jetupTot.size(); i++)
-            mdnnSM0_output_jetupTot.at(i) = mdnnSM0_score_jetupTot.at(i).second;
-          for (uint i=0; i<mdnnSM1_score_jetupTot.size(); i++)
-            mdnnSM1_output_jetupTot.at(i) = mdnnSM1_score_jetupTot.at(i).second;
-          for (uint i=0; i<mdnnBSM0_score_jetupTot.size(); i++)
-            mdnnBSM0_output_jetupTot.at(i) = mdnnBSM0_score_jetupTot.at(i).second;
+          for (uint k=0; k<mdnnSM0_score_jetupTot.size(); k++)
+            mdnnSM0_output_jetupTot.at(k) = mdnnSM0_score_jetupTot.at(k).second;
+          for (uint k=0; k<mdnnSM1_score_jetupTot.size(); k++)
+            mdnnSM1_output_jetupTot.at(k) = mdnnSM1_score_jetupTot.at(k).second;
+          for (uint k=0; k<mdnnBSM0_score_jetupTot.size(); k++)
+            mdnnBSM0_output_jetupTot.at(k) = mdnnBSM0_score_jetupTot.at(k).second;
 
           mci.clearInputs();
-          for (uint i=0; i<mci.getNumberOfModels(); i++)
+          for (uint j=0; j<mci.getNumberOfModels(); j++)
           {
-            mci.setInputs(i,
+            mci.setInputs(j,
             {
               {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
               {"bjet1_pt", bjet1_jetdownTot.Pt()}, {"bjet1_eta", bjet1_jetdownTot.Eta()}, {"bjet1_phi", bjet1_jetdownTot.Phi()}, {"bjet1_e", bjet1_jetdownTot.E()},
@@ -2374,12 +2480,12 @@ int main (int argc, char** argv)
           auto mdnnSM0_score_jetdownTot  = mci.predict(EventNumber, 0);
           auto mdnnSM1_score_jetdownTot  = mci.predict(EventNumber, 1);
           auto mdnnBSM0_score_jetdownTot = mci.predict(EventNumber, 2);
-          for (uint i=0; i<mdnnSM0_score_jetdownTot.size(); i++)
-            mdnnSM0_output_jetdownTot.at(i) = mdnnSM0_score_jetdownTot.at(i).second;
-          for (uint i=0; i<mdnnSM1_score_jetdownTot.size(); i++)
-            mdnnSM1_output_jetdownTot.at(i) = mdnnSM1_score_jetdownTot.at(i).second;
-          for (uint i=0; i<mdnnBSM0_score_jetdownTot.size(); i++)
-            mdnnBSM0_output_jetdownTot.at(i) = mdnnBSM0_score_jetdownTot.at(i).second;
+          for (uint k=0; k<mdnnSM0_score_jetdownTot.size(); k++)
+            mdnnSM0_output_jetdownTot.at(k) = mdnnSM0_score_jetdownTot.at(k).second;
+          for (uint k=0; k<mdnnSM1_score_jetdownTot.size(); k++)
+            mdnnSM1_output_jetdownTot.at(k) = mdnnSM1_score_jetdownTot.at(k).second;
+          for (uint k=0; k<mdnnBSM0_score_jetdownTot.size(); k++)
+            mdnnBSM0_output_jetdownTot.at(k) = mdnnBSM0_score_jetdownTot.at(k).second;
         }
 
         if (doBDT)
@@ -2495,6 +2601,10 @@ int main (int argc, char** argv)
       b_mdnnSM0_new.at(i)->Fill();
       b_mdnnSM0_muup.at(i)->Fill();
       b_mdnnSM0_mudown.at(i)->Fill();
+      b_mdnnSM0_eleup_DM0.at(i)->Fill();
+      b_mdnnSM0_eledown_DM0.at(i)->Fill();
+      b_mdnnSM0_eleup_DM1.at(i)->Fill();
+      b_mdnnSM0_eledown_DM1.at(i)->Fill();
       b_mdnnSM0_jetupTot.at(i)->Fill();
       b_mdnnSM0_jetdownTot.at(i)->Fill();
     }
@@ -2503,6 +2613,10 @@ int main (int argc, char** argv)
       b_mdnnSM1_new.at(i)->Fill();
       b_mdnnSM1_muup.at(i)->Fill();
       b_mdnnSM1_mudown.at(i)->Fill();
+      b_mdnnSM1_eleup_DM0.at(i)->Fill();
+      b_mdnnSM1_eledown_DM0.at(i)->Fill();
+      b_mdnnSM1_eleup_DM1.at(i)->Fill();
+      b_mdnnSM1_eledown_DM1.at(i)->Fill();
       b_mdnnSM1_jetupTot.at(i)->Fill();
       b_mdnnSM1_jetdownTot.at(i)->Fill();
     }
@@ -2511,6 +2625,10 @@ int main (int argc, char** argv)
       b_mdnnBSM0_new.at(i)->Fill();
       b_mdnnBSM0_muup.at(i)->Fill();
       b_mdnnBSM0_mudown.at(i)->Fill();
+      b_mdnnBSM0_eleup_DM0.at(i)->Fill();
+      b_mdnnBSM0_eledown_DM0.at(i)->Fill();
+      b_mdnnBSM0_eleup_DM1.at(i)->Fill();
+      b_mdnnBSM0_eledown_DM1.at(i)->Fill();
       b_mdnnBSM0_jetupTot.at(i)->Fill();
       b_mdnnBSM0_jetdownTot.at(i)->Fill();
     }

--- a/test/skimOutputter.cpp
+++ b/test/skimOutputter.cpp
@@ -1863,6 +1863,47 @@ int main (int argc, char** argv)
           DNNoutSM_kl_1_taudown.at(i)   = DNNoutSM_kl_1;
           BDToutSM_kl_1_tauup.at(i)     = BDToutSM_kl_1;
           BDToutSM_kl_1_taudown.at(i)   = BDToutSM_kl_1;
+
+          // VBF multiclass
+          mci.clearInputs();
+          for (uint j=0; j<mci.getNumberOfModels(); j++)
+          {
+            mci.setInputs(j,
+            {
+              {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
+              {"bjet1_pt", bjet1_pt}, {"bjet1_eta", bjet1_eta}, {"bjet1_phi", bjet1_phi}, {"bjet1_e", bjet1_e},
+              {"bjet1_deepflavor_b", bjet1_bID_deepFlavor}, {"bjet1_deepflavor_cvsb", CvsB_b1}, {"bjet1_deepflavor_cvsl", CvsL_b1}, {"bjet1_hhbtag", HHbtag_b1},
+              {"bjet2_pt", bjet2_pt}, {"bjet2_eta", bjet2_eta}, {"bjet2_phi", bjet2_phi}, {"bjet2_e", bjet2_e},
+              {"bjet2_deepflavor_b", bjet2_bID_deepFlavor}, {"bjet2_deepflavor_cvsb", CvsB_b2}, {"bjet2_deepflavor_cvsl", CvsL_b2}, {"bjet2_hhbtag", HHbtag_b2},
+              {"vbfjet1_pt", vbfjet1_pt}, {"vbfjet1_eta", vbfjet1_eta}, {"vbfjet1_phi", vbfjet1_phi}, {"vbfjet1_e", vbfjet1_e},
+              {"vbfjet1_deepflavor_b", VBFjet1_btag_deepFlavor}, {"vbfjet1_deepflavor_cvsb", CvsB_vbf1}, {"vbfjet1_deepflavor_cvsl", CvsL_vbf1}, {"vbfjet1_hhbtag", HHbtag_vbf1},
+              {"vbfjet2_pt", vbfjet2_pt}, {"vbfjet2_eta", vbfjet2_eta}, {"vbfjet2_phi", vbfjet2_phi}, {"vbfjet2_e", vbfjet2_e},
+              {"vbfjet2_deepflavor_b", VBFjet2_btag_deepFlavor}, {"vbfjet2_deepflavor_cvsb", CvsB_vbf2}, {"vbfjet2_deepflavor_cvsl", CvsL_vbf2}, {"vbfjet2_hhbtag", HHbtag_vbf2},
+              {"lep1_pt", dau1_pt}, {"lep1_eta", dau1_eta}, {"lep1_phi", dau1_phi}, {"lep1_e", dau1_e},
+              {"lep2_pt", dau2_pt}, {"lep2_eta", dau2_eta}, {"lep2_phi", dau2_phi}, {"lep2_e", dau2_e},
+              {"met_pt", met.Pt()}, {"met_phi", met.Phi()},
+              {"bh_pt", (bjet1+bjet2).Pt()}, {"bh_eta", (bjet1+bjet2).Eta()}, {"bh_phi", (bjet1+bjet2).Phi()}, {"bh_e", (bjet1+bjet2).E()},
+              {"tauh_sv_pt", tauH_SVFIT_pt}, {"tauh_sv_eta", tauH_SVFIT_eta}, {"tauh_sv_phi", tauH_SVFIT_phi}, {"tauh_sv_e", svfit.E()}
+            });
+          }
+          auto mdnnSM0_score_tes  = mci.predict(EventNumber, 0);
+          auto mdnnSM1_score_tes  = mci.predict(EventNumber, 1);
+          auto mdnnBSM0_score_tes = mci.predict(EventNumber, 2);
+          for (uint k=0; k<mdnnSM0_score_tes.size(); k++)
+          {
+            mdnnSM0_output_tauup  [i].at(k) = mdnnSM0_score_tes.at(k).second;
+            mdnnSM0_output_taudown[i].at(k) = mdnnSM0_score_tes.at(k).second;
+          }
+          for (uint k=0; k<mdnnSM1_score_tes.size(); k++)
+          {
+            mdnnSM1_output_tauup  [i].at(k) = mdnnSM1_score_tes.at(k).second;
+            mdnnSM1_output_taudown[i].at(k) = mdnnSM1_score_tes.at(k).second;
+          }
+          for (uint k=0; k<mdnnBSM0_score_tes.size(); k++)
+          {
+            mdnnBSM0_output_tauup  [i].at(k) = mdnnBSM0_score_tes.at(k).second;
+            mdnnBSM0_output_taudown[i].at(k) = mdnnBSM0_score_tes.at(k).second;
+          }
         }
         else /*isMC*/
         {
@@ -2000,6 +2041,71 @@ int main (int argc, char** argv)
                 HHKin_mass_taudown, HHKin_chi2_taudown, KinFitConv_taudown, SVfitConv_taudown, MT2_taudown);
             std::vector<float> outs_taudown = DNNreader.GetPredictions();
             DNNoutSM_kl_1_taudown.at(i) = outs_taudown.at(0);
+          }
+
+          if (doMult)
+          {
+            mci.clearInputs();
+            for (uint j=0; j<mci.getNumberOfModels(); j++)
+            {
+              mci.setInputs(j,
+              {
+                {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
+                {"bjet1_pt", bjet1_pt}, {"bjet1_eta", bjet1_eta}, {"bjet1_phi", bjet1_phi}, {"bjet1_e", bjet1_e},
+                {"bjet1_deepflavor_b", bjet1_bID_deepFlavor}, {"bjet1_deepflavor_cvsb", CvsB_b1}, {"bjet1_deepflavor_cvsl", CvsL_b1}, {"bjet1_hhbtag", HHbtag_b1},
+                {"bjet2_pt", bjet2_pt}, {"bjet2_eta", bjet2_eta}, {"bjet2_phi", bjet2_phi}, {"bjet2_e", bjet2_e},
+                {"bjet2_deepflavor_b", bjet2_bID_deepFlavor}, {"bjet2_deepflavor_cvsb", CvsB_b2}, {"bjet2_deepflavor_cvsl", CvsL_b2}, {"bjet2_hhbtag", HHbtag_b2},
+                {"vbfjet1_pt", vbfjet1_pt}, {"vbfjet1_eta", vbfjet1_eta}, {"vbfjet1_phi", vbfjet1_phi}, {"vbfjet1_e", vbfjet1_e},
+                {"vbfjet1_deepflavor_b", VBFjet1_btag_deepFlavor}, {"vbfjet1_deepflavor_cvsb", CvsB_vbf1}, {"vbfjet1_deepflavor_cvsl", CvsL_vbf1}, {"vbfjet1_hhbtag", HHbtag_vbf1},
+                {"vbfjet2_pt", vbfjet2_pt}, {"vbfjet2_eta", vbfjet2_eta}, {"vbfjet2_phi", vbfjet2_phi}, {"vbfjet2_e", vbfjet2_e},
+                {"vbfjet2_deepflavor_b", VBFjet2_btag_deepFlavor}, {"vbfjet2_deepflavor_cvsb", CvsB_vbf2}, {"vbfjet2_deepflavor_cvsl", CvsL_vbf2}, {"vbfjet2_hhbtag", HHbtag_vbf2},
+                {"lep1_pt", tau1_tauup.Pt()}, {"lep1_eta", tau1_tauup.Eta()}, {"lep1_phi", tau1_tauup.Phi()}, {"lep1_e", tau1_tauup.E()},
+                {"lep2_pt", tau2_tauup.Pt()}, {"lep2_eta", tau2_tauup.Eta()}, {"lep2_phi", tau2_tauup.Phi()}, {"lep2_e", tau2_tauup.E()},
+                {"met_pt", met_tauup.Pt()}, {"met_phi", met_tauup.Phi()},
+                {"bh_pt", (bjet1+bjet2).Pt()}, {"bh_eta", (bjet1+bjet2).Eta()}, {"bh_phi", (bjet1+bjet2).Phi()}, {"bh_e", (bjet1+bjet2).E()},
+                {"tauh_sv_pt", svfit_tauup.Pt()}, {"tauh_sv_eta", svfit_tauup.Eta()}, {"tauh_sv_phi", svfit_tauup.Phi()}, {"tauh_sv_e", svfit_tauup.E()}
+              });
+            }
+            auto mdnnSM0_score_tauup  = mci.predict(EventNumber, 0);
+            auto mdnnSM1_score_tauup  = mci.predict(EventNumber, 1);
+            auto mdnnBSM0_score_tauup = mci.predict(EventNumber, 2);
+            for (uint k=0; k<mdnnSM0_score_tauup.size(); k++)
+              mdnnSM0_output_tauup[i].at(k) = mdnnSM0_score_tauup.at(k).second;
+            for (uint k=0; k<mdnnSM1_score_tauup.size(); k++)
+              mdnnSM1_output_tauup[i].at(k) = mdnnSM1_score_tauup.at(k).second;
+            for (uint k=0; k<mdnnBSM0_score_tauup.size(); k++)
+              mdnnBSM0_output_tauup[i].at(k) = mdnnBSM0_score_tauup.at(k).second;
+
+            mci.clearInputs();
+            for (uint j=0; j<mci.getNumberOfModels(); j++)
+            {
+              mci.setInputs(j,
+              {
+                {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
+                {"bjet1_pt", bjet1_pt}, {"bjet1_eta", bjet1_eta}, {"bjet1_phi", bjet1_phi}, {"bjet1_e", bjet1_e},
+                {"bjet1_deepflavor_b", bjet1_bID_deepFlavor}, {"bjet1_deepflavor_cvsb", CvsB_b1}, {"bjet1_deepflavor_cvsl", CvsL_b1}, {"bjet1_hhbtag", HHbtag_b1},
+                {"bjet2_pt", bjet2_pt}, {"bjet2_eta", bjet2_eta}, {"bjet2_phi", bjet2_phi}, {"bjet2_e", bjet2_e},
+                {"bjet2_deepflavor_b", bjet2_bID_deepFlavor}, {"bjet2_deepflavor_cvsb", CvsB_b2}, {"bjet2_deepflavor_cvsl", CvsL_b2}, {"bjet2_hhbtag", HHbtag_b2},
+                {"vbfjet1_pt", vbfjet1_pt}, {"vbfjet1_eta", vbfjet1_eta}, {"vbfjet1_phi", vbfjet1_phi}, {"vbfjet1_e", vbfjet1_e},
+                {"vbfjet1_deepflavor_b", VBFjet1_btag_deepFlavor}, {"vbfjet1_deepflavor_cvsb", CvsB_vbf1}, {"vbfjet1_deepflavor_cvsl", CvsL_vbf1}, {"vbfjet1_hhbtag", HHbtag_vbf1},
+                {"vbfjet2_pt", vbfjet2_pt}, {"vbfjet2_eta", vbfjet2_eta}, {"vbfjet2_phi", vbfjet2_phi}, {"vbfjet2_e", vbfjet2_e},
+                {"vbfjet2_deepflavor_b", VBFjet2_btag_deepFlavor}, {"vbfjet2_deepflavor_cvsb", CvsB_vbf2}, {"vbfjet2_deepflavor_cvsl", CvsL_vbf2}, {"vbfjet2_hhbtag", HHbtag_vbf2},
+                {"lep1_pt", tau1_taudown.Pt()}, {"lep1_eta", tau1_taudown.Eta()}, {"lep1_phi", tau1_taudown.Phi()}, {"lep1_e", tau1_taudown.E()},
+                {"lep2_pt", tau2_taudown.Pt()}, {"lep2_eta", tau2_taudown.Eta()}, {"lep2_phi", tau2_taudown.Phi()}, {"lep2_e", tau2_taudown.E()},
+                {"met_pt", met_taudown.Pt()}, {"met_phi", met_taudown.Phi()},
+                {"bh_pt", (bjet1+bjet2).Pt()}, {"bh_eta", (bjet1+bjet2).Eta()}, {"bh_phi", (bjet1+bjet2).Phi()}, {"bh_e", (bjet1+bjet2).E()},
+                {"tauh_sv_pt", svfit_taudown.Pt()}, {"tauh_sv_eta", svfit_taudown.Eta()}, {"tauh_sv_phi", svfit_taudown.Phi()}, {"tauh_sv_e", svfit_taudown.E()}
+              });
+            }
+            auto mdnnSM0_score_taudown  = mci.predict(EventNumber, 0);
+            auto mdnnSM1_score_taudown  = mci.predict(EventNumber, 1);
+            auto mdnnBSM0_score_taudown = mci.predict(EventNumber, 2);
+            for (uint k=0; k<mdnnSM0_score_taudown.size(); k++)
+              mdnnSM0_output_taudown[i].at(k) = mdnnSM0_score_taudown.at(k).second;
+            for (uint k=0; k<mdnnSM1_score_taudown.size(); k++)
+              mdnnSM1_output_taudown[i].at(k) = mdnnSM1_score_taudown.at(k).second;
+            for (uint k=0; k<mdnnBSM0_score_taudown.size(); k++)
+              mdnnBSM0_output_taudown[i].at(k) = mdnnBSM0_score_taudown.at(k).second;
           }
 
           if (doBDT)
@@ -2605,6 +2711,14 @@ int main (int argc, char** argv)
       b_mdnnSM0_eledown_DM0.at(i)->Fill();
       b_mdnnSM0_eleup_DM1.at(i)->Fill();
       b_mdnnSM0_eledown_DM1.at(i)->Fill();
+      b_mdnnSM0_tauup_DM0.at(i)->Fill();
+      b_mdnnSM0_taudown_DM0.at(i)->Fill();
+      b_mdnnSM0_tauup_DM1.at(i)->Fill();
+      b_mdnnSM0_taudown_DM1.at(i)->Fill();
+      b_mdnnSM0_tauup_DM10.at(i)->Fill();
+      b_mdnnSM0_taudown_DM10.at(i)->Fill();
+      b_mdnnSM0_tauup_DM11.at(i)->Fill();
+      b_mdnnSM0_taudown_DM11.at(i)->Fill();
       b_mdnnSM0_jetupTot.at(i)->Fill();
       b_mdnnSM0_jetdownTot.at(i)->Fill();
     }
@@ -2617,6 +2731,14 @@ int main (int argc, char** argv)
       b_mdnnSM1_eledown_DM0.at(i)->Fill();
       b_mdnnSM1_eleup_DM1.at(i)->Fill();
       b_mdnnSM1_eledown_DM1.at(i)->Fill();
+      b_mdnnSM1_tauup_DM0.at(i)->Fill();
+      b_mdnnSM1_taudown_DM0.at(i)->Fill();
+      b_mdnnSM1_tauup_DM1.at(i)->Fill();
+      b_mdnnSM1_taudown_DM1.at(i)->Fill();
+      b_mdnnSM1_tauup_DM10.at(i)->Fill();
+      b_mdnnSM1_taudown_DM10.at(i)->Fill();
+      b_mdnnSM1_tauup_DM11.at(i)->Fill();
+      b_mdnnSM1_taudown_DM11.at(i)->Fill();
       b_mdnnSM1_jetupTot.at(i)->Fill();
       b_mdnnSM1_jetdownTot.at(i)->Fill();
     }
@@ -2629,6 +2751,14 @@ int main (int argc, char** argv)
       b_mdnnBSM0_eledown_DM0.at(i)->Fill();
       b_mdnnBSM0_eleup_DM1.at(i)->Fill();
       b_mdnnBSM0_eledown_DM1.at(i)->Fill();
+      b_mdnnBSM0_tauup_DM0.at(i)->Fill();
+      b_mdnnBSM0_taudown_DM0.at(i)->Fill();
+      b_mdnnBSM0_tauup_DM1.at(i)->Fill();
+      b_mdnnBSM0_taudown_DM1.at(i)->Fill();
+      b_mdnnBSM0_tauup_DM10.at(i)->Fill();
+      b_mdnnBSM0_taudown_DM10.at(i)->Fill();
+      b_mdnnBSM0_tauup_DM11.at(i)->Fill();
+      b_mdnnBSM0_taudown_DM11.at(i)->Fill();
       b_mdnnBSM0_jetupTot.at(i)->Fill();
       b_mdnnBSM0_jetdownTot.at(i)->Fill();
     }

--- a/test/skimOutputter.cpp
+++ b/test/skimOutputter.cpp
@@ -2129,6 +2129,47 @@ int main (int argc, char** argv)
         DNNoutSM_kl_1_jetdownTot   = DNNoutSM_kl_1;
         BDToutSM_kl_1_jetupTot     = BDToutSM_kl_1;
         BDToutSM_kl_1_jetdownTot   = BDToutSM_kl_1;
+
+        // VBF multiclass
+        mci.clearInputs();
+        for (uint i=0; i<mci.getNumberOfModels(); i++)
+        {
+          mci.setInputs(i,
+          {
+            {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
+            {"bjet1_pt", bjet1_pt}, {"bjet1_eta", bjet1_eta}, {"bjet1_phi", bjet1_phi}, {"bjet1_e", bjet1_e},
+            {"bjet1_deepflavor_b", bjet1_bID_deepFlavor}, {"bjet1_deepflavor_cvsb", CvsB_b1}, {"bjet1_deepflavor_cvsl", CvsL_b1}, {"bjet1_hhbtag", HHbtag_b1},
+            {"bjet2_pt", bjet2_pt}, {"bjet2_eta", bjet2_eta}, {"bjet2_phi", bjet2_phi}, {"bjet2_e", bjet2_e},
+            {"bjet2_deepflavor_b", bjet2_bID_deepFlavor}, {"bjet2_deepflavor_cvsb", CvsB_b2}, {"bjet2_deepflavor_cvsl", CvsL_b2}, {"bjet2_hhbtag", HHbtag_b2},
+            {"vbfjet1_pt", vbfjet1_pt}, {"vbfjet1_eta", vbfjet1_eta}, {"vbfjet1_phi", vbfjet1_phi}, {"vbfjet1_e", vbfjet1_e},
+            {"vbfjet1_deepflavor_b", VBFjet1_btag_deepFlavor}, {"vbfjet1_deepflavor_cvsb", CvsB_vbf1}, {"vbfjet1_deepflavor_cvsl", CvsL_vbf1}, {"vbfjet1_hhbtag", HHbtag_vbf1},
+            {"vbfjet2_pt", vbfjet2_pt}, {"vbfjet2_eta", vbfjet2_eta}, {"vbfjet2_phi", vbfjet2_phi}, {"vbfjet2_e", vbfjet2_e},
+            {"vbfjet2_deepflavor_b", VBFjet2_btag_deepFlavor}, {"vbfjet2_deepflavor_cvsb", CvsB_vbf2}, {"vbfjet2_deepflavor_cvsl", CvsL_vbf2}, {"vbfjet2_hhbtag", HHbtag_vbf2},
+            {"lep1_pt", dau1_pt}, {"lep1_eta", dau1_eta}, {"lep1_phi", dau1_phi}, {"lep1_e", dau1_e},
+            {"lep2_pt", dau2_pt}, {"lep2_eta", dau2_eta}, {"lep2_phi", dau2_phi}, {"lep2_e", dau2_e},
+            {"met_pt", met.Pt()}, {"met_phi", met.Phi()},
+            {"bh_pt", (bjet1+bjet2).Pt()}, {"bh_eta", (bjet1+bjet2).Eta()}, {"bh_phi", (bjet1+bjet2).Phi()}, {"bh_e", (bjet1+bjet2).E()},
+            {"tauh_sv_pt", tauH_SVFIT_pt}, {"tauh_sv_eta", tauH_SVFIT_eta}, {"tauh_sv_phi", tauH_SVFIT_phi}, {"tauh_sv_e", svfit.E()}
+          });
+        }
+        auto mdnnSM0_score_jetTot  = mci.predict(EventNumber, 0);
+        auto mdnnSM1_score_jetTot  = mci.predict(EventNumber, 1);
+        auto mdnnBSM0_score_jetTot = mci.predict(EventNumber, 2);
+        for (uint i=0; i<mdnnSM0_score_jetTot.size(); i++)
+        {
+          mdnnSM0_output_jetupTot.at(i)   = mdnnSM0_score_jetTot.at(i).second;
+          mdnnSM0_output_jetdownTot.at(i) = mdnnSM0_score_jetTot.at(i).second;
+        }
+        for (uint i=0; i<mdnnSM1_score_jetTot.size(); i++)
+        {
+          mdnnSM1_output_jetupTot.at(i)   = mdnnSM1_score_jetTot.at(i).second;
+          mdnnSM1_output_jetdownTot.at(i) = mdnnSM1_score_jetTot.at(i).second;
+        }
+        for (uint i=0; i<mdnnBSM0_score_jetTot.size(); i++)
+        {
+          mdnnBSM0_output_jetupTot.at(i)   = mdnnBSM0_score_jetTot.at(i).second;
+          mdnnBSM0_output_jetdownTot.at(i) = mdnnBSM0_score_jetTot.at(i).second;
+        }
       }
       else /*isMC*/
       {
@@ -2276,6 +2317,71 @@ int main (int argc, char** argv)
           DNNoutSM_kl_1_jetdownTot = outs_jetdownTot.at(0);
         }
 
+        if (doMult)
+        {
+          mci.clearInputs();
+          for (uint i=0; i<mci.getNumberOfModels(); i++)
+          {
+            mci.setInputs(i,
+            {
+              {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
+              {"bjet1_pt", bjet1_jetupTot.Pt()}, {"bjet1_eta", bjet1_jetupTot.Eta()}, {"bjet1_phi", bjet1_jetupTot.Phi()}, {"bjet1_e", bjet1_jetupTot.E()},
+              {"bjet1_deepflavor_b", bjet1_bID_deepFlavor}, {"bjet1_deepflavor_cvsb", CvsB_b1}, {"bjet1_deepflavor_cvsl", CvsL_b1}, {"bjet1_hhbtag", HHbtag_b1},
+              {"bjet2_pt", bjet2_jetupTot.Pt()}, {"bjet2_eta", bjet2_jetupTot.Eta()}, {"bjet2_phi", bjet2_jetupTot.Phi()}, {"bjet2_e", bjet2_jetupTot.E()},
+              {"bjet2_deepflavor_b", bjet2_bID_deepFlavor}, {"bjet2_deepflavor_cvsb", CvsB_b2}, {"bjet2_deepflavor_cvsl", CvsL_b2}, {"bjet2_hhbtag", HHbtag_b2},
+              {"vbfjet1_pt", vbfjet1_jetupTot.Pt()}, {"vbfjet1_eta", vbfjet1_jetupTot.Eta()}, {"vbfjet1_phi", vbfjet1_jetupTot.Phi()}, {"vbfjet1_e", vbfjet1_jetupTot.E()},
+              {"vbfjet1_deepflavor_b", VBFjet1_btag_deepFlavor}, {"vbfjet1_deepflavor_cvsb", CvsB_vbf1}, {"vbfjet1_deepflavor_cvsl", CvsL_vbf1}, {"vbfjet1_hhbtag", HHbtag_vbf1},
+              {"vbfjet2_pt", vbfjet2_jetupTot.Pt()}, {"vbfjet2_eta", vbfjet2_jetupTot.Eta()}, {"vbfjet2_phi", vbfjet2_jetupTot.Phi()}, {"vbfjet2_e", vbfjet2_jetupTot.E()},
+              {"vbfjet2_deepflavor_b", VBFjet2_btag_deepFlavor}, {"vbfjet2_deepflavor_cvsb", CvsB_vbf2}, {"vbfjet2_deepflavor_cvsl", CvsL_vbf2}, {"vbfjet2_hhbtag", HHbtag_vbf2},
+              {"lep1_pt", dau1_pt}, {"lep1_eta", dau1_eta}, {"lep1_phi", dau1_phi}, {"lep1_e", dau1_e},
+              {"lep2_pt", dau2_pt}, {"lep2_eta", dau2_eta}, {"lep2_phi", dau2_phi}, {"lep2_e", dau2_e},
+              {"met_pt", met_jetupTot.Pt()}, {"met_phi", met_jetupTot.Phi()},
+              {"bh_pt", (bjet1_jetupTot+bjet2_jetupTot).Pt()}, {"bh_eta", (bjet1_jetupTot+bjet2_jetupTot).Eta()}, {"bh_phi", (bjet1_jetupTot+bjet2_jetupTot).Phi()}, {"bh_e", (bjet1_jetupTot+bjet2_jetupTot).E()},
+              {"tauh_sv_pt", svfit_jetupTot.Pt()}, {"tauh_sv_eta", svfit_jetupTot.Eta()}, {"tauh_sv_phi", svfit_jetupTot.Phi()}, {"tauh_sv_e", svfit_jetupTot.E()}
+            });
+          }
+          auto mdnnSM0_score_jetupTot  = mci.predict(EventNumber, 0);
+          auto mdnnSM1_score_jetupTot  = mci.predict(EventNumber, 1);
+          auto mdnnBSM0_score_jetupTot = mci.predict(EventNumber, 2);
+          for (uint i=0; i<mdnnSM0_score_jetupTot.size(); i++)
+            mdnnSM0_output_jetupTot.at(i) = mdnnSM0_score_jetupTot.at(i).second;
+          for (uint i=0; i<mdnnSM1_score_jetupTot.size(); i++)
+            mdnnSM1_output_jetupTot.at(i) = mdnnSM1_score_jetupTot.at(i).second;
+          for (uint i=0; i<mdnnBSM0_score_jetupTot.size(); i++)
+            mdnnBSM0_output_jetupTot.at(i) = mdnnBSM0_score_jetupTot.at(i).second;
+
+          mci.clearInputs();
+          for (uint i=0; i<mci.getNumberOfModels(); i++)
+          {
+            mci.setInputs(i,
+            {
+              {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
+              {"bjet1_pt", bjet1_jetdownTot.Pt()}, {"bjet1_eta", bjet1_jetdownTot.Eta()}, {"bjet1_phi", bjet1_jetdownTot.Phi()}, {"bjet1_e", bjet1_jetdownTot.E()},
+              {"bjet1_deepflavor_b", bjet1_bID_deepFlavor}, {"bjet1_deepflavor_cvsb", CvsB_b1}, {"bjet1_deepflavor_cvsl", CvsL_b1}, {"bjet1_hhbtag", HHbtag_b1},
+              {"bjet2_pt", bjet2_jetdownTot.Pt()}, {"bjet2_eta", bjet2_jetdownTot.Eta()}, {"bjet2_phi", bjet2_jetdownTot.Phi()}, {"bjet2_e", bjet2_jetdownTot.E()},
+              {"bjet2_deepflavor_b", bjet2_bID_deepFlavor}, {"bjet2_deepflavor_cvsb", CvsB_b2}, {"bjet2_deepflavor_cvsl", CvsL_b2}, {"bjet2_hhbtag", HHbtag_b2},
+              {"vbfjet1_pt", vbfjet1_jetdownTot.Pt()}, {"vbfjet1_eta", vbfjet1_jetdownTot.Eta()}, {"vbfjet1_phi", vbfjet1_jetdownTot.Phi()}, {"vbfjet1_e", vbfjet1_jetdownTot.E()},
+              {"vbfjet1_deepflavor_b", VBFjet1_btag_deepFlavor}, {"vbfjet1_deepflavor_cvsb", CvsB_vbf1}, {"vbfjet1_deepflavor_cvsl", CvsL_vbf1}, {"vbfjet1_hhbtag", HHbtag_vbf1},
+              {"vbfjet2_pt", vbfjet2_jetdownTot.Pt()}, {"vbfjet2_eta", vbfjet2_jetdownTot.Eta()}, {"vbfjet2_phi", vbfjet2_jetdownTot.Phi()}, {"vbfjet2_e", vbfjet2_jetdownTot.E()},
+              {"vbfjet2_deepflavor_b", VBFjet2_btag_deepFlavor}, {"vbfjet2_deepflavor_cvsb", CvsB_vbf2}, {"vbfjet2_deepflavor_cvsl", CvsL_vbf2}, {"vbfjet2_hhbtag", HHbtag_vbf2},
+              {"lep1_pt", dau1_pt}, {"lep1_eta", dau1_eta}, {"lep1_phi", dau1_phi}, {"lep1_e", dau1_e},
+              {"lep2_pt", dau2_pt}, {"lep2_eta", dau2_eta}, {"lep2_phi", dau2_phi}, {"lep2_e", dau2_e},
+              {"met_pt", met_jetdownTot.Pt()}, {"met_phi", met_jetdownTot.Phi()},
+              {"bh_pt", (bjet1_jetdownTot+bjet2_jetdownTot).Pt()}, {"bh_eta", (bjet1_jetdownTot+bjet2_jetdownTot).Eta()}, {"bh_phi", (bjet1_jetdownTot+bjet2_jetdownTot).Phi()}, {"bh_e", (bjet1_jetdownTot+bjet2_jetdownTot).E()},
+              {"tauh_sv_pt", svfit_jetdownTot.Pt()}, {"tauh_sv_eta", svfit_jetdownTot.Eta()}, {"tauh_sv_phi", svfit_jetdownTot.Phi()}, {"tauh_sv_e", svfit_jetdownTot.E()}
+            });
+          }
+          auto mdnnSM0_score_jetdownTot  = mci.predict(EventNumber, 0);
+          auto mdnnSM1_score_jetdownTot  = mci.predict(EventNumber, 1);
+          auto mdnnBSM0_score_jetdownTot = mci.predict(EventNumber, 2);
+          for (uint i=0; i<mdnnSM0_score_jetdownTot.size(); i++)
+            mdnnSM0_output_jetdownTot.at(i) = mdnnSM0_score_jetdownTot.at(i).second;
+          for (uint i=0; i<mdnnSM1_score_jetdownTot.size(); i++)
+            mdnnSM1_output_jetdownTot.at(i) = mdnnSM1_score_jetdownTot.at(i).second;
+          for (uint i=0; i<mdnnBSM0_score_jetdownTot.size(); i++)
+            mdnnBSM0_output_jetdownTot.at(i) = mdnnBSM0_score_jetdownTot.at(i).second;
+        }
+
         if (doBDT)
         {
           BDTreader.SetInputValues(bjet2_jetupTot.Pt(), (bjet1_jetupTot+bjet2_jetupTot).Pt(), tau1.Pt(),
@@ -2389,18 +2495,24 @@ int main (int argc, char** argv)
       b_mdnnSM0_new.at(i)->Fill();
       b_mdnnSM0_muup.at(i)->Fill();
       b_mdnnSM0_mudown.at(i)->Fill();
+      b_mdnnSM0_jetupTot.at(i)->Fill();
+      b_mdnnSM0_jetdownTot.at(i)->Fill();
     }
     for (int i=0; i<mdnnSM1_size; i++)
     {
       b_mdnnSM1_new.at(i)->Fill();
       b_mdnnSM1_muup.at(i)->Fill();
       b_mdnnSM1_mudown.at(i)->Fill();
+      b_mdnnSM1_jetupTot.at(i)->Fill();
+      b_mdnnSM1_jetdownTot.at(i)->Fill();
     }
     for (int i=0; i<mdnnBSM0_size; i++)
     {
       b_mdnnBSM0_new.at(i)->Fill();
       b_mdnnBSM0_muup.at(i)->Fill();
       b_mdnnBSM0_mudown.at(i)->Fill();
+      b_mdnnBSM0_jetupTot.at(i)->Fill();
+      b_mdnnBSM0_jetdownTot.at(i)->Fill();
     }
 
     // Timing branches

--- a/test/skimOutputter.cpp
+++ b/test/skimOutputter.cpp
@@ -132,6 +132,10 @@ int main (int argc, char** argv)
   // Input setup
   TFile *inputFile = new TFile (inputFileName, "read") ;
 
+  // Efficiency histograms
+  TH1F* h_eff        = (TH1F*)inputFile->Get("h_eff");
+  TH1F* h_effSummary = (TH1F*)inputFile->Get("h_effSummary");
+
   // Systematics histogram
   TH1F* h_syst = (TH1F*)inputFile->Get("h_syst");
   const int N_jecSources = h_syst->GetBinContent(1); //jec sources
@@ -162,12 +166,12 @@ int main (int argc, char** argv)
   // Define branches to be activated
   std::vector<std::string> toBeActivated {
   "EventNumber", "RunNumber","nleps","pairType","nbjetscand",          // General
-  "isOS", "isBoosted",
+  "isOS","isBoosted","isTau1real","isTau2real",
 
   "MC_weight","PUReweight","PUjetID_SF","L1pref_weight",               // Weights and SFs
   "prescaleWeight","trigSF","VBFtrigSF","DYscale_MTT","DYscale_MH",
   "IdAndIsoAndFakeSF_deep","IdAndIsoAndFakeSF_deep_pt",
-  "TTtopPtreweight", "bTagweightM", "bTagweightL",
+  "TTtopPtreweight*","bTagweightM","bTagweightL",
 
   "isVBFtrigger", "isVBF",                                             // Trigger vbf selection
 
@@ -179,6 +183,7 @@ int main (int argc, char** argv)
   "bjet1_bID_deepFlavor", "bjet2_bID_deepFlavor",                      // b-tagging          
   "bjet1_bID_deepCSV", "bjet2_bID_deepCSV",
   "bjet1_Cvs*","bjet2_Cvs*","VBFjet1_Cvs*","VBFjet2_Cvs*",
+  "VBFjet1_btag_deepFlavor","VBFjet2_btag_deepFlavor",
 
   "bjet1_HHbtag","bjet2_HHbtag","VBFjet1_HHbtag","VBFjet2_HHbtag",     // HHbtag
 
@@ -257,7 +262,7 @@ int main (int argc, char** argv)
 
   "HHKin_mass","HHKin_chi2", "MT2",                                    // Old values KinFit, MT2, SVfit, DNN, BDT
   "tauH_SVFIT_pt","tauH_SVFIT_eta","tauH_SVFIT_phi","tauH_SVFIT_mass",
-  "DNNoutSM_kl_1","BDToutSM_kl_1"
+  "DNNoutSM_kl_1","BDToutSM_kl_1","mdnn*"
   };
 
   // Activate only branches I need/want to store
@@ -288,6 +293,9 @@ int main (int argc, char** argv)
 
   // Save and close cloneFile and inputFile
   cloneFile->cd();
+  h_eff->Write();
+  h_effSummary->Write();
+  h_syst->Write();
   treenew->Write();
   cloneFile->Write();
   cloneFile->Close();

--- a/test/skimOutputter.cpp
+++ b/test/skimOutputter.cpp
@@ -913,16 +913,27 @@ int main (int argc, char** argv)
   // JES variations
   std::vector<Float_t> tauH_SVFIT_mass_jetup(N_jecSources), DNNoutSM_kl_1_jetup(N_jecSources), BDToutSM_kl_1_jetup(N_jecSources);
   std::vector<Float_t> tauH_SVFIT_mass_jetdown(N_jecSources), DNNoutSM_kl_1_jetdown(N_jecSources), BDToutSM_kl_1_jetdown(N_jecSources);
+  std::vector<std::vector<Float_t>> mdnnSM0_output_jetup (N_jecSources, std::vector<Float_t>(mdnnSM0_size)) , mdnnSM0_output_jetdown (N_jecSources, std::vector<Float_t>(mdnnSM0_size));
+  std::vector<std::vector<Float_t>> mdnnSM1_output_jetup (N_jecSources, std::vector<Float_t>(mdnnSM1_size)) , mdnnSM1_output_jetdown (N_jecSources, std::vector<Float_t>(mdnnSM1_size));
+  std::vector<std::vector<Float_t>> mdnnBSM0_output_jetup(N_jecSources, std::vector<Float_t>(mdnnBSM0_size)), mdnnBSM0_output_jetdown(N_jecSources, std::vector<Float_t>(mdnnBSM0_size));
   std::vector<TBranch*> b_tauH_SVFIT_mass_jetup, b_tauH_SVFIT_mass_jetdown;
   std::vector<TBranch*> b_DNNoutSM_kl_1_jetup  , b_DNNoutSM_kl_1_jetdown  ;
   std::vector<TBranch*> b_BDToutSM_kl_1_jetup  , b_BDToutSM_kl_1_jetdown  ;
-
+  std::vector<std::vector<TBranch*>> b_mdnnSM0_jetup (N_jecSources, std::vector<TBranch*>(mdnnSM0_size)) , b_mdnnSM0_jetdown (N_jecSources, std::vector<TBranch*>(mdnnSM0_size));
+  std::vector<std::vector<TBranch*>> b_mdnnSM1_jetup (N_jecSources, std::vector<TBranch*>(mdnnSM1_size)) , b_mdnnSM1_jetdown (N_jecSources, std::vector<TBranch*>(mdnnSM1_size));
+  std::vector<std::vector<TBranch*>> b_mdnnBSM0_jetup(N_jecSources, std::vector<TBranch*>(mdnnBSM0_size)), b_mdnnBSM0_jetdown(N_jecSources, std::vector<TBranch*>(mdnnBSM0_size));
   boost::format tauHName_up  ("tauH_SVFIT_mass_jetup%i");
   boost::format DNNName_up   ("DNNoutSM_kl_1_jetup%i");
   boost::format BDTName_up   ("BDToutSM_kl_1_jetup%i");
   boost::format tauHName_down("tauH_SVFIT_mass_jetdown%i");
   boost::format DNNName_down ("DNNoutSM_kl_1_jetdown%i");
   boost::format BDTName_down ("BDToutSM_kl_1_jetdown%i");
+  boost::format mdnnSM0name_jetup   ("mdnn__v0__kl1_c2v1_c31__%1%_jetup%2%");
+  boost::format mdnnSM0name_jetdown ("mdnn__v0__kl1_c2v1_c31__%1%_jetdown%2%");
+  boost::format mdnnSM1name_jetup   ("mdnn__v1__kl1_c2v1_c31__%1%_jetup%2%");
+  boost::format mdnnSM1name_jetdown ("mdnn__v1__kl1_c2v1_c31__%1%_jetdown%2%");
+  boost::format mdnnBSM0name_jetup  ("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_jetup%2%");
+  boost::format mdnnBSM0name_jetdown("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_jetdown%2%");
   for (int i=0; i<N_jecSources; i++)
   {
     std::string tmp_tauH_up_branch_name   = boost::str(tauHName_up   % (i+1));
@@ -945,6 +956,34 @@ int main (int argc, char** argv)
     b_tauH_SVFIT_mass_jetdown.push_back(tmp_tauH_down_branch);
     b_DNNoutSM_kl_1_jetdown  .push_back(tmp_DNN_down_branch);
     b_BDToutSM_kl_1_jetdown  .push_back(tmp_DBT_down_branch);
+
+    for (int k=0; k<mdnnSM0_size; k++)
+    {
+      std::string tmp_mdnnSM0_branch_name_up   = boost::str( mdnnSM0name_jetup   % (mci.getNodeNames(0)).at(k) % (i+1) );
+      std::string tmp_mdnnSM0_branch_name_down = boost::str( mdnnSM0name_jetdown % (mci.getNodeNames(0)).at(k) % (i+1) );
+      TBranch* tmp_mdnnSM0_branch_up   = outTree->Branch(tmp_mdnnSM0_branch_name_up.c_str()  , &mdnnSM0_output_jetup  [i].at(k));
+      TBranch* tmp_mdnnSM0_branch_down = outTree->Branch(tmp_mdnnSM0_branch_name_down.c_str(), &mdnnSM0_output_jetdown[i].at(k));
+      b_mdnnSM0_jetup  [i][k] = tmp_mdnnSM0_branch_up;
+      b_mdnnSM0_jetdown[i][k] = tmp_mdnnSM0_branch_down;
+    }
+    for (int k=0; k<mdnnSM1_size; k++)
+    {
+      std::string tmp_mdnnSM1_branch_name_up   = boost::str( mdnnSM1name_jetup   % (mci.getNodeNames(1)).at(k) % (i+1) );
+      std::string tmp_mdnnSM1_branch_name_down = boost::str( mdnnSM1name_jetdown % (mci.getNodeNames(1)).at(k) % (i+1) );
+      TBranch* tmp_mdnnSM1_branch_up   = outTree->Branch(tmp_mdnnSM1_branch_name_up.c_str()  , &mdnnSM1_output_jetup  [i].at(k));
+      TBranch* tmp_mdnnSM1_branch_down = outTree->Branch(tmp_mdnnSM1_branch_name_down.c_str(), &mdnnSM1_output_jetdown[i].at(k));
+      b_mdnnSM1_jetup  [i][k] = tmp_mdnnSM1_branch_up;
+      b_mdnnSM1_jetdown[i][k] = tmp_mdnnSM1_branch_down;
+    }
+    for (int k=0; k<mdnnBSM0_size; k++)
+    {
+      std::string tmp_mdnnBSM0_branch_name_up   = boost::str( mdnnBSM0name_jetup   % (mci.getNodeNames(2)).at(k) % (i+1) );
+      std::string tmp_mdnnBSM0_branch_name_down = boost::str( mdnnBSM0name_jetdown % (mci.getNodeNames(2)).at(k) % (i+1) );
+      TBranch* tmp_mdnnBSM0_branch_up   = outTree->Branch(tmp_mdnnBSM0_branch_name_up.c_str()  , &mdnnBSM0_output_jetup  [i].at(k));
+      TBranch* tmp_mdnnBSM0_branch_down = outTree->Branch(tmp_mdnnBSM0_branch_name_down.c_str(), &mdnnBSM0_output_jetdown[i].at(k));
+      b_mdnnBSM0_jetup  [i][k] = tmp_mdnnBSM0_branch_up;
+      b_mdnnBSM0_jetdown[i][k] = tmp_mdnnBSM0_branch_down;
+    }
   }
 
   // JES variations Total
@@ -2152,6 +2191,47 @@ int main (int argc, char** argv)
           DNNoutSM_kl_1_jetdown.at(i)   = DNNoutSM_kl_1;
           BDToutSM_kl_1_jetup.at(i)     = BDToutSM_kl_1;
           BDToutSM_kl_1_jetdown.at(i)   = BDToutSM_kl_1;
+
+          // VBF multiclass
+          mci.clearInputs();
+          for (uint j=0; j<mci.getNumberOfModels(); j++)
+          {
+            mci.setInputs(j,
+            {
+              {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
+              {"bjet1_pt", bjet1_pt}, {"bjet1_eta", bjet1_eta}, {"bjet1_phi", bjet1_phi}, {"bjet1_e", bjet1_e},
+              {"bjet1_deepflavor_b", bjet1_bID_deepFlavor}, {"bjet1_deepflavor_cvsb", CvsB_b1}, {"bjet1_deepflavor_cvsl", CvsL_b1}, {"bjet1_hhbtag", HHbtag_b1},
+              {"bjet2_pt", bjet2_pt}, {"bjet2_eta", bjet2_eta}, {"bjet2_phi", bjet2_phi}, {"bjet2_e", bjet2_e},
+              {"bjet2_deepflavor_b", bjet2_bID_deepFlavor}, {"bjet2_deepflavor_cvsb", CvsB_b2}, {"bjet2_deepflavor_cvsl", CvsL_b2}, {"bjet2_hhbtag", HHbtag_b2},
+              {"vbfjet1_pt", vbfjet1_pt}, {"vbfjet1_eta", vbfjet1_eta}, {"vbfjet1_phi", vbfjet1_phi}, {"vbfjet1_e", vbfjet1_e},
+              {"vbfjet1_deepflavor_b", VBFjet1_btag_deepFlavor}, {"vbfjet1_deepflavor_cvsb", CvsB_vbf1}, {"vbfjet1_deepflavor_cvsl", CvsL_vbf1}, {"vbfjet1_hhbtag", HHbtag_vbf1},
+              {"vbfjet2_pt", vbfjet2_pt}, {"vbfjet2_eta", vbfjet2_eta}, {"vbfjet2_phi", vbfjet2_phi}, {"vbfjet2_e", vbfjet2_e},
+              {"vbfjet2_deepflavor_b", VBFjet2_btag_deepFlavor}, {"vbfjet2_deepflavor_cvsb", CvsB_vbf2}, {"vbfjet2_deepflavor_cvsl", CvsL_vbf2}, {"vbfjet2_hhbtag", HHbtag_vbf2},
+              {"lep1_pt", dau1_pt}, {"lep1_eta", dau1_eta}, {"lep1_phi", dau1_phi}, {"lep1_e", dau1_e},
+              {"lep2_pt", dau2_pt}, {"lep2_eta", dau2_eta}, {"lep2_phi", dau2_phi}, {"lep2_e", dau2_e},
+              {"met_pt", met.Pt()}, {"met_phi", met.Phi()},
+              {"bh_pt", (bjet1+bjet2).Pt()}, {"bh_eta", (bjet1+bjet2).Eta()}, {"bh_phi", (bjet1+bjet2).Phi()}, {"bh_e", (bjet1+bjet2).E()},
+              {"tauh_sv_pt", tauH_SVFIT_pt}, {"tauh_sv_eta", tauH_SVFIT_eta}, {"tauh_sv_phi", tauH_SVFIT_phi}, {"tauh_sv_e", svfit.E()}
+            });
+          }
+          auto mdnnSM0_score_jes  = mci.predict(EventNumber, 0);
+          auto mdnnSM1_score_jes  = mci.predict(EventNumber, 1);
+          auto mdnnBSM0_score_jes = mci.predict(EventNumber, 2);
+          for (uint k=0; k<mdnnSM0_score_jes.size(); k++)
+          {
+            mdnnSM0_output_jetup  [i].at(k) = mdnnSM0_score_jes.at(k).second;
+            mdnnSM0_output_jetdown[i].at(k) = mdnnSM0_score_jes.at(k).second;
+          }
+          for (uint k=0; k<mdnnSM1_score_jes.size(); k++)
+          {
+            mdnnSM1_output_jetup  [i].at(k) = mdnnSM1_score_jes.at(k).second;
+            mdnnSM1_output_jetdown[i].at(k) = mdnnSM1_score_jes.at(k).second;
+          }
+          for (uint k=0; k<mdnnBSM0_score_jes.size(); k++)
+          {
+            mdnnBSM0_output_jetup  [i].at(k) = mdnnBSM0_score_jes.at(k).second;
+            mdnnBSM0_output_jetdown[i].at(k) = mdnnBSM0_score_jes.at(k).second;
+          }
         }
         else /*isMC*/
         {
@@ -2297,6 +2377,71 @@ int main (int argc, char** argv)
                 HHKin_mass_jetdown, HHKin_chi2_jetdown, KinFitConv_jetdown, SVfitConv_jetdown, MT2_jetdown);
             std::vector<float> outs_jetdown = DNNreader.GetPredictions();
             DNNoutSM_kl_1_jetdown.at(i) = outs_jetdown.at(0);
+          }
+
+          if (doMult)
+          {
+            mci.clearInputs();
+            for (uint j=0; j<mci.getNumberOfModels(); j++)
+            {
+              mci.setInputs(j,
+              {
+                {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
+                {"bjet1_pt", bjet1_jetup.Pt()}, {"bjet1_eta", bjet1_jetup.Eta()}, {"bjet1_phi", bjet1_jetup.Phi()}, {"bjet1_e", bjet1_jetup.E()},
+                {"bjet1_deepflavor_b", bjet1_bID_deepFlavor}, {"bjet1_deepflavor_cvsb", CvsB_b1}, {"bjet1_deepflavor_cvsl", CvsL_b1}, {"bjet1_hhbtag", HHbtag_b1},
+                {"bjet2_pt", bjet2_jetup.Pt()}, {"bjet2_eta", bjet2_jetup.Eta()}, {"bjet2_phi", bjet2_jetup.Phi()}, {"bjet2_e", bjet2_jetup.E()},
+                {"bjet2_deepflavor_b", bjet2_bID_deepFlavor}, {"bjet2_deepflavor_cvsb", CvsB_b2}, {"bjet2_deepflavor_cvsl", CvsL_b2}, {"bjet2_hhbtag", HHbtag_b2},
+                {"vbfjet1_pt", vbfjet1_jetup.Pt()}, {"vbfjet1_eta", vbfjet1_jetup.Eta()}, {"vbfjet1_phi", vbfjet1_jetup.Phi()}, {"vbfjet1_e", vbfjet1_jetup.E()},
+                {"vbfjet1_deepflavor_b", VBFjet1_btag_deepFlavor}, {"vbfjet1_deepflavor_cvsb", CvsB_vbf1}, {"vbfjet1_deepflavor_cvsl", CvsL_vbf1}, {"vbfjet1_hhbtag", HHbtag_vbf1},
+                {"vbfjet2_pt", vbfjet2_jetup.Pt()}, {"vbfjet2_eta", vbfjet2_jetup.Eta()}, {"vbfjet2_phi", vbfjet2_jetup.Phi()}, {"vbfjet2_e", vbfjet2_jetup.E()},
+                {"vbfjet2_deepflavor_b", VBFjet2_btag_deepFlavor}, {"vbfjet2_deepflavor_cvsb", CvsB_vbf2}, {"vbfjet2_deepflavor_cvsl", CvsL_vbf2}, {"vbfjet2_hhbtag", HHbtag_vbf2},
+                {"lep1_pt", dau1_pt}, {"lep1_eta", dau1_eta}, {"lep1_phi", dau1_phi}, {"lep1_e", dau1_e},
+                {"lep2_pt", dau2_pt}, {"lep2_eta", dau2_eta}, {"lep2_phi", dau2_phi}, {"lep2_e", dau2_e},
+                {"met_pt", met_jetup.Pt()}, {"met_phi", met_jetup.Phi()},
+                {"bh_pt", (bjet1_jetup+bjet2_jetup).Pt()}, {"bh_eta", (bjet1_jetup+bjet2_jetup).Eta()}, {"bh_phi", (bjet1_jetup+bjet2_jetup).Phi()}, {"bh_e", (bjet1_jetup+bjet2_jetup).E()},
+                {"tauh_sv_pt", svfit_jetup.Pt()}, {"tauh_sv_eta", svfit_jetup.Eta()}, {"tauh_sv_phi", svfit_jetup.Phi()}, {"tauh_sv_e", svfit_jetup.E()}
+              });
+            }
+            auto mdnnSM0_score_jetup  = mci.predict(EventNumber, 0);
+            auto mdnnSM1_score_jetup  = mci.predict(EventNumber, 1);
+            auto mdnnBSM0_score_jetup = mci.predict(EventNumber, 2);
+            for (uint k=0; k<mdnnSM0_score_jetup.size(); k++)
+              mdnnSM0_output_jetup[i].at(k) = mdnnSM0_score_jetup.at(k).second;
+            for (uint k=0; k<mdnnSM1_score_jetup.size(); k++)
+              mdnnSM1_output_jetup[i].at(k) = mdnnSM1_score_jetup.at(k).second;
+            for (uint k=0; k<mdnnBSM0_score_jetup.size(); k++)
+              mdnnBSM0_output_jetup[i].at(k) = mdnnBSM0_score_jetup.at(k).second;
+
+            mci.clearInputs();
+            for (uint j=0; j<mci.getNumberOfModels(); j++)
+            {
+              mci.setInputs(j,
+              {
+                {"is_mutau", mdnn_isMuTau}, {"is_etau", mdnn_isETau}, {"is_tautau", mdnn_isTauTau},
+                {"bjet1_pt", bjet1_jetdown.Pt()}, {"bjet1_eta", bjet1_jetdown.Eta()}, {"bjet1_phi", bjet1_jetdown.Phi()}, {"bjet1_e", bjet1_jetdown.E()},
+                {"bjet1_deepflavor_b", bjet1_bID_deepFlavor}, {"bjet1_deepflavor_cvsb", CvsB_b1}, {"bjet1_deepflavor_cvsl", CvsL_b1}, {"bjet1_hhbtag", HHbtag_b1},
+                {"bjet2_pt", bjet2_jetdown.Pt()}, {"bjet2_eta", bjet2_jetdown.Eta()}, {"bjet2_phi", bjet2_jetdown.Phi()}, {"bjet2_e", bjet2_jetdown.E()},
+                {"bjet2_deepflavor_b", bjet2_bID_deepFlavor}, {"bjet2_deepflavor_cvsb", CvsB_b2}, {"bjet2_deepflavor_cvsl", CvsL_b2}, {"bjet2_hhbtag", HHbtag_b2},
+                {"vbfjet1_pt", vbfjet1_jetdown.Pt()}, {"vbfjet1_eta", vbfjet1_jetdown.Eta()}, {"vbfjet1_phi", vbfjet1_jetdown.Phi()}, {"vbfjet1_e", vbfjet1_jetdown.E()},
+                {"vbfjet1_deepflavor_b", VBFjet1_btag_deepFlavor}, {"vbfjet1_deepflavor_cvsb", CvsB_vbf1}, {"vbfjet1_deepflavor_cvsl", CvsL_vbf1}, {"vbfjet1_hhbtag", HHbtag_vbf1},
+                {"vbfjet2_pt", vbfjet2_jetdown.Pt()}, {"vbfjet2_eta", vbfjet2_jetdown.Eta()}, {"vbfjet2_phi", vbfjet2_jetdown.Phi()}, {"vbfjet2_e", vbfjet2_jetdown.E()},
+                {"vbfjet2_deepflavor_b", VBFjet2_btag_deepFlavor}, {"vbfjet2_deepflavor_cvsb", CvsB_vbf2}, {"vbfjet2_deepflavor_cvsl", CvsL_vbf2}, {"vbfjet2_hhbtag", HHbtag_vbf2},
+                {"lep1_pt", dau1_pt}, {"lep1_eta", dau1_eta}, {"lep1_phi", dau1_phi}, {"lep1_e", dau1_e},
+                {"lep2_pt", dau2_pt}, {"lep2_eta", dau2_eta}, {"lep2_phi", dau2_phi}, {"lep2_e", dau2_e},
+                {"met_pt", met_jetdown.Pt()}, {"met_phi", met_jetdown.Phi()},
+                {"bh_pt", (bjet1_jetdown+bjet2_jetdown).Pt()}, {"bh_eta", (bjet1_jetdown+bjet2_jetdown).Eta()}, {"bh_phi", (bjet1_jetdown+bjet2_jetdown).Phi()}, {"bh_e", (bjet1_jetdown+bjet2_jetdown).E()},
+                {"tauh_sv_pt", svfit_jetdown.Pt()}, {"tauh_sv_eta", svfit_jetdown.Eta()}, {"tauh_sv_phi", svfit_jetdown.Phi()}, {"tauh_sv_e", svfit_jetdown.E()}
+              });
+            }
+            auto mdnnSM0_score_jetdown  = mci.predict(EventNumber, 0);
+            auto mdnnSM1_score_jetdown  = mci.predict(EventNumber, 1);
+            auto mdnnBSM0_score_jetdown = mci.predict(EventNumber, 2);
+            for (uint k=0; k<mdnnSM0_score_jetdown.size(); k++)
+              mdnnSM0_output_jetdown[i].at(k) = mdnnSM0_score_jetdown.at(k).second;
+            for (uint k=0; k<mdnnSM1_score_jetdown.size(); k++)
+              mdnnSM1_output_jetdown[i].at(k) = mdnnSM1_score_jetdown.at(k).second;
+            for (uint k=0; k<mdnnBSM0_score_jetdown.size(); k++)
+              mdnnBSM0_output_jetdown[i].at(k) = mdnnBSM0_score_jetdown.at(k).second;
           }
 
           if (doBDT)
@@ -2721,6 +2866,11 @@ int main (int argc, char** argv)
       b_mdnnSM0_taudown_DM11.at(i)->Fill();
       b_mdnnSM0_jetupTot.at(i)->Fill();
       b_mdnnSM0_jetdownTot.at(i)->Fill();
+      for (int jec=0; jec<N_jecSources; jec++)
+      {
+        b_mdnnSM0_jetup  [jec].at(i)->Fill();
+        b_mdnnSM0_jetdown[jec].at(i)->Fill();
+      }
     }
     for (int i=0; i<mdnnSM1_size; i++)
     {
@@ -2741,6 +2891,11 @@ int main (int argc, char** argv)
       b_mdnnSM1_taudown_DM11.at(i)->Fill();
       b_mdnnSM1_jetupTot.at(i)->Fill();
       b_mdnnSM1_jetdownTot.at(i)->Fill();
+      for (int jec=0; jec<N_jecSources; jec++)
+      {
+        b_mdnnSM1_jetup  [jec].at(i)->Fill();
+        b_mdnnSM1_jetdown[jec].at(i)->Fill();
+      }
     }
     for (int i=0; i<mdnnBSM0_size; i++)
     {
@@ -2761,6 +2916,11 @@ int main (int argc, char** argv)
       b_mdnnBSM0_taudown_DM11.at(i)->Fill();
       b_mdnnBSM0_jetupTot.at(i)->Fill();
       b_mdnnBSM0_jetdownTot.at(i)->Fill();
+      for (int jec=0; jec<N_jecSources; jec++)
+      {
+        b_mdnnBSM0_jetup  [jec].at(i)->Fill();
+        b_mdnnBSM0_jetdown[jec].at(i)->Fill();
+      }
     }
 
     // Timing branches

--- a/test/skimOutputter.cpp
+++ b/test/skimOutputter.cpp
@@ -950,12 +950,51 @@ int main (int argc, char** argv)
   // JES variations Total
   Float_t tauH_SVFIT_mass_jetupTot, DNNoutSM_kl_1_jetupTot, BDToutSM_kl_1_jetupTot;
   Float_t tauH_SVFIT_mass_jetdownTot, DNNoutSM_kl_1_jetdownTot, BDToutSM_kl_1_jetdownTot;
+  std::vector<Float_t> mdnnSM0_output_jetupTot (mdnnSM0_size) , mdnnSM0_output_jetdownTot (mdnnSM0_size);
+  std::vector<Float_t> mdnnSM1_output_jetupTot (mdnnSM1_size) , mdnnSM1_output_jetdownTot (mdnnSM1_size);
+  std::vector<Float_t> mdnnBSM0_output_jetupTot(mdnnBSM0_size), mdnnBSM0_output_jetdownTot(mdnnBSM0_size);
   TBranch* b_tauH_SVFIT_mass_jetupTot   = outTree->Branch("tauH_SVFIT_mass_jetupTot"  , &tauH_SVFIT_mass_jetupTot);
   TBranch* b_DNNoutSM_kl_1_jetupTot     = outTree->Branch("DNNoutSM_kl_1_jetupTot"    , &DNNoutSM_kl_1_jetupTot);
   TBranch* b_BDToutSM_kl_1_jetupTot     = outTree->Branch("BDToutSM_kl_1_jetupTot"    , &BDToutSM_kl_1_jetupTot);
   TBranch* b_tauH_SVFIT_mass_jetdownTot = outTree->Branch("tauH_SVFIT_mass_jetdownTot", &tauH_SVFIT_mass_jetdownTot);
   TBranch* b_DNNoutSM_kl_1_jetdownTot   = outTree->Branch("DNNoutSM_kl_1_jetdownTot"  , &DNNoutSM_kl_1_jetdownTot);
   TBranch* b_BDToutSM_kl_1_jetdownTot   = outTree->Branch("BDToutSM_kl_1_jetdownTot"  , &BDToutSM_kl_1_jetdownTot);
+  std::vector<TBranch*> b_mdnnSM0_jetupTot , b_mdnnSM0_jetdownTot;
+  std::vector<TBranch*> b_mdnnSM1_jetupTot , b_mdnnSM1_jetdownTot;
+  std::vector<TBranch*> b_mdnnBSM0_jetupTot, b_mdnnBSM0_jetdownTot;
+  boost::format mdnnSM0name_jetupTot   ("mdnn__v0__kl1_c2v1_c31__%1%_jetupTot");
+  boost::format mdnnSM0name_jetdownTot ("mdnn__v0__kl1_c2v1_c31__%1%_jetdownTot");
+  boost::format mdnnSM1name_jetupTot   ("mdnn__v1__kl1_c2v1_c31__%1%_jetupTot");
+  boost::format mdnnSM1name_jetdownTot ("mdnn__v1__kl1_c2v1_c31__%1%_jetdownTot");
+  boost::format mdnnBSM0name_jetupTot  ("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_jetupTot");
+  boost::format mdnnBSM0name_jetdownTot("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_jetdownTot");
+  for (int i=0; i<mdnnSM0_size; i++)
+  {
+    std::string tmp_mdnnSM0_branch_name_up   = boost::str( mdnnSM0name_jetupTot   % (mci.getNodeNames(0)).at(i) );
+    std::string tmp_mdnnSM0_branch_name_down = boost::str( mdnnSM0name_jetdownTot % (mci.getNodeNames(0)).at(i) );
+    TBranch* tmp_mdnnSM0_branch_up   = outTree->Branch(tmp_mdnnSM0_branch_name_up.c_str()  , &mdnnSM0_output_jetupTot.at(i));
+    TBranch* tmp_mdnnSM0_branch_down = outTree->Branch(tmp_mdnnSM0_branch_name_down.c_str(), &mdnnSM0_output_jetdownTot.at(i));
+    b_mdnnSM0_jetupTot  .push_back(tmp_mdnnSM0_branch_up);
+    b_mdnnSM0_jetdownTot.push_back(tmp_mdnnSM0_branch_down);
+  }
+  for (int i=0; i<mdnnSM1_size; i++)
+  {
+    std::string tmp_mdnnSM1_branch_name_up   = boost::str( mdnnSM1name_jetupTot   % (mci.getNodeNames(1)).at(i) );
+    std::string tmp_mdnnSM1_branch_name_down = boost::str( mdnnSM1name_jetdownTot % (mci.getNodeNames(1)).at(i) );
+    TBranch* tmp_mdnnSM1_branch_up   = outTree->Branch(tmp_mdnnSM1_branch_name_up.c_str()  , &mdnnSM1_output_jetupTot.at(i));
+    TBranch* tmp_mdnnSM1_branch_down = outTree->Branch(tmp_mdnnSM1_branch_name_down.c_str(), &mdnnSM1_output_jetdownTot.at(i));
+    b_mdnnSM1_jetupTot  .push_back(tmp_mdnnSM1_branch_up);
+    b_mdnnSM1_jetdownTot.push_back(tmp_mdnnSM1_branch_down);
+  }
+  for (int i=0; i<mdnnBSM0_size; i++)
+  {
+    std::string tmp_mdnnBSM0_branch_name_up   = boost::str( mdnnBSM0name_jetupTot   % (mci.getNodeNames(2)).at(i) );
+    std::string tmp_mdnnBSM0_branch_name_down = boost::str( mdnnBSM0name_jetdownTot % (mci.getNodeNames(2)).at(i) );
+    TBranch* tmp_mdnnBSM0_branch_up   = outTree->Branch(tmp_mdnnBSM0_branch_name_up.c_str()  , &mdnnBSM0_output_jetupTot.at(i));
+    TBranch* tmp_mdnnBSM0_branch_down = outTree->Branch(tmp_mdnnBSM0_branch_name_down.c_str(), &mdnnBSM0_output_jetdownTot.at(i));
+    b_mdnnBSM0_jetupTot  .push_back(tmp_mdnnBSM0_branch_up);
+    b_mdnnBSM0_jetdownTot.push_back(tmp_mdnnBSM0_branch_down);
+  }
 
   // Add some branches to store timing information
   double time_prep, time_nominal, time_TES, time_EES, time_MES, time_splitJES, time_totalJES, time_tot;

--- a/test/skimOutputter.cpp
+++ b/test/skimOutputter.cpp
@@ -765,6 +765,9 @@ int main (int argc, char** argv)
   // TES variations
   std::vector<Float_t> tauH_SVFIT_mass_tauup(N_tauhDM), DNNoutSM_kl_1_tauup(N_tauhDM), BDToutSM_kl_1_tauup(N_tauhDM);
   std::vector<Float_t> tauH_SVFIT_mass_taudown(N_tauhDM), DNNoutSM_kl_1_taudown(N_tauhDM), BDToutSM_kl_1_taudown(N_tauhDM);
+  std::vector<std::vector<Float_t>> mdnnSM0_output_tauup (N_tauhDM, std::vector<Float_t>(mdnnSM0_size)) , mdnnSM0_output_taudown (N_tauhDM, std::vector<Float_t>(mdnnSM0_size));
+  std::vector<std::vector<Float_t>> mdnnSM1_output_tauup (N_tauhDM, std::vector<Float_t>(mdnnSM1_size)) , mdnnSM1_output_taudown (N_tauhDM, std::vector<Float_t>(mdnnSM1_size));
+  std::vector<std::vector<Float_t>> mdnnBSM0_output_tauup(N_tauhDM, std::vector<Float_t>(mdnnBSM0_size)), mdnnBSM0_output_taudown(N_tauhDM, std::vector<Float_t>(mdnnBSM0_size));
   TBranch* b_tauH_SVFIT_mass_tauup_DM0    = outTree->Branch("tauH_SVFIT_mass_tauup_DM0"   , &tauH_SVFIT_mass_tauup.at(0));    // DM 0
   TBranch* b_DNNoutSM_kl_1_tauup_DM0      = outTree->Branch("DNNoutSM_kl_1_tauup_DM0"     , &DNNoutSM_kl_1_tauup.at(0));
   TBranch* b_BDToutSM_kl_1_tauup_DM0      = outTree->Branch("BDToutSM_kl_1_tauup_DM0"     , &BDToutSM_kl_1_tauup.at(0));
@@ -789,6 +792,123 @@ int main (int argc, char** argv)
   TBranch* b_tauH_SVFIT_mass_taudown_DM11 = outTree->Branch("tauH_SVFIT_mass_taudown_DM11", &tauH_SVFIT_mass_taudown.at(3));
   TBranch* b_DNNoutSM_kl_1_taudown_DM11   = outTree->Branch("DNNoutSM_kl_1_taudown_DM11"  , &DNNoutSM_kl_1_taudown.at(3));
   TBranch* b_BDToutSM_kl_1_taudown_DM11   = outTree->Branch("BDToutSM_kl_1_taudown_DM11"  , &BDToutSM_kl_1_taudown.at(3));
+  std::vector<TBranch*> b_mdnnSM0_tauup_DM0  , b_mdnnSM0_taudown_DM0;
+  std::vector<TBranch*> b_mdnnSM0_tauup_DM1  , b_mdnnSM0_taudown_DM1;
+  std::vector<TBranch*> b_mdnnSM0_tauup_DM10 , b_mdnnSM0_taudown_DM10;
+  std::vector<TBranch*> b_mdnnSM0_tauup_DM11 , b_mdnnSM0_taudown_DM11;
+  std::vector<TBranch*> b_mdnnSM1_tauup_DM0  , b_mdnnSM1_taudown_DM0;
+  std::vector<TBranch*> b_mdnnSM1_tauup_DM1  , b_mdnnSM1_taudown_DM1;
+  std::vector<TBranch*> b_mdnnSM1_tauup_DM10 , b_mdnnSM1_taudown_DM10;
+  std::vector<TBranch*> b_mdnnSM1_tauup_DM11 , b_mdnnSM1_taudown_DM11;
+  std::vector<TBranch*> b_mdnnBSM0_tauup_DM0 , b_mdnnBSM0_taudown_DM0;
+  std::vector<TBranch*> b_mdnnBSM0_tauup_DM1 , b_mdnnBSM0_taudown_DM1;
+  std::vector<TBranch*> b_mdnnBSM0_tauup_DM10, b_mdnnBSM0_taudown_DM10;
+  std::vector<TBranch*> b_mdnnBSM0_tauup_DM11, b_mdnnBSM0_taudown_DM11;
+  boost::format mdnnSM0name_tauup_DM0    ("mdnn__v0__kl1_c2v1_c31__%1%_tauup_DM0");
+  boost::format mdnnSM0name_taudown_DM0  ("mdnn__v0__kl1_c2v1_c31__%1%_taudown_DM0");
+  boost::format mdnnSM0name_tauup_DM1    ("mdnn__v0__kl1_c2v1_c31__%1%_tauup_DM1");
+  boost::format mdnnSM0name_taudown_DM1  ("mdnn__v0__kl1_c2v1_c31__%1%_taudown_DM1");
+  boost::format mdnnSM0name_tauup_DM10   ("mdnn__v0__kl1_c2v1_c31__%1%_tauup_DM10");
+  boost::format mdnnSM0name_taudown_DM10 ("mdnn__v0__kl1_c2v1_c31__%1%_taudown_DM10");
+  boost::format mdnnSM0name_tauup_DM11   ("mdnn__v0__kl1_c2v1_c31__%1%_tauup_DM11");
+  boost::format mdnnSM0name_taudown_DM11 ("mdnn__v0__kl1_c2v1_c31__%1%_taudown_DM11");
+  boost::format mdnnSM1name_tauup_DM0    ("mdnn__v1__kl1_c2v1_c31__%1%_tauup_DM0");
+  boost::format mdnnSM1name_taudown_DM0  ("mdnn__v1__kl1_c2v1_c31__%1%_taudown_DM0");
+  boost::format mdnnSM1name_tauup_DM1    ("mdnn__v1__kl1_c2v1_c31__%1%_tauup_DM1");
+  boost::format mdnnSM1name_taudown_DM1  ("mdnn__v1__kl1_c2v1_c31__%1%_taudown_DM1");
+  boost::format mdnnSM1name_tauup_DM10   ("mdnn__v1__kl1_c2v1_c31__%1%_tauup_DM10");
+  boost::format mdnnSM1name_taudown_DM10 ("mdnn__v1__kl1_c2v1_c31__%1%_taudown_DM10");
+  boost::format mdnnSM1name_tauup_DM11   ("mdnn__v1__kl1_c2v1_c31__%1%_tauup_DM11");
+  boost::format mdnnSM1name_taudown_DM11 ("mdnn__v1__kl1_c2v1_c31__%1%_taudown_DM11");
+  boost::format mdnnBSM0name_tauup_DM0   ("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_tauup_DM0");
+  boost::format mdnnBSM0name_taudown_DM0 ("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_taudown_DM0");
+  boost::format mdnnBSM0name_tauup_DM1   ("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_tauup_DM1");
+  boost::format mdnnBSM0name_taudown_DM1 ("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_taudown_DM1");
+  boost::format mdnnBSM0name_tauup_DM10  ("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_tauup_DM10");
+  boost::format mdnnBSM0name_taudown_DM10("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_taudown_DM10");
+  boost::format mdnnBSM0name_tauup_DM11  ("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_tauup_DM11");
+  boost::format mdnnBSM0name_taudown_DM11("mdnn__v0__kl1_c2v1_c31_vbfbsm__%1%_taudown_DM11");
+  for (int i=0; i<mdnnSM0_size; i++)
+  {
+    std::string tmp_mdnnSM0_branch_name_up_DM0    = boost::str( mdnnSM0name_tauup_DM0    % (mci.getNodeNames(0)).at(i) );
+    std::string tmp_mdnnSM0_branch_name_down_DM0  = boost::str( mdnnSM0name_taudown_DM0  % (mci.getNodeNames(0)).at(i) );
+    std::string tmp_mdnnSM0_branch_name_up_DM1    = boost::str( mdnnSM0name_tauup_DM1    % (mci.getNodeNames(0)).at(i) );
+    std::string tmp_mdnnSM0_branch_name_down_DM1  = boost::str( mdnnSM0name_taudown_DM1  % (mci.getNodeNames(0)).at(i) );
+    std::string tmp_mdnnSM0_branch_name_up_DM10   = boost::str( mdnnSM0name_tauup_DM10   % (mci.getNodeNames(0)).at(i) );
+    std::string tmp_mdnnSM0_branch_name_down_DM10 = boost::str( mdnnSM0name_taudown_DM10 % (mci.getNodeNames(0)).at(i) );
+    std::string tmp_mdnnSM0_branch_name_up_DM11   = boost::str( mdnnSM0name_tauup_DM11   % (mci.getNodeNames(0)).at(i) );
+    std::string tmp_mdnnSM0_branch_name_down_DM11 = boost::str( mdnnSM0name_taudown_DM11 % (mci.getNodeNames(0)).at(i) );
+    TBranch* tmp_mdnnSM0_branch_up_DM0    = outTree->Branch(tmp_mdnnSM0_branch_name_up_DM0.c_str()   , &mdnnSM0_output_tauup  [0].at(i));
+    TBranch* tmp_mdnnSM0_branch_down_DM0  = outTree->Branch(tmp_mdnnSM0_branch_name_down_DM0.c_str() , &mdnnSM0_output_taudown[0].at(i));
+    TBranch* tmp_mdnnSM0_branch_up_DM1    = outTree->Branch(tmp_mdnnSM0_branch_name_up_DM1.c_str()   , &mdnnSM0_output_tauup  [1].at(i));
+    TBranch* tmp_mdnnSM0_branch_down_DM1  = outTree->Branch(tmp_mdnnSM0_branch_name_down_DM1.c_str() , &mdnnSM0_output_taudown[1].at(i));
+    TBranch* tmp_mdnnSM0_branch_up_DM10   = outTree->Branch(tmp_mdnnSM0_branch_name_up_DM10.c_str()  , &mdnnSM0_output_tauup  [2].at(i));
+    TBranch* tmp_mdnnSM0_branch_down_DM10 = outTree->Branch(tmp_mdnnSM0_branch_name_down_DM10.c_str(), &mdnnSM0_output_taudown[2].at(i));
+    TBranch* tmp_mdnnSM0_branch_up_DM11   = outTree->Branch(tmp_mdnnSM0_branch_name_up_DM11.c_str()  , &mdnnSM0_output_tauup  [3].at(i));
+    TBranch* tmp_mdnnSM0_branch_down_DM11 = outTree->Branch(tmp_mdnnSM0_branch_name_down_DM11.c_str(), &mdnnSM0_output_taudown[3].at(i));
+    b_mdnnSM0_tauup_DM0   .push_back(tmp_mdnnSM0_branch_up_DM0);
+    b_mdnnSM0_taudown_DM0 .push_back(tmp_mdnnSM0_branch_down_DM0);
+    b_mdnnSM0_tauup_DM1   .push_back(tmp_mdnnSM0_branch_up_DM1);
+    b_mdnnSM0_taudown_DM1 .push_back(tmp_mdnnSM0_branch_down_DM1);
+    b_mdnnSM0_tauup_DM10  .push_back(tmp_mdnnSM0_branch_up_DM10);
+    b_mdnnSM0_taudown_DM10.push_back(tmp_mdnnSM0_branch_down_DM10);
+    b_mdnnSM0_tauup_DM11  .push_back(tmp_mdnnSM0_branch_up_DM11);
+    b_mdnnSM0_taudown_DM11.push_back(tmp_mdnnSM0_branch_down_DM11);
+  }
+  for (int i=0; i<mdnnSM1_size; i++)
+  {
+    std::string tmp_mdnnSM1_branch_name_up_DM0    = boost::str( mdnnSM1name_tauup_DM0    % (mci.getNodeNames(1)).at(i) );
+    std::string tmp_mdnnSM1_branch_name_down_DM0  = boost::str( mdnnSM1name_taudown_DM0  % (mci.getNodeNames(1)).at(i) );
+    std::string tmp_mdnnSM1_branch_name_up_DM1    = boost::str( mdnnSM1name_tauup_DM1    % (mci.getNodeNames(1)).at(i) );
+    std::string tmp_mdnnSM1_branch_name_down_DM1  = boost::str( mdnnSM1name_taudown_DM1  % (mci.getNodeNames(1)).at(i) );
+    std::string tmp_mdnnSM1_branch_name_up_DM10   = boost::str( mdnnSM1name_tauup_DM10   % (mci.getNodeNames(1)).at(i) );
+    std::string tmp_mdnnSM1_branch_name_down_DM10 = boost::str( mdnnSM1name_taudown_DM10 % (mci.getNodeNames(1)).at(i) );
+    std::string tmp_mdnnSM1_branch_name_up_DM11   = boost::str( mdnnSM1name_tauup_DM11   % (mci.getNodeNames(1)).at(i) );
+    std::string tmp_mdnnSM1_branch_name_down_DM11 = boost::str( mdnnSM1name_taudown_DM11 % (mci.getNodeNames(1)).at(i) );
+    TBranch* tmp_mdnnSM1_branch_up_DM0    = outTree->Branch(tmp_mdnnSM1_branch_name_up_DM0.c_str()   , &mdnnSM1_output_tauup  [0].at(i));
+    TBranch* tmp_mdnnSM1_branch_down_DM0  = outTree->Branch(tmp_mdnnSM1_branch_name_down_DM0.c_str() , &mdnnSM1_output_taudown[0].at(i));
+    TBranch* tmp_mdnnSM1_branch_up_DM1    = outTree->Branch(tmp_mdnnSM1_branch_name_up_DM1.c_str()   , &mdnnSM1_output_tauup  [1].at(i));
+    TBranch* tmp_mdnnSM1_branch_down_DM1  = outTree->Branch(tmp_mdnnSM1_branch_name_down_DM1.c_str() , &mdnnSM1_output_taudown[1].at(i));
+    TBranch* tmp_mdnnSM1_branch_up_DM10   = outTree->Branch(tmp_mdnnSM1_branch_name_up_DM10.c_str()  , &mdnnSM1_output_tauup  [2].at(i));
+    TBranch* tmp_mdnnSM1_branch_down_DM10 = outTree->Branch(tmp_mdnnSM1_branch_name_down_DM10.c_str(), &mdnnSM1_output_taudown[2].at(i));
+    TBranch* tmp_mdnnSM1_branch_up_DM11   = outTree->Branch(tmp_mdnnSM1_branch_name_up_DM11.c_str()  , &mdnnSM1_output_tauup  [3].at(i));
+    TBranch* tmp_mdnnSM1_branch_down_DM11 = outTree->Branch(tmp_mdnnSM1_branch_name_down_DM11.c_str(), &mdnnSM1_output_taudown[3].at(i));
+    b_mdnnSM1_tauup_DM0   .push_back(tmp_mdnnSM1_branch_up_DM0);
+    b_mdnnSM1_taudown_DM0 .push_back(tmp_mdnnSM1_branch_down_DM0);
+    b_mdnnSM1_tauup_DM1   .push_back(tmp_mdnnSM1_branch_up_DM1);
+    b_mdnnSM1_taudown_DM1 .push_back(tmp_mdnnSM1_branch_down_DM1);
+    b_mdnnSM1_tauup_DM10  .push_back(tmp_mdnnSM1_branch_up_DM10);
+    b_mdnnSM1_taudown_DM10.push_back(tmp_mdnnSM1_branch_down_DM10);
+    b_mdnnSM1_tauup_DM11  .push_back(tmp_mdnnSM1_branch_up_DM11);
+    b_mdnnSM1_taudown_DM11.push_back(tmp_mdnnSM1_branch_down_DM11);
+  }
+  for (int i=0; i<mdnnBSM0_size; i++)
+  {
+    std::string tmp_mdnnBSM0_branch_name_up_DM0    = boost::str( mdnnBSM0name_tauup_DM0    % (mci.getNodeNames(2)).at(i) );
+    std::string tmp_mdnnBSM0_branch_name_down_DM0  = boost::str( mdnnBSM0name_taudown_DM0  % (mci.getNodeNames(2)).at(i) );
+    std::string tmp_mdnnBSM0_branch_name_up_DM1    = boost::str( mdnnBSM0name_tauup_DM1    % (mci.getNodeNames(2)).at(i) );
+    std::string tmp_mdnnBSM0_branch_name_down_DM1  = boost::str( mdnnBSM0name_taudown_DM1  % (mci.getNodeNames(2)).at(i) );
+    std::string tmp_mdnnBSM0_branch_name_up_DM10   = boost::str( mdnnBSM0name_tauup_DM10   % (mci.getNodeNames(2)).at(i) );
+    std::string tmp_mdnnBSM0_branch_name_down_DM10 = boost::str( mdnnBSM0name_taudown_DM10 % (mci.getNodeNames(2)).at(i) );
+    std::string tmp_mdnnBSM0_branch_name_up_DM11   = boost::str( mdnnBSM0name_tauup_DM11   % (mci.getNodeNames(2)).at(i) );
+    std::string tmp_mdnnBSM0_branch_name_down_DM11 = boost::str( mdnnBSM0name_taudown_DM11 % (mci.getNodeNames(2)).at(i) );
+    TBranch* tmp_mdnnBSM0_branch_up_DM0    = outTree->Branch(tmp_mdnnBSM0_branch_name_up_DM0.c_str()   , &mdnnBSM0_output_tauup  [0].at(i));
+    TBranch* tmp_mdnnBSM0_branch_down_DM0  = outTree->Branch(tmp_mdnnBSM0_branch_name_down_DM0.c_str() , &mdnnBSM0_output_taudown[0].at(i));
+    TBranch* tmp_mdnnBSM0_branch_up_DM1    = outTree->Branch(tmp_mdnnBSM0_branch_name_up_DM1.c_str()   , &mdnnBSM0_output_tauup  [1].at(i));
+    TBranch* tmp_mdnnBSM0_branch_down_DM1  = outTree->Branch(tmp_mdnnBSM0_branch_name_down_DM1.c_str() , &mdnnBSM0_output_taudown[1].at(i));
+    TBranch* tmp_mdnnBSM0_branch_up_DM10   = outTree->Branch(tmp_mdnnBSM0_branch_name_up_DM10.c_str()  , &mdnnBSM0_output_tauup  [2].at(i));
+    TBranch* tmp_mdnnBSM0_branch_down_DM10 = outTree->Branch(tmp_mdnnBSM0_branch_name_down_DM10.c_str(), &mdnnBSM0_output_taudown[2].at(i));
+    TBranch* tmp_mdnnBSM0_branch_up_DM11   = outTree->Branch(tmp_mdnnBSM0_branch_name_up_DM11.c_str()  , &mdnnBSM0_output_tauup  [3].at(i));
+    TBranch* tmp_mdnnBSM0_branch_down_DM11 = outTree->Branch(tmp_mdnnBSM0_branch_name_down_DM11.c_str(), &mdnnBSM0_output_taudown[3].at(i));
+    b_mdnnBSM0_tauup_DM0   .push_back(tmp_mdnnBSM0_branch_up_DM0);
+    b_mdnnBSM0_taudown_DM0 .push_back(tmp_mdnnBSM0_branch_down_DM0);
+    b_mdnnBSM0_tauup_DM1   .push_back(tmp_mdnnBSM0_branch_up_DM1);
+    b_mdnnBSM0_taudown_DM1 .push_back(tmp_mdnnBSM0_branch_down_DM1);
+    b_mdnnBSM0_tauup_DM10  .push_back(tmp_mdnnBSM0_branch_up_DM10);
+    b_mdnnBSM0_taudown_DM10.push_back(tmp_mdnnBSM0_branch_down_DM10);
+    b_mdnnBSM0_tauup_DM11  .push_back(tmp_mdnnBSM0_branch_up_DM11);
+    b_mdnnBSM0_taudown_DM11.push_back(tmp_mdnnBSM0_branch_down_DM11);
+  }
 
   // JES variations
   std::vector<Float_t> tauH_SVFIT_mass_jetup(N_jecSources), DNNoutSM_kl_1_jetup(N_jecSources), BDToutSM_kl_1_jetup(N_jecSources);


### PR DESCRIPTION
- In README, updated instructions needed to compile the new Multiclass interface
- Updated skim configs for **all three years** (heads up @dzuolo @camendola @jonamotta !):
  - new `[Multiclass]` section
  - new `doMult` option in `[outPutter]` section
- Included Multiclass interface in the systematics module:
  - all up/down variations implemented for the three multiclass trainings available at the moment
- Added some forgotten variables + the efficiency histos in the systematics module