### PR TITLE
update DNN to tag V4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cmsenv
 # DNN packages
 git clone git@github.com:GilesStrong/cms_hh_proc_interface.git
 cd cms_hh_proc_interface
-git checkout tags/v2.0
+git checkout tags/V4.0
 cd -
 git clone git@github.com:GilesStrong/cms_hh_tf_inference.git
 git clone git@github.com:GilesStrong/cms_runII_dnn_models.git

--- a/config/skim_Legacy2016_mib.cfg
+++ b/config/skim_Legacy2016_mib.cfg
@@ -125,8 +125,8 @@ variables  = VBFjet1_pt:BDT_j1n_pt, bH_pt:BDT_n_bH_pt, dib_dEtaSign:BDT_n_b1b2_d
 
 [DNN]
 computeMVA = true
-weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-05-18-2/ensemble
-features = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-05-18-2/features.txt
+weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-06-29-0/ensemble
+features = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-06-29-0/features.txt
 kl = 1
 
 [HHbtag]

--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -128,8 +128,8 @@ variables  = VBFjet1_pt:BDT_j1n_pt, bH_pt:BDT_n_bH_pt, dib_dEtaSign:BDT_n_b1b2_d
 
 [DNN]
 computeMVA = true
-weights = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-05-18-2/ensemble
-features = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-05-18-2/features.txt
+weights = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-06-29-0/ensemble
+features = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-06-29-0/features.txt
 kl = 1
 
 [HHbtag]

--- a/config/skim_Legacy2018.cfg
+++ b/config/skim_Legacy2018.cfg
@@ -136,8 +136,8 @@ sfFile    = /home/llr/cms/amendola/HHLegacy/CMSSW_11_1_0_pre6/src/KLUBAnalysis/w
 
 [DNN]
 computeMVA = true
-weights = /home/llr/cms/amendola/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-05-18-2/ensemble
-features = /home/llr/cms/amendola/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-05-18-2/features.txt
+weights = /home/llr/cms/amendola/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-06-29-0/ensemble
+features = /home/llr/cms/amendola/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-06-29-0/features.txt
 kl = 1
 
 [HHbtag]

--- a/interface/DNNKLUBinterface.h
+++ b/interface/DNNKLUBinterface.h
@@ -79,7 +79,7 @@ class DNNKLUBinterface {
     float DNN_vbf_2_hhbtag_, DNN_vbf_2_cvsl_, DNN_vbf_2_cvsb_;
     int DNN_is_boosted_, DNN_n_vbf_;
     unsigned long long int DNN_evt_;
-    bool DNN_svfit_conv_, DNN_hh_kinfit_conv_;
+    bool DNN_svfit_conv_, DNN_hh_kinfit_conv_, DNN_pass_massCut_;
     Channel DNN_e_channel_;
     Year DNN_e_year_;
     Spin DNN_spin_;

--- a/src/DNNKLUBinterface.cc
+++ b/src/DNNKLUBinterface.cc
@@ -90,6 +90,11 @@ void DNNKLUBinterface::SetShiftedInputs(TLorentzVector b1, TLorentzVector b2, TL
   DNN_hh_kinfit_conv_ = KinFitConv;
   DNN_svfit_conv_     = SVfitConv;
   DNN_mt2_            = MT2;
+
+  // Pass ellyptic mass cut
+  // ((tauH_SVFIT_mass-116.)*(tauH_SVFIT_mass-116.))/(35.*35.) + ((bH_mass_raw-111.)*(bH_mass_raw-111.))/(45.*45.) <  1.0
+  DNN_pass_massCut_ = ( ((svfit.M()-116.)*(svfit.M()-116.))/(35.*35.) + (((b1+b2).M()-111.)*((b1+b2).M()-111.))/(45.*45.) <  1.0 );
+
 }
 
 
@@ -113,8 +118,8 @@ std::vector<float> DNNKLUBinterface::GetPredictions()
         DNN_b_1_hhbtag_, DNN_b_2_hhbtag_, DNN_vbf_1_hhbtag_, DNN_vbf_2_hhbtag_,
         DNN_b_1_cvsl_, DNN_b_2_cvsl_, DNN_vbf_1_cvsl_, DNN_vbf_2_cvsl_,
         DNN_b_1_cvsb_, DNN_b_2_cvsb_, DNN_vbf_1_cvsb_, DNN_vbf_2_cvsb_,
-        0, 0, 0 // cv, c2v, c3
-        );
+        0, 0, 0, // cv, c2v, c3
+        DNN_pass_massCut_);
 
     std::vector<std::string> feats_names = evt_proc_.get_feats();
 

--- a/test/skimNtuple2016.cpp
+++ b/test/skimNtuple2016.cpp
@@ -5222,7 +5222,7 @@ int main (int argc, char** argv)
      float DNN_b_1_HHbtag, DNN_b_2_HHbtag, DNN_vbf_1_HHbtag, DNN_vbf_2_HHbtag;
      int DNN_is_boosted, DNN_n_vbf, DNN_isvbf;
      unsigned long long int DNN_evt;
-     bool DNN_svfit_conv, DNN_hh_kinfit_conv;
+     bool DNN_svfit_conv, DNN_hh_kinfit_conv, DNN_pass_massCut;
      int DNN_nleps, DNN_nbjetscand;
 
      Channel DNN_e_channel;
@@ -5398,6 +5398,8 @@ int main (int argc, char** argv)
            if (*rv_vbf_2_e != -999.) DNN_n_vbf++;
        }
 
+       DNN_pass_massCut = ( ((DNN_svfit.M()-116.)*(DNN_svfit.M()-116.))/(35.*35.) + (((DNN_b_1+DNN_b_2).M()-111.)*((DNN_b_1+DNN_b_2).M()-111.))/(45.*45.) <  1.0 );
+
        // Loop on configurable options to get the output prediction
        // For each event save the predictions for all the kl values requested
        for (unsigned int jkl = 0; jkl < DNN_kl.size(); ++jkl)
@@ -5413,7 +5415,8 @@ int main (int argc, char** argv)
             DNN_b_1_HHbtag, DNN_b_2_HHbtag, DNN_vbf_1_HHbtag, DNN_vbf_2_HHbtag,
             DNN_b_1_CvsL, DNN_b_2_CvsL, DNN_vbf_1_CvsL, DNN_vbf_2_CvsL,
             DNN_b_1_CvsB, DNN_b_2_CvsB, DNN_vbf_1_CvsB, DNN_vbf_2_CvsB,
-            0, 0, 0); // cv, c2v, c3
+            0, 0, 0, // cv, c2v, c3
+            DNN_pass_massCut);
 
          // Get model prediction
          DNN_pred = wrapper.predict(feat_vals, DNN_evt);

--- a/test/skimNtuple2017.cpp
+++ b/test/skimNtuple2017.cpp
@@ -5305,7 +5305,7 @@ int main (int argc, char** argv)
     float DNN_b_1_HHbtag, DNN_b_2_HHbtag, DNN_vbf_1_HHbtag, DNN_vbf_2_HHbtag;
     int DNN_is_boosted, DNN_n_vbf, DNN_isvbf;
     unsigned long long int DNN_evt;
-    bool DNN_svfit_conv, DNN_hh_kinfit_conv;
+    bool DNN_svfit_conv, DNN_hh_kinfit_conv, DNN_pass_massCut;
     int DNN_nleps, DNN_nbjetscand;
 
     Channel DNN_e_channel;
@@ -5481,6 +5481,8 @@ int main (int argc, char** argv)
           if (*rv_vbf_2_e != -999.) DNN_n_vbf++;
       }
 
+      DNN_pass_massCut = ( ((DNN_svfit.M()-116.)*(DNN_svfit.M()-116.))/(35.*35.) + (((DNN_b_1+DNN_b_2).M()-111.)*((DNN_b_1+DNN_b_2).M()-111.))/(45.*45.) <  1.0 );
+
       // Loop on configurable options to get the output prediction
       // For each event save the predictions for all the kl values requested
       for (unsigned int jkl = 0; jkl < DNN_kl.size(); ++jkl)
@@ -5496,7 +5498,8 @@ int main (int argc, char** argv)
            DNN_b_1_HHbtag, DNN_b_2_HHbtag, DNN_vbf_1_HHbtag, DNN_vbf_2_HHbtag,
            DNN_b_1_CvsL, DNN_b_2_CvsL, DNN_vbf_1_CvsL, DNN_vbf_2_CvsL,
            DNN_b_1_CvsB, DNN_b_2_CvsB, DNN_vbf_1_CvsB, DNN_vbf_2_CvsB,
-           0, 0, 0); // cv, c2v, c3
+           0, 0, 0, // cv, c2v, c3
+           DNN_pass_massCut);
 
         // Get model prediction
         DNN_pred = wrapper.predict(feat_vals, DNN_evt);

--- a/test/skimNtuple2018.cpp
+++ b/test/skimNtuple2018.cpp
@@ -5345,7 +5345,7 @@ int main (int argc, char** argv)
     float DNN_b_1_HHbtag, DNN_b_2_HHbtag, DNN_vbf_1_HHbtag, DNN_vbf_2_HHbtag;
     int DNN_is_boosted, DNN_n_vbf, DNN_isvbf;
     unsigned long long int DNN_evt;
-    bool DNN_svfit_conv, DNN_hh_kinfit_conv;
+    bool DNN_svfit_conv, DNN_hh_kinfit_conv, DNN_pass_massCut;
     int DNN_nleps, DNN_nbjetscand;
 
     Channel DNN_e_channel;
@@ -5522,6 +5522,8 @@ int main (int argc, char** argv)
             if (*rv_vbf_2_e != -999.) DNN_n_vbf++;
           }
 
+        DNN_pass_massCut = ( ((DNN_svfit.M()-116.)*(DNN_svfit.M()-116.))/(35.*35.) + (((DNN_b_1+DNN_b_2).M()-111.)*((DNN_b_1+DNN_b_2).M()-111.))/(45.*45.) <  1.0 );
+
         // Loop on configurable options to get the output prediction
         // For each event save the predictions for all the kl values requested
         for (unsigned int jkl = 0; jkl < DNN_kl.size(); ++jkl)
@@ -5537,7 +5539,8 @@ int main (int argc, char** argv)
              DNN_b_1_HHbtag, DNN_b_2_HHbtag, DNN_vbf_1_HHbtag, DNN_vbf_2_HHbtag,
              DNN_b_1_CvsL, DNN_b_2_CvsL, DNN_vbf_1_CvsL, DNN_vbf_2_CvsL,
              DNN_b_1_CvsB, DNN_b_2_CvsB, DNN_vbf_1_CvsB, DNN_vbf_2_CvsB,
-             0, 0, 0); // cv, c2v, c3
+             0, 0, 0, // cv, c2v, c3
+             DNN_pass_massCut);
 
           // Get model prediction
           DNN_pred = wrapper.predict(feat_vals, DNN_evt);


### PR DESCRIPTION
Update DNN to tag V4.0: 
- it should be ok for all the most recent availabe models
- files updated:
  - README.md
  - DNNKLUBinterface.h/cc
  - skimNtuple201*.cpp
  - all three of the skim_configs (**heads up** @camendola , @dzuolo and @jonamotta )

For now the mass selection is set to the old elliptic mass cut, but it should be updated once we converge on a final mass cut.
In the configs I put the model `2020-06-29-0` for now, which is ok with the old mass cut.
For more information about the different models see [this page](https://github.com/GilesStrong/cms_runII_dnn_models).

This PR is still to be tested.