### PR TITLE
QCD shifts and bTagReshape SF normalization

### DIFF
--- a/config/mainCfg_ETau_Legacy2016_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2016_limits.cfg
@@ -112,12 +112,23 @@ regionD      = SSinviso
 doUnc        = True
 
 
-[VBF_rew]
-# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
-# See the list 'inputSignals' to understand the link node<->couplings
-doReweighting = False
-inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
-target_kl  = 1
-target_cv  = 0, 1
-target_c2v = 1
-target_xs = 1 #[pb]
+[bTagRfactor]
+central                          = 1.0120
+#bTagweightReshape_jes_up        = 1.0120
+#bTagweightReshape_lf_up         = 1.0120
+#bTagweightReshape_hf_up         = 1.0120
+#bTagweightReshape_hfstats1_up   = 1.0120
+#bTagweightReshape_hfstats2_up   = 1.0120
+#bTagweightReshape_lfstats1_up   = 1.0120
+#bTagweightReshape_lfstats2_up   = 1.0120
+#bTagweightReshape_cferr1_up     = 1.0120
+#bTagweightReshape_cferr2_up     = 1.0120
+#bTagweightReshape_jes_down      = 1.0120
+#bTagweightReshape_lf_down       = 1.0120
+#bTagweightReshape_hf_down       = 1.0120
+#bTagweightReshape_hfstats1_down = 1.0120
+#bTagweightReshape_hfstats2_down = 1.0120
+#bTagweightReshape_lfstats1_down = 1.0120
+#bTagweightReshape_lfstats2_down = 1.0120
+#bTagweightReshape_cferr1_down   = 1.0120
+#bTagweightReshape_cferr2_down   = 1.0120

--- a/config/mainCfg_ETau_Legacy2016_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2016_limits.cfg
@@ -109,6 +109,7 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+doUnc        = True
 
 
 [VBF_rew]

--- a/config/mainCfg_ETau_Legacy2016_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2016_limits.cfg
@@ -2,7 +2,7 @@
 
 lumi = 35922 # pb^-1 full 2016
 
-outputFolder = analysis_ETau_2016_2Oct2020_limits
+outputFolder = analysis_ETau_2016_17Nov2020_limits
 
 data = DsingleEleB, DsingleEleC, DsingleEleD, DsingleEleE, DsingleEleF, DsingleEleG, DsingleEleH
 
@@ -10,8 +10,10 @@ signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH2p45_xs, GGHH_NLO_cHHH5_xs, VBFHH_CV_1
 
 backgrounds = TTfullyHad, TTfullyLep, TTsemiLep, DY_0b_1Pt, DY_0b_2Pt, DY_0b_3Pt, DY_0b_4Pt, DY_0b_5Pt, DY_0b_6Pt, DY_1b_1Pt, DY_1b_2Pt, DY_1b_3Pt, DY_1b_4Pt, DY_1b_5Pt, DY_1b_6Pt, DY_2b_1Pt, DY_2b_2Pt, DY_2b_3Pt, DY_2b_4Pt, DY_2b_5Pt, DY_2b_6Pt, DY_LM, WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, WWW, WWZ, WZZ, ZZZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ
 
-variables = DNNoutSM_kl_1, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot
+variables = DNNoutSM_kl_1 #, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot
+#variables = DNNoutSM_kl_1, dau1_pt, dau1_eta, tauH_SVFIT_mass, bjet1_bID_deepFlavor, bjet2_bID_deepFlavor
 
+#selections = baseline, baselineBtag, baselineMcut, s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose, GGFclass, VBFclass, ttHclass, TTlepclass, TThadclass, DYclass
 selections = s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose, GGFclass, VBFclass, ttHclass, TTlepclass, TThadclass, DYclass
 
 regions    = SR, SStight, OSinviso, SSinviso
@@ -21,13 +23,15 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 sampleCfg = config/sampleCfg_Legacy2016.cfg
 cutCfg    = config/selectionCfg_ETau_Legacy2016.cfg
-pattern   = goodsystfiles  # use this only when running on systematics files
+#pattern   = goodsystfiles  # use this only when running on systematics files
 
 
 [merge]
-#TT        = TTfullyHad, TTfullyLep, TTsemiLep
-#WJets     = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
-#other	  = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, TWantitop, singleTop_top, singleTop_antitop, ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, WWW, WWZ, WZZ, ZZZ, DY_LM
+# plotting
+#DY      = DY_0b_1Pt, DY_0b_2Pt, DY_0b_3Pt, DY_0b_4Pt, DY_0b_5Pt, DY_0b_6Pt, DY_1b_1Pt, DY_1b_2Pt, DY_1b_3Pt, DY_1b_4Pt, DY_1b_5Pt, DY_1b_6Pt, DY_2b_1Pt, DY_2b_2Pt, DY_2b_3Pt, DY_2b_4Pt, DY_2b_5Pt, DY_2b_6Pt, DY_LM
+#TT      = TTfullyHad, TTfullyLep, TTsemiLep
+#singleH = ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, ggHTauTau, VBFHTauTau
+#other   = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, singleTop_top, singleTop_antitop, TWtop, TWantitop, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, TTZZ, TTWW, TTWZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, WWW, WWZ, WZZ, ZZZ
 
 # For shape sync
 #TT      = TTfullyHad
@@ -113,22 +117,22 @@ doUnc        = True
 
 
 [bTagRfactor]
-central                          = 1.0120
-#bTagweightReshape_jes_up        = 1.0120
-#bTagweightReshape_lf_up         = 1.0120
-#bTagweightReshape_hf_up         = 1.0120
-#bTagweightReshape_hfstats1_up   = 1.0120
-#bTagweightReshape_hfstats2_up   = 1.0120
-#bTagweightReshape_lfstats1_up   = 1.0120
-#bTagweightReshape_lfstats2_up   = 1.0120
-#bTagweightReshape_cferr1_up     = 1.0120
-#bTagweightReshape_cferr2_up     = 1.0120
-#bTagweightReshape_jes_down      = 1.0120
-#bTagweightReshape_lf_down       = 1.0120
-#bTagweightReshape_hf_down       = 1.0120
-#bTagweightReshape_hfstats1_down = 1.0120
-#bTagweightReshape_hfstats2_down = 1.0120
-#bTagweightReshape_lfstats1_down = 1.0120
-#bTagweightReshape_lfstats2_down = 1.0120
-#bTagweightReshape_cferr1_down   = 1.0120
-#bTagweightReshape_cferr2_down   = 1.0120
+central                         = 1.0120
+bTagweightReshape_jes_up        = 0.9664
+bTagweightReshape_lf_up         = 1.1869
+bTagweightReshape_hf_up         = 0.9821
+bTagweightReshape_hfstats1_up   = 0.9734
+bTagweightReshape_hfstats2_up   = 0.9910
+bTagweightReshape_lfstats1_up   = 1.0168
+bTagweightReshape_lfstats2_up   = 1.0098
+bTagweightReshape_cferr1_up     = 0.9887
+bTagweightReshape_cferr2_up     = 0.9904
+bTagweightReshape_jes_down      = 1.0262
+bTagweightReshape_lf_down       = 0.8461
+bTagweightReshape_hf_down       = 1.0175
+bTagweightReshape_hfstats1_down = 1.0270
+bTagweightReshape_hfstats2_down = 1.0089
+bTagweightReshape_lfstats1_down = 0.9831
+bTagweightReshape_lfstats2_down = 0.9899
+bTagweightReshape_cferr1_down   = 1.0184
+bTagweightReshape_cferr2_down   = 1.0127

--- a/config/mainCfg_ETau_Legacy2017_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2017_limits.cfg
@@ -94,6 +94,7 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+doUnc        = True
 
 
 [VBF_rew]

--- a/config/mainCfg_ETau_Legacy2017_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2017_limits.cfg
@@ -97,12 +97,23 @@ regionD      = SSinviso
 doUnc        = True
 
 
-[VBF_rew]
-# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
-# See the list 'inputSignals' to understand the link node<->couplings
-doReweighting = False
-inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
-target_kl  = 1
-target_cv  = 0, 1
-target_c2v = 1
-target_xs = 1 #[pb]
+[bTagRfactor]
+central                          = 0.9949
+#bTagweightReshape_jes_up        = 0.9949
+#bTagweightReshape_lf_up         = 0.9949
+#bTagweightReshape_hf_up         = 0.9949
+#bTagweightReshape_hfstats1_up   = 0.9949
+#bTagweightReshape_hfstats2_up   = 0.9949
+#bTagweightReshape_lfstats1_up   = 0.9949
+#bTagweightReshape_lfstats2_up   = 0.9949
+#bTagweightReshape_cferr1_up     = 0.9949
+#bTagweightReshape_cferr2_up     = 0.9949
+#bTagweightReshape_jes_down      = 0.9949
+#bTagweightReshape_lf_down       = 0.9949
+#bTagweightReshape_hf_down       = 0.9949
+#bTagweightReshape_hfstats1_down = 0.9949
+#bTagweightReshape_hfstats2_down = 0.9949
+#bTagweightReshape_lfstats1_down = 0.9949
+#bTagweightReshape_lfstats2_down = 0.9949
+#bTagweightReshape_cferr1_down   = 0.9949
+#bTagweightReshape_cferr2_down   = 0.9949

--- a/config/mainCfg_ETau_Legacy2017_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2017_limits.cfg
@@ -5,7 +5,7 @@ lumi = 41529 # pb^-1 full 2017
 # approximate to only one decimal digit
 lumi_fb = 41.5 # fb^-1 full 2017
 
-outputFolder = analysis_ETau_2017_1Sept2020_limits
+outputFolder = analysis_ETau_2017_17Nov2020_limits
 
 data = DsingleEleB, DsingleEleC, DsingleEleD, DsingleEleE, DsingleEleF
 
@@ -13,8 +13,9 @@ signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH2p45_xs, GGHH_NLO_cHHH5_xs, VBFHH_CV_1
 
 backgrounds = TTfullyHad, TTfullyLep, TTsemiLep, DY_0b_1Pt, DY_0b_2Pt, DY_0b_3Pt, DY_0b_4Pt, DY_0b_5Pt, DY_0b_6Pt, DY_1b_1Pt, DY_1b_2Pt, DY_1b_3Pt, DY_1b_4Pt, DY_1b_5Pt, DY_1b_6Pt, DY_2b_1Pt, DY_2b_2Pt, DY_2b_3Pt, DY_2b_4Pt, DY_2b_5Pt, DY_2b_6Pt, DYJets_M_10_50_Not_PU_Safe, DYJets_M_10_50_PU_Safe, WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, VBFHTauTau, ggHTauTau, WplusHTauTau, WminusHTauTau, ZZTo4L, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, WZTo3LNu, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WWTo2L2Nu, WWToLNuQQ, WWTo4Q, ZZZ, WZZ, WWW, WWZ, ttHJetToBB, ttHJetTononBB, ttHToTauTau, TTWJetsToLNu, TTWJetsToQQ, TTZZ, TTWW, TTWZ, TTWH, TTZH, TTZToLLNuNu, TTZToQQ
 
-variables = DNNoutSM_kl_1, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot
+variables = DNNoutSM_kl_1 #, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot
 
+#selections = baseline, baselineMcut, s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose, GGFclass, VBFclass, ttHclass, TTlepclass, TThadclass, DYclass
 selections = s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose, GGFclass, VBFclass, ttHclass, TTlepclass, TThadclass, DYclass
 
 regions    = SR, SStight, OSinviso, SSinviso
@@ -23,10 +24,17 @@ regions    = SR, SStight, OSinviso, SSinviso
 [configs]
 sampleCfg = config/sampleCfg_Legacy2017.cfg
 cutCfg    = config/selectionCfg_ETau_Legacy2017.cfg
-pattern   = goodsystfiles
+#pattern   = goodsystfiles
 
 
 [merge]
+# plotting
+#DY      = DYJets_M_10_50_Not_PU_Safe, DYJets_M_10_50_PU_Safe, DY_0b_1Pt, DY_0b_2Pt, DY_0b_3Pt, DY_0b_4Pt, DY_0b_5Pt, DY_0b_6Pt, DY_1b_1Pt, DY_1b_2Pt, DY_1b_3Pt, DY_1b_4Pt, DY_1b_5Pt, DY_1b_6Pt, DY_2b_1Pt, DY_2b_2Pt, DY_2b_3Pt, DY_2b_4Pt, DY_2b_5Pt, DY_2b_6Pt
+#TT      = TTfullyHad, TTfullyLep, TTsemiLep
+#singleH = ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, ttHToTauTau, ggHTauTau, VBFHTauTau, TTWH, TTZH
+#other   = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, singleTop_top, singleTop_antitop, TWtop, TWantitop, WWTo2L2Nu, WWToLNuQQ, WWTo4Q, WZTo3LNu, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, ZZTo4L, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, TTWJetsToLNu, TTWJetsToQQ, TTZZ, TTWW, TTWZ, TTZToLLNuNu, TTZToQQ, WWW, WWZ, WZZ, ZZZ
+
+# limits
 TT      = TTfullyHad, TTfullyLep, TTsemiLep
 W       = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 EWK     = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL
@@ -98,22 +106,22 @@ doUnc        = True
 
 
 [bTagRfactor]
-central                          = 0.9949
-#bTagweightReshape_jes_up        = 0.9949
-#bTagweightReshape_lf_up         = 0.9949
-#bTagweightReshape_hf_up         = 0.9949
-#bTagweightReshape_hfstats1_up   = 0.9949
-#bTagweightReshape_hfstats2_up   = 0.9949
-#bTagweightReshape_lfstats1_up   = 0.9949
-#bTagweightReshape_lfstats2_up   = 0.9949
-#bTagweightReshape_cferr1_up     = 0.9949
-#bTagweightReshape_cferr2_up     = 0.9949
-#bTagweightReshape_jes_down      = 0.9949
-#bTagweightReshape_lf_down       = 0.9949
-#bTagweightReshape_hf_down       = 0.9949
-#bTagweightReshape_hfstats1_down = 0.9949
-#bTagweightReshape_hfstats2_down = 0.9949
-#bTagweightReshape_lfstats1_down = 0.9949
-#bTagweightReshape_lfstats2_down = 0.9949
-#bTagweightReshape_cferr1_down   = 0.9949
-#bTagweightReshape_cferr2_down   = 0.9949
+central                         = 0.9949
+bTagweightReshape_jes_up        = 1.1704
+bTagweightReshape_lf_up         = 1.6027
+bTagweightReshape_hf_up         = 1.2080
+bTagweightReshape_hfstats1_up   = 1.1880
+bTagweightReshape_hfstats2_up   = 1.2075
+bTagweightReshape_lfstats1_up   = 1.2539
+bTagweightReshape_lfstats2_up   = 1.2456
+bTagweightReshape_cferr1_up     = 1.2055
+bTagweightReshape_cferr2_up     = 1.2078
+bTagweightReshape_jes_down      = 1.2679
+bTagweightReshape_lf_down       = 0.9523
+bTagweightReshape_hf_down       = 1.2402
+bTagweightReshape_hfstats1_down = 1.2628
+bTagweightReshape_hfstats2_down = 1.2423
+bTagweightReshape_lfstats1_down = 1.1963
+bTagweightReshape_lfstats2_down = 1.2043
+bTagweightReshape_cferr1_down   = 1.2605
+bTagweightReshape_cferr2_down   = 1.2492

--- a/config/mainCfg_ETau_Legacy2018_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2018_limits.cfg
@@ -95,6 +95,7 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+doUnc        = True
 
 
 [VBF_rew]

--- a/config/mainCfg_ETau_Legacy2018_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2018_limits.cfg
@@ -98,12 +98,23 @@ regionD      = SSinviso
 doUnc        = True
 
 
-[VBF_rew]
-# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
-# See the list 'inputSignals' to understand the link node<->couplings
-doReweighting = False
-inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
-target_kl  = 1
-target_cv  = 0, 1
-target_c2v = 1
-target_xs = 1 #[pb]
+[bTagRfactor]
+central                          = 1.0004
+#bTagweightReshape_jes_up        = 1.0004
+#bTagweightReshape_lf_up         = 1.0004
+#bTagweightReshape_hf_up         = 1.0004
+#bTagweightReshape_hfstats1_up   = 1.0004
+#bTagweightReshape_hfstats2_up   = 1.0004
+#bTagweightReshape_lfstats1_up   = 1.0004
+#bTagweightReshape_lfstats2_up   = 1.0004
+#bTagweightReshape_cferr1_up     = 1.0004
+#bTagweightReshape_cferr2_up     = 1.0004
+#bTagweightReshape_jes_down      = 1.0004
+#bTagweightReshape_lf_down       = 1.0004
+#bTagweightReshape_hf_down       = 1.0004
+#bTagweightReshape_hfstats1_down = 1.0004
+#bTagweightReshape_hfstats2_down = 1.0004
+#bTagweightReshape_lfstats1_down = 1.0004
+#bTagweightReshape_lfstats2_down = 1.0004
+#bTagweightReshape_cferr1_down   = 1.0004
+#bTagweightReshape_cferr2_down   = 1.0004

--- a/config/mainCfg_MuTau_Legacy2016_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2016_limits.cfg
@@ -112,12 +112,23 @@ regionD      = SSinviso
 doUnc        = True
 
 
-[VBF_rew]
-# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
-# See the list 'inputSignals' to understand the link node<->couplings
-doReweighting = False
-inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
-target_kl  = 1
-target_cv  = 0, 1
-target_c2v = 1
-target_xs = 1 #[pb]
+[bTagRfactor]
+central                          = 1.013
+#bTagweightReshape_jes_up        = 1.013
+#bTagweightReshape_lf_up         = 1.013
+#bTagweightReshape_hf_up         = 1.013
+#bTagweightReshape_hfstats1_up   = 1.013
+#bTagweightReshape_hfstats2_up   = 1.013
+#bTagweightReshape_lfstats1_up   = 1.013
+#bTagweightReshape_lfstats2_up   = 1.013
+#bTagweightReshape_cferr1_up     = 1.013
+#bTagweightReshape_cferr2_up     = 1.013
+#bTagweightReshape_jes_down      = 1.013
+#bTagweightReshape_lf_down       = 1.013
+#bTagweightReshape_hf_down       = 1.013
+#bTagweightReshape_hfstats1_down = 1.013
+#bTagweightReshape_hfstats2_down = 1.013
+#bTagweightReshape_lfstats1_down = 1.013
+#bTagweightReshape_lfstats2_down = 1.013
+#bTagweightReshape_cferr1_down   = 1.013
+#bTagweightReshape_cferr2_down   = 1.013

--- a/config/mainCfg_MuTau_Legacy2016_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2016_limits.cfg
@@ -109,6 +109,7 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+doUnc        = True
 
 
 [VBF_rew]

--- a/config/mainCfg_MuTau_Legacy2016_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2016_limits.cfg
@@ -2,7 +2,7 @@
 
 lumi = 35922 # pb^-1 full 2016
 
-outputFolder = analysis_MuTau_2016_2Oct2020_limits
+outputFolder = analysis_MuTau_2016_17Nov2020_limits
 
 data = DsingleMuB, DsingleMuC, DsingleMuD, DsingleMuE, DsingleMuF, DsingleMuG, DsingleMuH
 
@@ -10,8 +10,10 @@ signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH2p45_xs, GGHH_NLO_cHHH5_xs, VBFHH_CV_1
 
 backgrounds = TTfullyHad, TTfullyLep, TTsemiLep, DY_0b_1Pt, DY_0b_2Pt, DY_0b_3Pt, DY_0b_4Pt, DY_0b_5Pt, DY_0b_6Pt, DY_1b_1Pt, DY_1b_2Pt, DY_1b_3Pt, DY_1b_4Pt, DY_1b_5Pt, DY_1b_6Pt, DY_2b_1Pt, DY_2b_2Pt, DY_2b_3Pt, DY_2b_4Pt, DY_2b_5Pt, DY_2b_6Pt, DY_LM, WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, WWW, WWZ, WZZ, ZZZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ
 
-variables = DNNoutSM_kl_1, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot
+variables = DNNoutSM_kl_1 #, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot
+#variables = DNNoutSM_kl_1, dau1_pt, dau1_eta, tauH_SVFIT_mass, bjet1_bID_deepFlavor, bjet2_bID_deepFlavor
 
+#selections = baseline, baselineBtag, baselineMcut, s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose, GGFclass, VBFclass, ttHclass, TTlepclass, TThadclass, DYclass
 selections = s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose, GGFclass, VBFclass, ttHclass, TTlepclass, TThadclass, DYclass
 
 regions    = SR, SStight, OSinviso, SSinviso
@@ -21,13 +23,15 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 sampleCfg = config/sampleCfg_Legacy2016.cfg
 cutCfg    = config/selectionCfg_MuTau_Legacy2016.cfg
-pattern   = goodsystfiles  # use this only when running on systematics files
+#pattern   = goodsystfiles  # use this only when running on systematics files
 
 
 [merge]
-#TT        = TTfullyHad, TTfullyLep, TTsemiLep
-#WJets     = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
-#other	  = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, TWantitop, singleTop_top, singleTop_antitop, ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, WWW, WWZ, WZZ, ZZZ, DY_LM
+# plotting
+#DY      = DY_0b_1Pt, DY_0b_2Pt, DY_0b_3Pt, DY_0b_4Pt, DY_0b_5Pt, DY_0b_6Pt, DY_1b_1Pt, DY_1b_2Pt, DY_1b_3Pt, DY_1b_4Pt, DY_1b_5Pt, DY_1b_6Pt, DY_2b_1Pt, DY_2b_2Pt, DY_2b_3Pt, DY_2b_4Pt, DY_2b_5Pt, DY_2b_6Pt, DY_LM
+#TT      = TTfullyHad, TTfullyLep, TTsemiLep
+#singleH = ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, ggHTauTau, VBFHTauTau
+#other   = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, singleTop_top, singleTop_antitop, TWtop, TWantitop, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, TTZZ, TTWW, TTWZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, WWW, WWZ, WZZ, ZZZ
 
 # For shape sync
 #TT      = TTfullyHad
@@ -113,22 +117,22 @@ doUnc        = True
 
 
 [bTagRfactor]
-central                          = 1.013
-#bTagweightReshape_jes_up        = 1.013
-#bTagweightReshape_lf_up         = 1.013
-#bTagweightReshape_hf_up         = 1.013
-#bTagweightReshape_hfstats1_up   = 1.013
-#bTagweightReshape_hfstats2_up   = 1.013
-#bTagweightReshape_lfstats1_up   = 1.013
-#bTagweightReshape_lfstats2_up   = 1.013
-#bTagweightReshape_cferr1_up     = 1.013
-#bTagweightReshape_cferr2_up     = 1.013
-#bTagweightReshape_jes_down      = 1.013
-#bTagweightReshape_lf_down       = 1.013
-#bTagweightReshape_hf_down       = 1.013
-#bTagweightReshape_hfstats1_down = 1.013
-#bTagweightReshape_hfstats2_down = 1.013
-#bTagweightReshape_lfstats1_down = 1.013
-#bTagweightReshape_lfstats2_down = 1.013
-#bTagweightReshape_cferr1_down   = 1.013
-#bTagweightReshape_cferr2_down   = 1.013
+central                         = 1.013
+bTagweightReshape_jes_up        = 0.9777
+bTagweightReshape_lf_up         = 1.1893
+bTagweightReshape_hf_up         = 0.9970
+bTagweightReshape_hfstats1_up   = 0.9901
+bTagweightReshape_hfstats2_up   = 1.0068
+bTagweightReshape_lfstats1_up   = 1.0316
+bTagweightReshape_lfstats2_up   = 1.0247
+bTagweightReshape_cferr1_up     = 1.0030
+bTagweightReshape_cferr2_up     = 1.0049
+bTagweightReshape_jes_down      = 1.0454
+bTagweightReshape_lf_down       = 0.8685
+bTagweightReshape_hf_down       = 1.0331
+bTagweightReshape_hfstats1_down = 1.0406
+bTagweightReshape_hfstats2_down = 1.0236
+bTagweightReshape_lfstats1_down = 0.9987
+bTagweightReshape_lfstats2_down = 1.0056
+bTagweightReshape_cferr1_down   = 1.0353
+bTagweightReshape_cferr2_down   = 1.0291

--- a/config/mainCfg_MuTau_Legacy2017_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2017_limits.cfg
@@ -94,6 +94,7 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+doUnc        = True
 
 
 [VBF_rew]

--- a/config/mainCfg_MuTau_Legacy2017_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2017_limits.cfg
@@ -97,12 +97,23 @@ regionD      = SSinviso
 doUnc        = True
 
 
-[VBF_rew]
-# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
-# See the list 'inputSignals' to understand the link node<->couplings
-doReweighting = False
-inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
-target_kl  = 1
-target_cv  = 0, 1
-target_c2v = 1
-target_xs = 1 #[pb]
+[bTagRfactor]
+central                          = 0.9993
+#bTagweightReshape_jes_up        = 0.9993
+#bTagweightReshape_lf_up         = 0.9993
+#bTagweightReshape_hf_up         = 0.9993
+#bTagweightReshape_hfstats1_up   = 0.9993
+#bTagweightReshape_hfstats2_up   = 0.9993
+#bTagweightReshape_lfstats1_up   = 0.9993
+#bTagweightReshape_lfstats2_up   = 0.9993
+#bTagweightReshape_cferr1_up     = 0.9993
+#bTagweightReshape_cferr2_up     = 0.9993
+#bTagweightReshape_jes_down      = 0.9993
+#bTagweightReshape_lf_down       = 0.9993
+#bTagweightReshape_hf_down       = 0.9993
+#bTagweightReshape_hfstats1_down = 0.9993
+#bTagweightReshape_hfstats2_down = 0.9993
+#bTagweightReshape_lfstats1_down = 0.9993
+#bTagweightReshape_lfstats2_down = 0.9993
+#bTagweightReshape_cferr1_down   = 0.9993
+#bTagweightReshape_cferr2_down   = 0.9993

--- a/config/mainCfg_MuTau_Legacy2017_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2017_limits.cfg
@@ -5,7 +5,7 @@ lumi = 41529 # pb^-1 full 2017
 # approximate to only one decimal digit
 lumi_fb = 41.5 # fb^-1 full 2017
 
-outputFolder = analysis_MuTau_2017_1Sept2020_limits
+outputFolder = analysis_MuTau_2017_17Nov2020_limits
 
 data = DsingleMuB, DsingleMuC, DsingleMuD, DsingleMuE, DsingleMuF
 
@@ -13,8 +13,9 @@ signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH2p45_xs, GGHH_NLO_cHHH5_xs, VBFHH_CV_1
 
 backgrounds = TTfullyHad, TTfullyLep, TTsemiLep, DY_0b_1Pt, DY_0b_2Pt, DY_0b_3Pt, DY_0b_4Pt, DY_0b_5Pt, DY_0b_6Pt, DY_1b_1Pt, DY_1b_2Pt, DY_1b_3Pt, DY_1b_4Pt, DY_1b_5Pt, DY_1b_6Pt, DY_2b_1Pt, DY_2b_2Pt, DY_2b_3Pt, DY_2b_4Pt, DY_2b_5Pt, DY_2b_6Pt, DYJets_M_10_50_Not_PU_Safe, DYJets_M_10_50_PU_Safe, WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, VBFHTauTau, ggHTauTau, WplusHTauTau, WminusHTauTau, ZZTo4L, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, WZTo3LNu, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WWTo2L2Nu, WWToLNuQQ, WWTo4Q, ZZZ, WZZ, WWW, WWZ, ttHJetToBB, ttHJetTononBB, ttHToTauTau, TTWJetsToLNu, TTWJetsToQQ, TTZZ, TTWW, TTWZ, TTWH, TTZH, TTZToLLNuNu, TTZToQQ
 
-variables = DNNoutSM_kl_1, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot
+variables = DNNoutSM_kl_1 #, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot
 
+#selections = baseline, baselineMcut, s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose, GGFclass, VBFclass, ttHclass, TTlepclass, TThadclass, DYclass
 selections = s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose, GGFclass, VBFclass, ttHclass, TTlepclass, TThadclass, DYclass
 
 regions    = SR, SStight, OSinviso, SSinviso
@@ -23,10 +24,17 @@ regions    = SR, SStight, OSinviso, SSinviso
 [configs]
 sampleCfg = config/sampleCfg_Legacy2017.cfg
 cutCfg    = config/selectionCfg_MuTau_Legacy2017.cfg
-pattern   = goodsystfiles
+#pattern   = goodsystfiles
 
 
 [merge]
+# plotting
+#DY      = DYJets_M_10_50_Not_PU_Safe, DYJets_M_10_50_PU_Safe, DY_0b_1Pt, DY_0b_2Pt, DY_0b_3Pt, DY_0b_4Pt, DY_0b_5Pt, DY_0b_6Pt, DY_1b_1Pt, DY_1b_2Pt, DY_1b_3Pt, DY_1b_4Pt, DY_1b_5Pt, DY_1b_6Pt, DY_2b_1Pt, DY_2b_2Pt, DY_2b_3Pt, DY_2b_4Pt, DY_2b_5Pt, DY_2b_6Pt
+#TT      = TTfullyHad, TTfullyLep, TTsemiLep
+#singleH = ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, ttHToTauTau, ggHTauTau, VBFHTauTau, TTWH, TTZH
+#other   = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, singleTop_top, singleTop_antitop, TWtop, TWantitop, WWTo2L2Nu, WWToLNuQQ, WWTo4Q, WZTo3LNu, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, ZZTo4L, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, TTWJetsToLNu, TTWJetsToQQ, TTZZ, TTWW, TTWZ, TTZToLLNuNu, TTZToQQ, WWW, WWZ, WZZ, ZZZ
+
+# Limits
 TT      = TTfullyHad, TTfullyLep, TTsemiLep
 W       = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 EWK     = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL
@@ -98,22 +106,22 @@ doUnc        = True
 
 
 [bTagRfactor]
-central                          = 0.9993
-#bTagweightReshape_jes_up        = 0.9993
-#bTagweightReshape_lf_up         = 0.9993
-#bTagweightReshape_hf_up         = 0.9993
-#bTagweightReshape_hfstats1_up   = 0.9993
-#bTagweightReshape_hfstats2_up   = 0.9993
-#bTagweightReshape_lfstats1_up   = 0.9993
-#bTagweightReshape_lfstats2_up   = 0.9993
-#bTagweightReshape_cferr1_up     = 0.9993
-#bTagweightReshape_cferr2_up     = 0.9993
-#bTagweightReshape_jes_down      = 0.9993
-#bTagweightReshape_lf_down       = 0.9993
-#bTagweightReshape_hf_down       = 0.9993
-#bTagweightReshape_hfstats1_down = 0.9993
-#bTagweightReshape_hfstats2_down = 0.9993
-#bTagweightReshape_lfstats1_down = 0.9993
-#bTagweightReshape_lfstats2_down = 0.9993
-#bTagweightReshape_cferr1_down   = 0.9993
-#bTagweightReshape_cferr2_down   = 0.9993
+central                         = 0.9993
+bTagweightReshape_jes_up        = 1.2225
+bTagweightReshape_lf_up         = 1.6499
+bTagweightReshape_hf_up         = 1.2746
+bTagweightReshape_hfstats1_up   = 1.2568
+bTagweightReshape_hfstats2_up   = 1.2758
+bTagweightReshape_lfstats1_up   = 1.3210
+bTagweightReshape_lfstats2_up   = 1.3124
+bTagweightReshape_cferr1_up     = 1.2715
+bTagweightReshape_cferr2_up     = 1.2740
+bTagweightReshape_jes_down      = 1.3493
+bTagweightReshape_lf_down       = 1.0238
+bTagweightReshape_hf_down       = 1.3090
+bTagweightReshape_hfstats1_down = 1.3292
+bTagweightReshape_hfstats2_down = 1.3095
+bTagweightReshape_lfstats1_down = 1.2645
+bTagweightReshape_lfstats2_down = 1.2728
+bTagweightReshape_cferr1_down   = 1.3317
+bTagweightReshape_cferr2_down   = 1.3192

--- a/config/mainCfg_MuTau_Legacy2018_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2018_limits.cfg
@@ -95,6 +95,7 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+doUnc        = True
 
 
 [VBF_rew]

--- a/config/mainCfg_MuTau_Legacy2018_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2018_limits.cfg
@@ -98,12 +98,23 @@ regionD      = SSinviso
 doUnc        = True
 
 
-[VBF_rew]
-# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
-# See the list 'inputSignals' to understand the link node<->couplings
-doReweighting = False
-inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
-target_kl  = 1
-target_cv  = 0, 1
-target_c2v = 1
-target_xs = 1 #[pb]
+[bTagRfactor]
+central                          = 1.0039
+#bTagweightReshape_jes_up        = 1.0039
+#bTagweightReshape_lf_up         = 1.0039
+#bTagweightReshape_hf_up         = 1.0039
+#bTagweightReshape_hfstats1_up   = 1.0039
+#bTagweightReshape_hfstats2_up   = 1.0039
+#bTagweightReshape_lfstats1_up   = 1.0039
+#bTagweightReshape_lfstats2_up   = 1.0039
+#bTagweightReshape_cferr1_up     = 1.0039
+#bTagweightReshape_cferr2_up     = 1.0039
+#bTagweightReshape_jes_down      = 1.0039
+#bTagweightReshape_lf_down       = 1.0039
+#bTagweightReshape_hf_down       = 1.0039
+#bTagweightReshape_hfstats1_down = 1.0039
+#bTagweightReshape_hfstats2_down = 1.0039
+#bTagweightReshape_lfstats1_down = 1.0039
+#bTagweightReshape_lfstats2_down = 1.0039
+#bTagweightReshape_cferr1_down   = 1.0039
+#bTagweightReshape_cferr2_down   = 1.0039

--- a/config/mainCfg_TauTau_Legacy2016_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2016_limits.cfg
@@ -112,12 +112,23 @@ regionD      = SSinviso
 doUnc        = True
 
 
-[VBF_rew]
-# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
-# See the list 'inputSignals' to understand the link node<->couplings
-doReweighting = False
-inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
-target_kl  = 1
-target_cv  = 0, 1
-target_c2v = 1
-target_xs = 1 #[pb]
+[bTagRfactor]
+central                          = 1.0101
+#bTagweightReshape_jes_up        = 1.0101
+#bTagweightReshape_lf_up         = 1.0101
+#bTagweightReshape_hf_up         = 1.0101
+#bTagweightReshape_hfstats1_up   = 1.0101
+#bTagweightReshape_hfstats2_up   = 1.0101
+#bTagweightReshape_lfstats1_up   = 1.0101
+#bTagweightReshape_lfstats2_up   = 1.0101
+#bTagweightReshape_cferr1_up     = 1.0101
+#bTagweightReshape_cferr2_up     = 1.0101
+#bTagweightReshape_jes_down      = 1.0101
+#bTagweightReshape_lf_down       = 1.0101
+#bTagweightReshape_hf_down       = 1.0101
+#bTagweightReshape_hfstats1_down = 1.0101
+#bTagweightReshape_hfstats2_down = 1.0101
+#bTagweightReshape_lfstats1_down = 1.0101
+#bTagweightReshape_lfstats2_down = 1.0101
+#bTagweightReshape_cferr1_down   = 1.0101
+#bTagweightReshape_cferr2_down   = 1.0101

--- a/config/mainCfg_TauTau_Legacy2016_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2016_limits.cfg
@@ -109,6 +109,7 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+doUnc        = True
 
 
 [VBF_rew]

--- a/config/mainCfg_TauTau_Legacy2016_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2016_limits.cfg
@@ -2,7 +2,7 @@
 
 lumi = 35922 # pb^-1 full 2016
 
-outputFolder = analysis_TauTau_2016_2Oct2020_limits
+outputFolder = analysis_TauTau_2016_17Nov2020_limits
 
 data = DTauB, DTauC, DTauD, DTauE, DTauF, DTauG, DTauH
 
@@ -10,8 +10,10 @@ signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH2p45_xs, GGHH_NLO_cHHH5_xs, VBFHH_CV_1
 
 backgrounds = TTfullyHad, TTfullyLep, TTsemiLep, DY_0b_1Pt, DY_0b_2Pt, DY_0b_3Pt, DY_0b_4Pt, DY_0b_5Pt, DY_0b_6Pt, DY_1b_1Pt, DY_1b_2Pt, DY_1b_3Pt, DY_1b_4Pt, DY_1b_5Pt, DY_1b_6Pt, DY_2b_1Pt, DY_2b_2Pt, DY_2b_3Pt, DY_2b_4Pt, DY_2b_5Pt, DY_2b_6Pt, DY_LM, WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, WWW, WWZ, WZZ, ZZZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ
 
-variables = DNNoutSM_kl_1, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot
+variables = DNNoutSM_kl_1 #, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot
+#variables = DNNoutSM_kl_1, dau1_pt, dau1_eta, tauH_SVFIT_mass, bjet1_bID_deepFlavor, bjet2_bID_deepFlavor
 
+#selections = baseline, baselineBtag, baselineMcut, s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose, GGFclass, VBFclass, ttHclass, TTlepclass, TThadclass, DYclass
 selections = s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose, GGFclass, VBFclass, ttHclass, TTlepclass, TThadclass, DYclass
 
 regions    = SR, SStight, OSinviso, SSinviso
@@ -21,13 +23,15 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 sampleCfg = config/sampleCfg_Legacy2016.cfg
 cutCfg    = config/selectionCfg_TauTau_Legacy2016.cfg
-pattern   = goodsystfiles  # use this only when running on systematics files
+#pattern   = goodsystfiles  # use this only when running on systematics files
 
 
 [merge]
-#TT        = TTfullyHad, TTfullyLep, TTsemiLep
-#WJets     = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
-#other	  = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, TWantitop, singleTop_top, singleTop_antitop, ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, ggHTauTau, VBFHTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, TTWW, TTWZ, TTZZ, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, WWW, WWZ, WZZ, ZZZ, DY_LM
+# plotting
+#DY      = DY_0b_1Pt, DY_0b_2Pt, DY_0b_3Pt, DY_0b_4Pt, DY_0b_5Pt, DY_0b_6Pt, DY_1b_1Pt, DY_1b_2Pt, DY_1b_3Pt, DY_1b_4Pt, DY_1b_5Pt, DY_1b_6Pt, DY_2b_1Pt, DY_2b_2Pt, DY_2b_3Pt, DY_2b_4Pt, DY_2b_5Pt, DY_2b_6Pt, DY_LM
+#TT      = TTfullyHad, TTfullyLep, TTsemiLep
+#singleH = ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, ggHTauTau, VBFHTauTau
+#other   = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, singleTop_top, singleTop_antitop, TWtop, TWantitop, WWTo2L2Nu, WWTo4Q, WWToLNuQQ, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WZTo3LNu, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, ZZTo4L, ZZTo4Q, TTZZ, TTWW, TTWZ, TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu, WWW, WWZ, WZZ, ZZZ
 
 # For shape sync
 #TT      = TTfullyHad
@@ -113,22 +117,22 @@ doUnc        = True
 
 
 [bTagRfactor]
-central                          = 1.0101
-#bTagweightReshape_jes_up        = 1.0101
-#bTagweightReshape_lf_up         = 1.0101
-#bTagweightReshape_hf_up         = 1.0101
-#bTagweightReshape_hfstats1_up   = 1.0101
-#bTagweightReshape_hfstats2_up   = 1.0101
-#bTagweightReshape_lfstats1_up   = 1.0101
-#bTagweightReshape_lfstats2_up   = 1.0101
-#bTagweightReshape_cferr1_up     = 1.0101
-#bTagweightReshape_cferr2_up     = 1.0101
-#bTagweightReshape_jes_down      = 1.0101
-#bTagweightReshape_lf_down       = 1.0101
-#bTagweightReshape_hf_down       = 1.0101
-#bTagweightReshape_hfstats1_down = 1.0101
-#bTagweightReshape_hfstats2_down = 1.0101
-#bTagweightReshape_lfstats1_down = 1.0101
-#bTagweightReshape_lfstats2_down = 1.0101
-#bTagweightReshape_cferr1_down   = 1.0101
-#bTagweightReshape_cferr2_down   = 1.0101
+central                         = 1.0101
+bTagweightReshape_jes_up        = 1.0492
+bTagweightReshape_lf_up         = 1.1845
+bTagweightReshape_hf_up         = 1.0723
+bTagweightReshape_hfstats1_up   = 1.0859
+bTagweightReshape_hfstats2_up   = 1.0947
+bTagweightReshape_lfstats1_up   = 1.1157
+bTagweightReshape_lfstats2_up   = 1.1077
+bTagweightReshape_cferr1_up     = 1.0845
+bTagweightReshape_cferr2_up     = 1.0869
+bTagweightReshape_jes_down      = 1.1448
+bTagweightReshape_lf_down       = 1.0162
+bTagweightReshape_hf_down       = 1.1270
+bTagweightReshape_hfstats1_down = 1.1129
+bTagweightReshape_hfstats2_down = 1.1041
+bTagweightReshape_lfstats1_down = 1.0830
+bTagweightReshape_lfstats2_down = 1.0910
+bTagweightReshape_cferr1_down   = 1.1232
+bTagweightReshape_cferr2_down   = 1.1160

--- a/config/mainCfg_TauTau_Legacy2017_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2017_limits.cfg
@@ -94,6 +94,7 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+doUnc        = True
 
 
 [VBF_rew]

--- a/config/mainCfg_TauTau_Legacy2017_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2017_limits.cfg
@@ -97,12 +97,23 @@ regionD      = SSinviso
 doUnc        = True
 
 
-[VBF_rew]
-# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
-# See the list 'inputSignals' to understand the link node<->couplings
-doReweighting = False
-inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
-target_kl  = 1
-target_cv  = 0, 1
-target_c2v = 1
-target_xs = 1 #[pb]
+[bTagRfactor]
+central                          = 0.9547
+#bTagweightReshape_jes_up        = 0.9547
+#bTagweightReshape_lf_up         = 0.9547
+#bTagweightReshape_hf_up         = 0.9547
+#bTagweightReshape_hfstats1_up   = 0.9547
+#bTagweightReshape_hfstats2_up   = 0.9547
+#bTagweightReshape_lfstats1_up   = 0.9547
+#bTagweightReshape_lfstats2_up   = 0.9547
+#bTagweightReshape_cferr1_up     = 0.9547
+#bTagweightReshape_cferr2_up     = 0.9547
+#bTagweightReshape_jes_down      = 0.9547
+#bTagweightReshape_lf_down       = 0.9547
+#bTagweightReshape_hf_down       = 0.9547
+#bTagweightReshape_hfstats1_down = 0.9547
+#bTagweightReshape_hfstats2_down = 0.9547
+#bTagweightReshape_lfstats1_down = 0.9547
+#bTagweightReshape_lfstats2_down = 0.9547
+#bTagweightReshape_cferr1_down   = 0.9547
+#bTagweightReshape_cferr2_down   = 0.9547

--- a/config/mainCfg_TauTau_Legacy2017_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2017_limits.cfg
@@ -5,7 +5,7 @@ lumi = 41529 # pb^-1 full 2017
 # approximate to only one decimal digit
 lumi_fb = 41.5 # fb^-1 full 2017
 
-outputFolder = analysis_TauTau_2017_1Sept2020_limits
+outputFolder = analysis_TauTau_2017_17Nov2020_limits
 
 data = DTauB, DTauC, DTauD, DTauE, DTauF
 
@@ -13,8 +13,9 @@ signals = GGHH_NLO_cHHH1_xs, GGHH_NLO_cHHH2p45_xs, GGHH_NLO_cHHH5_xs, VBFHH_CV_1
 
 backgrounds = TTfullyHad, TTfullyLep, TTsemiLep, DY_0b_1Pt, DY_0b_2Pt, DY_0b_3Pt, DY_0b_4Pt, DY_0b_5Pt, DY_0b_6Pt, DY_1b_1Pt, DY_1b_2Pt, DY_1b_3Pt, DY_1b_4Pt, DY_1b_5Pt, DY_1b_6Pt, DY_2b_1Pt, DY_2b_2Pt, DY_2b_3Pt, DY_2b_4Pt, DY_2b_5Pt, DY_2b_6Pt, DYJets_M_10_50_Not_PU_Safe, DYJets_M_10_50_PU_Safe, WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, TWtop, TWantitop, singleTop_top, singleTop_antitop, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, VBFHTauTau, ggHTauTau, WplusHTauTau, WminusHTauTau, ZZTo4L, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, WZTo3LNu, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, WWTo2L2Nu, WWToLNuQQ, WWTo4Q, ZZZ, WZZ, WWW, WWZ, ttHJetToBB, ttHJetTononBB, ttHToTauTau, TTWJetsToLNu, TTWJetsToQQ, TTZZ, TTWW, TTWZ, TTWH, TTZH, TTZToLLNuNu, TTZToQQ
 
-variables = DNNoutSM_kl_1, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot
+variables = DNNoutSM_kl_1 #, DNNoutSM_kl_1_tauup_DM0, DNNoutSM_kl_1_taudown_DM0, DNNoutSM_kl_1_tauup_DM1, DNNoutSM_kl_1_taudown_DM1, DNNoutSM_kl_1_tauup_DM10, DNNoutSM_kl_1_taudown_DM10, DNNoutSM_kl_1_tauup_DM11, DNNoutSM_kl_1_taudown_DM11, DNNoutSM_kl_1_eleup_DM0, DNNoutSM_kl_1_eledown_DM0, DNNoutSM_kl_1_eleup_DM1, DNNoutSM_kl_1_eledown_DM1, DNNoutSM_kl_1_muup, DNNoutSM_kl_1_mudown, DNNoutSM_kl_1_jetupTot, DNNoutSM_kl_1_jetdownTot
 
+#selections = baseline, baselineMcut, s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose, GGFclass, VBFclass, ttHclass, TTlepclass, TThadclass, DYclass
 selections = s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose, GGFclass, VBFclass, ttHclass, TTlepclass, TThadclass, DYclass
 
 regions    = SR, SStight, OSinviso, SSinviso
@@ -22,11 +23,18 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 [configs]
 sampleCfg = config/sampleCfg_Legacy2017.cfg
-pattern   = goodsystfiles
 cutCfg    = config/selectionCfg_TauTau_Legacy2017.cfg
+#pattern   = goodsystfiles
 
 
 [merge]
+# plotting
+#DY      = DYJets_M_10_50_Not_PU_Safe, DYJets_M_10_50_PU_Safe, DY_0b_1Pt, DY_0b_2Pt, DY_0b_3Pt, DY_0b_4Pt, DY_0b_5Pt, DY_0b_6Pt, DY_1b_1Pt, DY_1b_2Pt, DY_1b_3Pt, DY_1b_4Pt, DY_1b_5Pt, DY_1b_6Pt, DY_2b_1Pt, DY_2b_2Pt, DY_2b_3Pt, DY_2b_4Pt, DY_2b_5Pt, DY_2b_6Pt
+#TT      = TTfullyHad, TTfullyLep, TTsemiLep
+#singleH = ZH_HBB_ZLL, ZH_HBB_ZQQ, ZH_HTauTau, WplusHTauTau, WminusHTauTau, ttHJetTononBB, ttHJetToBB, ttHToTauTau, ggHTauTau, VBFHTauTau, TTWH, TTZH
+#other   = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, singleTop_top, singleTop_antitop, TWtop, TWantitop, WWTo2L2Nu, WWToLNuQQ, WWTo4Q, WZTo3LNu, WZTo1L1Nu2Q, WZTo1L3Nu, WZTo2L2Q, ZZTo4L, ZZTo2L2Nu, ZZTo2L2Q, ZZTo2Q2Nu, TTWJetsToLNu, TTWJetsToQQ, TTZZ, TTWW, TTWZ, TTZToLLNuNu, TTZToQQ, WWW, WWZ, WZZ, ZZZ
+
+# limits
 TT      = TTfullyHad, TTfullyLep, TTsemiLep
 W       = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 EWK     = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL
@@ -98,22 +106,22 @@ doUnc        = True
 
 
 [bTagRfactor]
-central                          = 0.9547
-#bTagweightReshape_jes_up        = 0.9547
-#bTagweightReshape_lf_up         = 0.9547
-#bTagweightReshape_hf_up         = 0.9547
-#bTagweightReshape_hfstats1_up   = 0.9547
-#bTagweightReshape_hfstats2_up   = 0.9547
-#bTagweightReshape_lfstats1_up   = 0.9547
-#bTagweightReshape_lfstats2_up   = 0.9547
-#bTagweightReshape_cferr1_up     = 0.9547
-#bTagweightReshape_cferr2_up     = 0.9547
-#bTagweightReshape_jes_down      = 0.9547
-#bTagweightReshape_lf_down       = 0.9547
-#bTagweightReshape_hf_down       = 0.9547
-#bTagweightReshape_hfstats1_down = 0.9547
-#bTagweightReshape_hfstats2_down = 0.9547
-#bTagweightReshape_lfstats1_down = 0.9547
-#bTagweightReshape_lfstats2_down = 0.9547
-#bTagweightReshape_cferr1_down   = 0.9547
-#bTagweightReshape_cferr2_down   = 0.9547
+central                         = 0.9547
+bTagweightReshape_jes_up        = 1.6255
+bTagweightReshape_lf_up         = 2.0341
+bTagweightReshape_hf_up         = 1.7261
+bTagweightReshape_hfstats1_up   = 1.7257
+bTagweightReshape_hfstats2_up   = 1.7421
+bTagweightReshape_lfstats1_up   = 1.7829
+bTagweightReshape_lfstats2_up   = 1.7722
+bTagweightReshape_cferr1_up     = 1.7208
+bTagweightReshape_cferr2_up     = 1.7250
+bTagweightReshape_jes_down      = 1.8677
+bTagweightReshape_lf_down       = 1.5092
+bTagweightReshape_hf_down       = 1.7864
+bTagweightReshape_hfstats1_down = 1.7881
+bTagweightReshape_hfstats2_down = 1.7714
+bTagweightReshape_lfstats1_down = 1.7306
+bTagweightReshape_lfstats2_down = 1.7413
+bTagweightReshape_cferr1_down   = 1.8229
+bTagweightReshape_cferr2_down   = 1.8022

--- a/config/mainCfg_TauTau_Legacy2018_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2018_limits.cfg
@@ -95,6 +95,7 @@ doFitIf      = False
 fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
+doUnc        = True
 
 
 [VBF_rew]

--- a/config/mainCfg_TauTau_Legacy2018_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2018_limits.cfg
@@ -98,12 +98,23 @@ regionD      = SSinviso
 doUnc        = True
 
 
-[VBF_rew]
-# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
-# See the list 'inputSignals' to understand the link node<->couplings
-doReweighting = False
-inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
-target_kl  = 1
-target_cv  = 0, 1
-target_c2v = 1
-target_xs = 1 #[pb]
+[bTagRfactor]
+central                          = 0.9795
+#bTagweightReshape_jes_up        = 0.9795
+#bTagweightReshape_lf_up         = 0.9795
+#bTagweightReshape_hf_up         = 0.9795
+#bTagweightReshape_hfstats1_up   = 0.9795
+#bTagweightReshape_hfstats2_up   = 0.9795
+#bTagweightReshape_lfstats1_up   = 0.9795
+#bTagweightReshape_lfstats2_up   = 0.9795
+#bTagweightReshape_cferr1_up     = 0.9795
+#bTagweightReshape_cferr2_up     = 0.9795
+#bTagweightReshape_jes_down      = 0.9795
+#bTagweightReshape_lf_down       = 0.9795
+#bTagweightReshape_hf_down       = 0.9795
+#bTagweightReshape_hfstats1_down = 0.9795
+#bTagweightReshape_hfstats2_down = 0.9795
+#bTagweightReshape_lfstats1_down = 0.9795
+#bTagweightReshape_lfstats2_down = 0.9795
+#bTagweightReshape_cferr1_down   = 0.9795
+#bTagweightReshape_cferr2_down   = 0.9795

--- a/config/sampleCfg_Legacy2016.cfg
+++ b/config/sampleCfg_Legacy2016.cfg
@@ -1,137 +1,133 @@
 [samples]
-DsingleMuB = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Mu_2016B
-DsingleMuC = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Mu_2016C
-DsingleMuD = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Mu_2016D
-DsingleMuE = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Mu_2016E
-DsingleMuF = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Mu_2016F
-DsingleMuG = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Mu_2016G
-DsingleMuH = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Mu_2016H
+DsingleMuB = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Mu_2016B
+DsingleMuC = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Mu_2016C
+DsingleMuD = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Mu_2016D
+DsingleMuE = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Mu_2016E
+DsingleMuF = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Mu_2016F
+DsingleMuG = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Mu_2016G
+DsingleMuH = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Mu_2016H
 
-DsingleEleB = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Ele_2016B
-DsingleEleC = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Ele_2016C
-DsingleEleD = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Ele_2016D
-DsingleEleE = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Ele_2016E
-DsingleEleF = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Ele_2016F
-DsingleEleG = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Ele_2016G
-DsingleEleH = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Ele_2016H
+DsingleEleB = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Ele_2016B
+DsingleEleC = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Ele_2016C
+DsingleEleD = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Ele_2016D
+DsingleEleE = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Ele_2016E
+DsingleEleF = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Ele_2016F
+DsingleEleG = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Ele_2016G
+DsingleEleH = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Ele_2016H
 
-DTauB = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Tau_2016B
-DTauC = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Tau_2016C
-DTauD = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Tau_2016D
-DTauE = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Tau_2016E
-DTauF = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Tau_2016F
-DTauG = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Tau_2016G
-DTauH = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_Tau_2016H
+DTauB = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Tau_2016B
+DTauC = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Tau_2016C
+DTauD = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Tau_2016D
+DTauE = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Tau_2016E
+DTauF = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Tau_2016F
+DTauG = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Tau_2016G
+DTauH = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_Tau_2016H
 
 ########
 
-TTfullyHad = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_TT_fullyHad
-TTfullyLep = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_TT_fullyLep
-TTsemiLep  = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_TT_semiLep
+TTfullyHad = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_TT_semiLep
 
-DY_HM = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY
+DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY
+DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_Low_Mass
 
-DY_LM = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_Low_Mass
+DY0b   = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_updown_allLHEjets_0b
+DY1b   = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_updown_allLHEjets_1b
+DY2b   = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_updown_allLHEjets_2b
 
-DY0b   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_updown_allLHEjets_0b
-DY1b   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_updown_allLHEjets_1b
-DY2b   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_updown_allLHEjets_2b
+DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_0b_50JPt
+DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_0b_80JPt
+DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_0b_110JPt
+DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_0b_190JPt
+DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_1b_50JPt
+DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_1b_80JPt
+DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_1b_110JPt
+DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_1b_190JPt
+DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_2b_50JPt
+DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_2b_80JPt
+DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_2b_110JPt
+DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_DY_2b_190JPt
 
-DY_0b_1Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_0b_0JPt
-DY_0b_2Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_0b_10JPt
-DY_0b_3Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_0b_50JPt
-DY_0b_4Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_0b_80JPt
-DY_0b_5Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_0b_110JPt
-DY_0b_6Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_0b_190JPt
-DY_1b_1Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_1b_0JPt
-DY_1b_2Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_1b_10JPt
-DY_1b_3Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_1b_50JPt
-DY_1b_4Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_1b_80JPt
-DY_1b_5Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_1b_110JPt
-DY_1b_6Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_1b_190JPt
-DY_2b_1Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_2b_0JPt
-DY_2b_2Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_2b_10JPt
-DY_2b_3Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_2b_50JPt
-DY_2b_4Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_2b_80JPt
-DY_2b_5Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_2b_110JPt
-DY_2b_6Pt = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_DY_2b_190JPt
+WJets_HT_0_70       = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WJets_HT_0_70
+WJets_HT_70_100     = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WJets_HT_70_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WJets_HT_2500_Inf
 
-WJets_HT_0_70       = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WJets_HT_0_70
-WJets_HT_70_100     = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WJets_HT_70_100
-WJets_HT_100_200    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WJets_HT_100_200
-WJets_HT_200_400    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WJets_HT_200_400
-WJets_HT_400_600    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WJets_HT_400_600
-WJets_HT_600_800    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WJets_HT_600_800
-WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WJets_HT_800_1200
-WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WJets_HT_1200_2500
-WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WJets_HT_2500_Inf
+TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ST_t_channel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ST_t_channel_antitop
 
-TWtop                  = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ST_tW_top
-TWantitop              = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ST_tW_antitop
-singleTop_top          = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ST_t_channel_top
-singleTop_antitop      = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ST_t_channel_antitop
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_EWKZ2Jets_ZToLL
 
-EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_EWKWMinus2Jets_WToLNu
-EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_EWKWPlus2Jets_WToLNu
-EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_EWKZ2Jets_ZToLL
+WWTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WWTo2L2Nu
+WWTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WWTo4Q
+WWToLNuQQ              = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WWToLNuQQ
+WZTo1L1Nu2Q            = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WZTo1L3Nu
+WZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WZTo2L2Q
+WZTo3LNu               = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WZTo3LNu
+ZZTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ZZTo2L2Nu
+ZZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ZZTo2Q2Nu
+ZZTo4L                 = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ZZTo4L
+ZZTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ZZTo4Q
 
-#WW                     = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WW
-#WZ                     = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WZ
-#ZZ                     = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ZZ
-WWTo2L2Nu              = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WWTo2L2Nu
-WWTo4Q                 = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WWTo4Q
-WWToLNuQQ              = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WWToLNuQQ
-WZTo1L1Nu2Q            = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WZTo1L1Nu2Q
-WZTo1L3Nu              = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WZTo1L3Nu
-WZTo2L2Q               = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WZTo2L2Q
-WZTo3LNu               = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WZTo3LNu
-ZZTo2L2Nu              = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ZZTo2L2Nu
-ZZTo2L2Q               = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ZZTo2L2Q
-ZZTo2Q2Nu              = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ZZTo2Q2Nu
-ZZTo4L                 = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ZZTo4L
-ZZTo4Q                 = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ZZTo4Q
+ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ZH_HBB_ZQQ
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ZH_HTauTau
+ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ttHJetToBB
 
+WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_WZZ
+ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_ZZZ
 
-ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ZH_HBB_ZQQ
-ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ZH_HBB_ZLL
-ZH_HTauTau             = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ZH_HTauTau
-ggHTauTau              = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ggHTauTau
-VBFHTauTau             = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_VBFHTauTau
-WplusHTauTau           = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WplusHTauTau
-WminusHTauTau          = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WminusHTauTau
-ttHJetTononBB          = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ttHJetTononBB
-ttHJetToBB             = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ttHJetToBB
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_TTZToLLNuNu
 
-WWW                    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WWW
-WWZ                    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WWZ
-WZZ                    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_WZZ
-ZZZ                    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_ZZZ
-
-TTWJetsToLNu           = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_TTWJetsToLNu
-TTWJetsToQQ            = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_TTWJetsToQQ
-TTZToLLNuNu            = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_TTZToLLNuNu
-
-TTWW                   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_TTWW
-TTWZ                   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_TTWZ
-TTZZ                   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_TTZZ
+TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_TTZZ
 
 #########
 
-#GGHHSM  = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_GGHHSM
-GGHHSM  = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_HHRew_SM
-VBFHHSM = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+#GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_GGHHSM
+GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_HHRew_SM
+VBFHHSM = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
 
-GGHH_NLO_cHHH1_xs    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_GGHH_NLO_cHHH1_xs
-GGHH_NLO_cHHH0_xs    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_GGHH_NLO_cHHH0_xs
-GGHH_NLO_cHHH2p45_xs = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_GGHH_NLO_cHHH2p45_xs
-GGHH_NLO_cHHH5_xs    = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_GGHH_NLO_cHHH5_xs
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_GGHH_NLO_cHHH5_xs
 
-VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
-VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1
-VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1
-VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0
-VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2
-VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMMED_Legacy2016_1September2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_12Nov2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_0_C3_1
 
 #########
 

--- a/config/sampleCfg_Legacy2017.cfg
+++ b/config/sampleCfg_Legacy2017.cfg
@@ -1,118 +1,137 @@
 [samples]
-DsingleMuB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Mu_2017B
-DsingleMuC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Mu_2017C
-DsingleMuD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Mu_2017D
-DsingleMuE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Mu_2017E
-DsingleMuF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Mu_2017F
+DsingleMuB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Mu_2017B
+DsingleMuC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Mu_2017C
+DsingleMuD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Mu_2017D
+DsingleMuE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Mu_2017E
+DsingleMuF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Mu_2017F
 
-DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Ele_2017B
-DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Ele_2017C
-DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Ele_2017D
-DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Ele_2017E
-DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Ele_2017F
+DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Ele_2017B
+DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Ele_2017C
+DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Ele_2017D
+DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Ele_2017E
+DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Ele_2017F
 
-DTauB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Tau_2017B
-DTauC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Tau_2017C
-DTauD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Tau_2017D
-DTauE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Tau_2017E
-DTauF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_Tau_2017F
-
-########
-
-TTfullyHad = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_TT_fullyHad
-TTfullyLep = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_TT_fullyLep
-TTsemiLep  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_TT_semiLep
-
-DYJets_0j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_0j0b
-DYJets_1j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_1j0b
-DYJets_1j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_1j1b
-DYJets_2j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_2j0b
-DYJets_2j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_2j1b
-DYJets_2j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_2j2b
-DYJets_3j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_3j0b
-DYJets_3j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_3j1b
-DYJets_3j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_3j2b
-DYJets_3j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_3j3b
-DYJets_4j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_4j0b
-DYJets_4j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_4j1b
-DYJets_4j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_4j2b
-DYJets_4j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_4j3b
-DYJets_4j4b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_4j4b
-
-DY_HM                      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DY
-DYJets_M_10_50_Not_PU_Safe = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_M_10_50_Not_PU_Safe
-DYJets_M_10_50_PU_Safe     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_DYJets_M_10_50_PU_Safe
-
-WJets_HT_0_70      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WJets_HT_0_70
-WJets_HT_70_100    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WJets_HT_70_100
-WJets_HT_100_200   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WJets_HT_100_200
-WJets_HT_200_400   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WJets_HT_200_400
-WJets_HT_400_600   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WJets_HT_400_600
-WJets_HT_600_800   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WJets_HT_600_800
-WJets_HT_800_1200  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WJets_HT_800_1200
-WJets_HT_1200_2500 = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WJets_HT_1200_2500
-WJets_HT_2500_Inf  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WJets_HT_2500_Inf
-
-TWtop             = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ST_tW_top
-TWantitop         = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ST_tW_antitop
-singleTop_top     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ST_tchannel_top
-singleTop_antitop = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ST_tchannel_antitop
-
-EWKWMinus2Jets_WToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_EWKWMinus2Jets_WToLNu
-EWKWPlus2Jets_WToLNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_EWKWPlus2Jets_WToLNu
-EWKZ2Jets_ZToLL        = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_EWKZ2Jets_ZToLL
-
-ZH_HBB_ZLL    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ZH_HBB_ZLL
-ZH_HBB_ZQQ    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ZH_HBB_ZQQ
-ZH_HTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ZH_HTauTau
-VBFHTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_VBFHTauTau
-ggHTauTau     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ggHTauTau
-WplusHTauTau  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WplusHTauTau
-WminusHTauTau = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WminusHTauTau
-
-ZZTo4L      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ZZTo4L
-ZZTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ZZTo2L2Nu
-ZZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ZZTo2L2Q
-ZZTo2Q2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ZZTo2Q2Nu
-WZTo3LNu    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WZTo3LNu
-WZTo1L1Nu2Q = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WZTo1L1Nu2Q
-WZTo1L3Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WZTo1L3Nu
-WZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WZTo2L2Q
-WWTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WWTo2L2Nu
-WWToLNuQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WWToLNuQQ
-WWTo4Q      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WWTo4Q
-ZZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ZZZ
-WZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WZZ
-WWW	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WWW
-WWZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_WWZ
-
-ttHJetToBB    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ttHJetToBB
-ttHJetTononBB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ttHJetTononBB
-ttHToTauTau   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_ttHToTauTau
-TTWJetsToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_TTWJetsToLNu
-TTWJetsToQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_TTWJetsToQQ
-TTZZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_TTZZ
-TTWW	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_TTWW
-TTWZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_TTWZ
-TTWH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_TTWH
-TTZH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_TTZH
-TTZToLLNuNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_TTZToLLNuNu
-TTZToQQ       = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_TTZToQQ
+DTauB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Tau_2017B
+DTauC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Tau_2017C
+DTauD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Tau_2017D
+DTauE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Tau_2017E
+DTauF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_Tau_2017F
 
 ########
 
-GGHH_NLO_cHHH0_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_GGHH_NLO_cHHH0_xs
-GGHH_NLO_cHHH1_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_GGHH_NLO_cHHH1_xs
-GGHH_NLO_cHHH2p45_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_GGHH_NLO_cHHH2p45_xs
-GGHH_NLO_cHHH5_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_GGHH_NLO_cHHH5_xs
+TTfullyHad = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_TT_semiLep
 
-VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
-VBFHH_CV_1_C2V_0_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_VBFHH_CV_1_C2V_0_C3_2_xs
-VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_VBFHH_CV_1p5_C2V_1_C3_1_xs
-VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
-VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
-VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
-VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_31Aug2020_HHbtag/SKIM_VBFHH_CV_0p5_C2V_1_C3_1_xs
+DYJets_0j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_0j0b
+DYJets_1j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_1j0b
+DYJets_1j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_1j1b
+DYJets_2j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_2j0b
+DYJets_2j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_2j1b
+DYJets_2j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_2j2b
+DYJets_3j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_3j0b
+DYJets_3j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_3j1b
+DYJets_3j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_3j2b
+DYJets_3j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_3j3b
+DYJets_4j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_4j0b
+DYJets_4j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_4j1b
+DYJets_4j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_4j2b
+DYJets_4j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_4j3b
+DYJets_4j4b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_4j4b
+
+DY_HM                      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY
+DYJets_M_10_50_Not_PU_Safe = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_M_10_50_Not_PU_Safe
+DYJets_M_10_50_PU_Safe     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DYJets_M_10_50_PU_Safe
+
+DY_0b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_0b_30JPt
+DY_0b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_0b_50JPt
+DY_0b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_0b_100JPt
+DY_0b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_0b_200JPt
+DY_1b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_1b_30JPt
+DY_1b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_1b_50JPt
+DY_1b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_1b_100JPt
+DY_1b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_1b_200JPt
+DY_2b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_2b_30JPt
+DY_2b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_2b_50JPt
+DY_2b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_2b_100JPt
+DY_2b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_DY_2b_200JPt
+
+WJets_HT_0_70      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WJets_HT_0_70
+WJets_HT_70_100    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WJets_HT_70_100
+WJets_HT_100_200   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WJets_HT_100_200
+WJets_HT_200_400   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WJets_HT_200_400
+WJets_HT_400_600   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WJets_HT_400_600
+WJets_HT_600_800   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WJets_HT_600_800
+WJets_HT_800_1200  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500 = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WJets_HT_2500_Inf
+
+TWtop             = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ST_tW_top
+TWantitop         = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ST_tW_antitop
+singleTop_top     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ST_tchannel_top
+singleTop_antitop = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ST_tchannel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_EWKZ2Jets_ZToLL
+
+ZH_HBB_ZLL    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ZH_HBB_ZLL
+ZH_HBB_ZQQ    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ZH_HBB_ZQQ
+ZH_HTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ZH_HTauTau
+VBFHTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_VBFHTauTau
+ggHTauTau     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ggHTauTau
+WplusHTauTau  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WplusHTauTau
+WminusHTauTau = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WminusHTauTau
+
+ZZTo4L      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ZZTo4L
+ZZTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ZZTo2L2Nu
+ZZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ZZTo2Q2Nu
+WZTo3LNu    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WZTo3LNu
+WZTo1L1Nu2Q = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WZTo1L3Nu
+WZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WZTo2L2Q
+WWTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WWTo2L2Nu
+WWToLNuQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WWToLNuQQ
+WWTo4Q      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WWTo4Q
+ZZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ZZZ
+WZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WZZ
+WWW	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WWW
+WWZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_WWZ
+
+ttHJetToBB    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ttHJetToBB
+ttHJetTononBB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ttHJetTononBB
+ttHToTauTau   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_ttHToTauTau
+TTWJetsToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_TTWJetsToLNu
+TTWJetsToQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_TTWJetsToQQ
+TTZZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_TTZZ
+TTWW	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_TTWW
+TTWZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_TTWZ
+TTWH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_TTWH
+TTZH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_TTZH
+TTZToLLNuNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_TTZToLLNuNu
+TTZToQQ       = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_TTZToQQ
+
+########
+
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_VBFHH_CV_1_C2V_0_C3_2_xs
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_VBFHH_CV_1p5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_16Nov020_HHbtag/SKIM_VBFHH_CV_0p5_C2V_1_C3_1_xs
 
 
 ## specify here if a sample should use a user-defined efficiency bin for the normalization

--- a/config/selectionCfg_ETau_Legacy2016.cfg
+++ b/config/selectionCfg_ETau_Legacy2016.cfg
@@ -81,15 +81,15 @@ DYclass     = VBFloose, mpp_dy_v5
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
 #baseline  = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
-baseline   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+baseline   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
 #baseline   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
 
-btagLL   = bTagweightL
-btagMM   = bTagweightM
-nobtagMM = bTagweightM
-btagL    = bTagweightL
-btagM    = bTagweightM
-btagMfirst = bTagweightM
+#btagLL   = bTagweightL
+#btagMM   = bTagweightM
+#nobtagMM = bTagweightM
+#btagL    = bTagweightL
+#btagM    = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################
@@ -106,29 +106,13 @@ btagMfirst = bTagweightM
 
 # define alternative weights to be tested instead of the nominal one
 [systematics]
-IdAndIsoAndFakeSF_deep_pt =  tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up, tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down, tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up, tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down, tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up, tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down, tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up, tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down, tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
-bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
-bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+IdAndIsoAndFakeSF_deep_pt = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up, tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down, tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up, tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down, tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up, tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down, tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up, tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down, tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
 trigSF = trigSFDM0Up:trigSF_DM0_up, trigSFDM0Down:trigSF_DM0_down, trigSFDM1Up:trigSF_DM1_up, trigSFDM1Down:trigSF_DM1_down, trigSFDM10Up:trigSF_DM10_up, trigSFDM10Down:trigSF_DM10_down, trigSFDM11Up:trigSF_DM11_up, trigSFDM11Down:trigSF_DM11_down, trigSFeleUp:trigSF_ele_up, trigSFeleDown:trigSF_ele_down
 PUjetID_SF = PUjetIDSFUp:PUjetID_SF_up, PUjetIDSFDown:PUjetID_SF_down
-
-#TTtopPtreweight      = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
-#trigSF_DM0           = trigSFDM0Up:trigSF_DM0_up , trigSFDM0Down:trigSF_DM0_down
-#trigSF_DM1           = trigSFDM1Up:trigSF_DM1_up , trigSFDM1Down:trigSF_DM1_down
-#trigSF_DM10          = trigSFDM10Up:trigSF_DM10_up , trigSFDM10Down:trigSF_DM10_down
-#trigSF_DM11          = trigSFDM11Up:trigSF_DM11_up , trigSFDM11Down:trigSF_DM11_down
-#tauid_pt20to25       = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up   , tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down
-#tauid_pt25to30       = tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up   , tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down
-#tauid_pt30to35       = tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up   , tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down
-#tauid_pt35to40       = tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up   , tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down
-#tauid_pt40toInf      = tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up , tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down
-#mutauFR_etaLt0p4     = mutauFR_etaLt0p4Up:idAndIsoAndFakeSF_mutauFR_etaLt0p4_up       , mutauFR_etaLt0p4Down:idAndIsoAndFakeSF_mutauFR_etaLt0p4_down
-#mutauFR_eta0p4to0p8  = mutauFR_eta0p4to0p8Up:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_up , mutauFR_eta0p4to0p8Down:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_dowm
-#mutauFR_eta0p8to1p2  = mutauFR_eta0p8to1p2Up:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_up , mutauFR_eta0p8to1p2Down:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_dowm
-#mutauFR_eta1p2to1p7  = mutauFR_eta1p2to1p7Up:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_up , mutauFR_eta1p2to1p7Down:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_dowm
-#mutauFR_etaGt1p7     = mutauFR_etaGt1p7Up:idAndIsoAndFakeSF_mutauFR_etaGt1p7_up       , mutauFR_etaGt1p7Down:idAndIsoAndFakeSF_mutauFR_etaGt1p7_down
-#etauFR_barrel        = etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up , etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down
-#etauFR_endcap        = etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up , etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
+#bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
+#bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+#TTtopPtreweight = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
+#bTagweightReshape = bTagweightReshapeJESUp:bTagweightReshape_jes_up, bTagweightReshapeLFUp:bTagweightReshape_lf_up, bTagweightReshapeHFUp:bTagweightReshape_hf_up, bTagweightReshapeHFSTATS1Up:bTagweightReshape_hfstats1_up, bTagweightReshapeHFSTATS2Up:bTagweightReshape_hfstats2_up, bTagweightReshapeLFSTATS1Up:bTagweightReshape_lfstats1_up, bTagweightReshapeLFSTATS2Up:bTagweightReshape_lfstats2_up, bTagweightReshapeCFERR1Up:bTagweightReshape_cferr1_up, bTagweightReshapeCFERR2Up:bTagweightReshape_cferr2_up, bTagweightReshapeJESDown:bTagweightReshape_jes_down, bTagweightReshapeLFDown:bTagweightReshape_lf_down, bTagweightReshapeHFDown:bTagweightReshape_hf_down, bTagweightReshapeHFSTATS1Down:bTagweightReshape_hfstats1_down, bTagweightReshapeHFSTATS2Down:bTagweightReshape_hfstats2_down, bTagweightReshapeLFSTATS1Down:bTagweightReshape_lfstats1_down, bTagweightReshapeLFSTATS2Down:bTagweightReshape_lfstats2_down, bTagweightReshapeCFERR1Down:bTagweightReshape_cferr1_down, bTagweightReshapeCFERR2Down:bTagweightReshape_cferr2_down
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_ETau_Legacy2016_syst.cfg
+++ b/config/selectionCfg_ETau_Legacy2016_syst.cfg
@@ -887,15 +887,15 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v2_jesDown_11
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
 
 # remove DY weights, they are already taken into account in baseline weights
-btagLL    = bTagweightL
-btagMM    = bTagweightM
-nobtagMM  = bTagweightM
-btagL     = bTagweightL
-btagM     = bTagweightM
-btagMfirst = bTagweightM
+#btagLL    = bTagweightL
+#btagMM    = bTagweightM
+#nobtagMM  = bTagweightM
+#btagL     = bTagweightL
+#btagM     = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_ETau_Legacy2017.cfg
+++ b/config/selectionCfg_ETau_Legacy2017.cfg
@@ -91,15 +91,15 @@ DYclass     = VBFloose, mpp_dy_v5
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF
+baseline = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF, bTagweightReshape
 #baseline = MC_weight, PUReweight, L1pref_weight, trigSF, FakeRateSF_deep, DYscale_MTT, prescaleWeight, PUjetID_SF
 
-btagLL   = bTagweightL
-btagMM   = bTagweightM
-nobtagMM = bTagweightM
-btagL    = bTagweightL
-btagM    = bTagweightM
-btagMfirst = bTagweightM
+#btagLL   = bTagweightL
+#btagMM   = bTagweightM
+#nobtagMM = bTagweightM
+#btagL    = bTagweightL
+#btagM    = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################
@@ -114,29 +114,13 @@ btagMfirst = bTagweightM
 
 # define alternative weights to be tested instead of the nominal one
 [systematics]
-IdAndIsoAndFakeSF_deep_pt =  tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up, tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down, tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up, tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down, tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up, tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down, tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up, tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down, tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
-bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
-bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+IdAndIsoAndFakeSF_deep_pt = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up, tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down, tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up, tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down, tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up, tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down, tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up, tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down, tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
 trigSF = trigSFDM0Up:trigSF_DM0_up, trigSFDM0Down:trigSF_DM0_down, trigSFDM1Up:trigSF_DM1_up, trigSFDM1Down:trigSF_DM1_down, trigSFDM10Up:trigSF_DM10_up, trigSFDM10Down:trigSF_DM10_down, trigSFDM11Up:trigSF_DM11_up, trigSFDM11Down:trigSF_DM11_down, trigSFeleUp:trigSF_ele_up, trigSFeleDown:trigSF_ele_down
 PUjetID_SF = PUjetIDSFUp:PUjetID_SF_up, PUjetIDSFDown:PUjetID_SF_down
-
-#TTtopPtreweight      = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
-#trigSF_DM0           = trigSFDM0Up:trigSF_DM0_up , trigSFDM0Down:trigSF_DM0_down
-#trigSF_DM1           = trigSFDM1Up:trigSF_DM1_up , trigSFDM1Down:trigSF_DM1_down
-#trigSF_DM10          = trigSFDM10Up:trigSF_DM10_up , trigSFDM10Down:trigSF_DM10_down
-#trigSF_DM11          = trigSFDM11Up:trigSF_DM11_up , trigSFDM11Down:trigSF_DM11_down
-#tauid_pt20to25       = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up   , tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down
-#tauid_pt25to30       = tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up   , tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down
-#tauid_pt30to35       = tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up   , tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down
-#tauid_pt35to40       = tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up   , tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down
-#tauid_pt40toInf      = tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up , tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down
-#mutauFR_etaLt0p4     = mutauFR_etaLt0p4Up:idAndIsoAndFakeSF_mutauFR_etaLt0p4_up       , mutauFR_etaLt0p4Down:idAndIsoAndFakeSF_mutauFR_etaLt0p4_down
-#mutauFR_eta0p4to0p8  = mutauFR_eta0p4to0p8Up:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_up , mutauFR_eta0p4to0p8Down:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_dowm
-#mutauFR_eta0p8to1p2  = mutauFR_eta0p8to1p2Up:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_up , mutauFR_eta0p8to1p2Down:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_dowm
-#mutauFR_eta1p2to1p7  = mutauFR_eta1p2to1p7Up:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_up , mutauFR_eta1p2to1p7Down:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_dowm
-#mutauFR_etaGt1p7     = mutauFR_etaGt1p7Up:idAndIsoAndFakeSF_mutauFR_etaGt1p7_up       , mutauFR_etaGt1p7Down:idAndIsoAndFakeSF_mutauFR_etaGt1p7_down
-#etauFR_barrel        = etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up , etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down
-#etauFR_endcap        = etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up , etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
+#bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
+#bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+#TTtopPtreweight = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
+#bTagweightReshape = bTagweightReshapeJESUp:bTagweightReshape_jes_up, bTagweightReshapeLFUp:bTagweightReshape_lf_up, bTagweightReshapeHFUp:bTagweightReshape_hf_up, bTagweightReshapeHFSTATS1Up:bTagweightReshape_hfstats1_up, bTagweightReshapeHFSTATS2Up:bTagweightReshape_hfstats2_up, bTagweightReshapeLFSTATS1Up:bTagweightReshape_lfstats1_up, bTagweightReshapeLFSTATS2Up:bTagweightReshape_lfstats2_up, bTagweightReshapeCFERR1Up:bTagweightReshape_cferr1_up, bTagweightReshapeCFERR2Up:bTagweightReshape_cferr2_up, bTagweightReshapeJESDown:bTagweightReshape_jes_down, bTagweightReshapeLFDown:bTagweightReshape_lf_down, bTagweightReshapeHFDown:bTagweightReshape_hf_down, bTagweightReshapeHFSTATS1Down:bTagweightReshape_hfstats1_down, bTagweightReshapeHFSTATS2Down:bTagweightReshape_hfstats2_down, bTagweightReshapeLFSTATS1Down:bTagweightReshape_lfstats1_down, bTagweightReshapeLFSTATS2Down:bTagweightReshape_lfstats2_down, bTagweightReshapeCFERR1Down:bTagweightReshape_cferr1_down, bTagweightReshapeCFERR2Down:bTagweightReshape_cferr2_down
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_ETau_Legacy2017_syst.cfg
+++ b/config/selectionCfg_ETau_Legacy2017_syst.cfg
@@ -886,15 +886,15 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v2_jesDown_11
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
 
 # remove DY weights, they are already taken into account in baseline weights
-btagLL    = bTagweightL
-btagMM    = bTagweightM
-nobtagMM  = bTagweightM
-btagL     = bTagweightL
-btagM     = bTagweightM
-btagMfirst = bTagweightM
+#btagLL    = bTagweightL
+#btagMM    = bTagweightM
+#nobtagMM  = bTagweightM
+#btagL     = bTagweightL
+#btagM     = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_ETau_Legacy2018.cfg
+++ b/config/selectionCfg_ETau_Legacy2018.cfg
@@ -83,15 +83,15 @@ DYclass     = VBFloose, mpp_dy_v5
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF
+baseline = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF, bTagweightReshape
 
 # remove DY weights, they are already taken into account in baseline weights
-btagLL   = bTagweightL
-btagMM   = bTagweightM
-nobtagMM = bTagweightM
-btagL    = bTagweightL
-btagM    = bTagweightM
-btagMfirst = bTagweightM
+#btagLL   = bTagweightL
+#btagMM   = bTagweightM
+#nobtagMM = bTagweightM
+#btagL    = bTagweightL
+#btagM    = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################
@@ -108,29 +108,13 @@ btagMfirst = bTagweightM
 
 # define alternative weights to be tested instead of the nominal one
 [systematics]
-IdAndIsoAndFakeSF_deep_pt =  tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up, tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down, tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up, tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down, tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up, tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down, tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up, tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down, tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
-bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
-bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+IdAndIsoAndFakeSF_deep_pt = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up, tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down, tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up, tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down, tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up, tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down, tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up, tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down, tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
 trigSF = trigSFDM0Up:trigSF_DM0_up, trigSFDM0Down:trigSF_DM0_down, trigSFDM1Up:trigSF_DM1_up, trigSFDM1Down:trigSF_DM1_down, trigSFDM10Up:trigSF_DM10_up, trigSFDM10Down:trigSF_DM10_down, trigSFDM11Up:trigSF_DM11_up, trigSFDM11Down:trigSF_DM11_down, trigSFeleUp:trigSF_ele_up, trigSFeleDown:trigSF_ele_down
 PUjetID_SF = PUjetIDSFUp:PUjetID_SF_up, PUjetIDSFDown:PUjetID_SF_down
-
-#TTtopPtreweight      = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
-#trigSF_DM0           = trigSFDM0Up:trigSF_DM0_up , trigSFDM0Down:trigSF_DM0_down
-#trigSF_DM1           = trigSFDM1Up:trigSF_DM1_up , trigSFDM1Down:trigSF_DM1_down
-#trigSF_DM10          = trigSFDM10Up:trigSF_DM10_up , trigSFDM10Down:trigSF_DM10_down
-#trigSF_DM11          = trigSFDM11Up:trigSF_DM11_up , trigSFDM11Down:trigSF_DM11_down
-#tauid_pt20to25       = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up   , tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down
-#tauid_pt25to30       = tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up   , tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down
-#tauid_pt30to35       = tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up   , tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down
-#tauid_pt35to40       = tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up   , tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down
-#tauid_pt40toInf      = tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up , tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down
-#mutauFR_etaLt0p4     = mutauFR_etaLt0p4Up:idAndIsoAndFakeSF_mutauFR_etaLt0p4_up       , mutauFR_etaLt0p4Down:idAndIsoAndFakeSF_mutauFR_etaLt0p4_down
-#mutauFR_eta0p4to0p8  = mutauFR_eta0p4to0p8Up:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_up , mutauFR_eta0p4to0p8Down:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_dowm
-#mutauFR_eta0p8to1p2  = mutauFR_eta0p8to1p2Up:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_up , mutauFR_eta0p8to1p2Down:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_dowm
-#mutauFR_eta1p2to1p7  = mutauFR_eta1p2to1p7Up:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_up , mutauFR_eta1p2to1p7Down:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_dowm
-#mutauFR_etaGt1p7     = mutauFR_etaGt1p7Up:idAndIsoAndFakeSF_mutauFR_etaGt1p7_up       , mutauFR_etaGt1p7Down:idAndIsoAndFakeSF_mutauFR_etaGt1p7_down
-#etauFR_barrel        = etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up , etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down
-#etauFR_endcap        = etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up , etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
+#bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
+#bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+#TTtopPtreweight = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
+#bTagweightReshape = bTagweightReshapeJESUp:bTagweightReshape_jes_up, bTagweightReshapeLFUp:bTagweightReshape_lf_up, bTagweightReshapeHFUp:bTagweightReshape_hf_up, bTagweightReshapeHFSTATS1Up:bTagweightReshape_hfstats1_up, bTagweightReshapeHFSTATS2Up:bTagweightReshape_hfstats2_up, bTagweightReshapeLFSTATS1Up:bTagweightReshape_lfstats1_up, bTagweightReshapeLFSTATS2Up:bTagweightReshape_lfstats2_up, bTagweightReshapeCFERR1Up:bTagweightReshape_cferr1_up, bTagweightReshapeCFERR2Up:bTagweightReshape_cferr2_up, bTagweightReshapeJESDown:bTagweightReshape_jes_down, bTagweightReshapeLFDown:bTagweightReshape_lf_down, bTagweightReshapeHFDown:bTagweightReshape_hf_down, bTagweightReshapeHFSTATS1Down:bTagweightReshape_hfstats1_down, bTagweightReshapeHFSTATS2Down:bTagweightReshape_hfstats2_down, bTagweightReshapeLFSTATS1Down:bTagweightReshape_lfstats1_down, bTagweightReshapeLFSTATS2Down:bTagweightReshape_lfstats2_down, bTagweightReshapeCFERR1Down:bTagweightReshape_cferr1_down, bTagweightReshapeCFERR2Down:bTagweightReshape_cferr2_down
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_ETau_Legacy2018_syst.cfg
+++ b/config/selectionCfg_ETau_Legacy2018_syst.cfg
@@ -884,15 +884,15 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v2_jesDown_11
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
 
 # remove DY weights, they are already taken into account in baseline weights
-btagLL    = bTagweightL
-btagMM    = bTagweightM
-nobtagMM  = bTagweightM
-btagL     = bTagweightL
-btagM     = bTagweightM
-btagMfirst = bTagweightM
+#btagLL    = bTagweightL
+#btagMM    = bTagweightM
+#nobtagMM  = bTagweightM
+#btagL     = bTagweightL
+#btagM     = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_MuTau_Legacy2016.cfg
+++ b/config/selectionCfg_MuTau_Legacy2016.cfg
@@ -85,19 +85,19 @@ DYclass     = VBFloose, mpp_dy_v5
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline       = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+baseline       = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
 #baseline       = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
 #baseline      = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
 #baselineHTT   = MC_weight, PUReweight, IdAndIsoSF, trigSF, FakeRateSF
 #baselineHTT_S = MC_weight, PUReweight, IdAndIsoSF, trigSF_single, FakeRateSF
 #baselineHTT_C = MC_weight, PUReweight, IdAndIsoSF, trigSF_cross , FakeRateSF
 
-btagLL   = bTagweightL
-btagMM   = bTagweightM
-nobtagMM = bTagweightM
-btagL    = bTagweightL
-btagM    = bTagweightM
-btagMfirst = bTagweightM
+#btagLL   = bTagweightL
+#btagMM   = bTagweightM
+#nobtagMM = bTagweightM
+#btagL    = bTagweightL
+#btagM    = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################
@@ -113,29 +113,13 @@ btagMfirst = bTagweightM
 
 # define alternative weights to be tested instead of the nominal one
 [systematics]
-IdAndIsoAndFakeSF_deep_pt =  tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up, tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down, tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up, tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down, tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up, tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down, tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up, tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down, tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
-bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
-bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+IdAndIsoAndFakeSF_deep_pt = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up, tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down, tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up, tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down, tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up, tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down, tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up, tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down, tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
 trigSF = trigSFDM0Up:trigSF_DM0_up, trigSFDM0Down:trigSF_DM0_down, trigSFDM1Up:trigSF_DM1_up, trigSFDM1Down:trigSF_DM1_down, trigSFDM10Up:trigSF_DM10_up, trigSFDM10Down:trigSF_DM10_down, trigSFDM11Up:trigSF_DM11_up, trigSFDM11Down:trigSF_DM11_down, trigSFmuUp:trigSF_mu_up, trigSFmuDown:trigSF_mu_down
 PUjetID_SF = PUjetIDSFUp:PUjetID_SF_up, PUjetIDSFDown:PUjetID_SF_down
-
-#TTtopPtreweight      = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
-#trigSF_DM0           = trigSFDM0Up:trigSF_DM0_up , trigSFDM0Down:trigSF_DM0_down
-#trigSF_DM1           = trigSFDM1Up:trigSF_DM1_up , trigSFDM1Down:trigSF_DM1_down
-#trigSF_DM10          = trigSFDM10Up:trigSF_DM10_up , trigSFDM10Down:trigSF_DM10_down
-#trigSF_DM11          = trigSFDM11Up:trigSF_DM11_up , trigSFDM11Down:trigSF_DM11_down
-#tauid_pt20to25       = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up   , tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down
-#tauid_pt25to30       = tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up   , tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down
-#tauid_pt30to35       = tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up   , tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down
-#tauid_pt35to40       = tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up   , tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down
-#tauid_pt40toInf      = tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up , tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down
-#mutauFR_etaLt0p4     = mutauFR_etaLt0p4Up:idAndIsoAndFakeSF_mutauFR_etaLt0p4_up       , mutauFR_etaLt0p4Down:idAndIsoAndFakeSF_mutauFR_etaLt0p4_down
-#mutauFR_eta0p4to0p8  = mutauFR_eta0p4to0p8Up:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_up , mutauFR_eta0p4to0p8Down:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_dowm
-#mutauFR_eta0p8to1p2  = mutauFR_eta0p8to1p2Up:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_up , mutauFR_eta0p8to1p2Down:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_dowm
-#mutauFR_eta1p2to1p7  = mutauFR_eta1p2to1p7Up:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_up , mutauFR_eta1p2to1p7Down:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_dowm
-#mutauFR_etaGt1p7     = mutauFR_etaGt1p7Up:idAndIsoAndFakeSF_mutauFR_etaGt1p7_up       , mutauFR_etaGt1p7Down:idAndIsoAndFakeSF_mutauFR_etaGt1p7_down
-#etauFR_barrel        = etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up , etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down
-#etauFR_endcap        = etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up , etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
+#bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
+#bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+#TTtopPtreweight = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
+#bTagweightReshape = bTagweightReshapeJESUp:bTagweightReshape_jes_up, bTagweightReshapeLFUp:bTagweightReshape_lf_up, bTagweightReshapeHFUp:bTagweightReshape_hf_up, bTagweightReshapeHFSTATS1Up:bTagweightReshape_hfstats1_up, bTagweightReshapeHFSTATS2Up:bTagweightReshape_hfstats2_up, bTagweightReshapeLFSTATS1Up:bTagweightReshape_lfstats1_up, bTagweightReshapeLFSTATS2Up:bTagweightReshape_lfstats2_up, bTagweightReshapeCFERR1Up:bTagweightReshape_cferr1_up, bTagweightReshapeCFERR2Up:bTagweightReshape_cferr2_up, bTagweightReshapeJESDown:bTagweightReshape_jes_down, bTagweightReshapeLFDown:bTagweightReshape_lf_down, bTagweightReshapeHFDown:bTagweightReshape_hf_down, bTagweightReshapeHFSTATS1Down:bTagweightReshape_hfstats1_down, bTagweightReshapeHFSTATS2Down:bTagweightReshape_hfstats2_down, bTagweightReshapeLFSTATS1Down:bTagweightReshape_lfstats1_down, bTagweightReshapeLFSTATS2Down:bTagweightReshape_lfstats2_down, bTagweightReshapeCFERR1Down:bTagweightReshape_cferr1_down, bTagweightReshapeCFERR2Down:bTagweightReshape_cferr2_down
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_MuTau_Legacy2016_syst.cfg
+++ b/config/selectionCfg_MuTau_Legacy2016_syst.cfg
@@ -888,15 +888,15 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v2_jesDown_11
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
 
 # remove DY weights, they are already taken into account in baseline weights
-btagLL    = bTagweightL
-btagMM    = bTagweightM
-nobtagMM  = bTagweightM
-btagL     = bTagweightL
-btagM     = bTagweightM
-btagMfirst = bTagweightM
+#btagLL    = bTagweightL
+#btagMM    = bTagweightM
+#nobtagMM  = bTagweightM
+#btagL     = bTagweightL
+#btagM     = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_MuTau_Legacy2017.cfg
+++ b/config/selectionCfg_MuTau_Legacy2017.cfg
@@ -129,15 +129,15 @@ DYregHTT_MTcutTight_invMETCut_minHmass_cross  = baselineHTT_cross , nobtagM, MTc
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF
+baseline = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF, bTagweightReshape
 #baseline = MC_weight, PUReweight, L1pref_weight, trigSF, FakeRateSF_deep, DYscale_MTT, prescaleWeight, PUjetID_SF
 
-btagLL   = bTagweightL
-btagMM   = bTagweightM
-nobtagMM = bTagweightM
-btagL    = bTagweightL
-btagM    = bTagweightM
-btagMfirst = bTagweightM
+#btagLL   = bTagweightL
+#btagMM   = bTagweightM
+#nobtagMM = bTagweightM
+#btagL    = bTagweightL
+#btagM    = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################
@@ -152,29 +152,13 @@ btagMfirst = bTagweightM
 
 # define alternative weights to be tested instead of the nominal one
 [systematics]
-IdAndIsoAndFakeSF_deep_pt =  tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up, tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down, tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up, tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down, tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up, tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down, tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up, tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down, tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
-bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
-bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+IdAndIsoAndFakeSF_deep_pt = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up, tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down, tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up, tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down, tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up, tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down, tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up, tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down, tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
 trigSF = trigSFDM0Up:trigSF_DM0_up, trigSFDM0Down:trigSF_DM0_down, trigSFDM1Up:trigSF_DM1_up, trigSFDM1Down:trigSF_DM1_down, trigSFDM10Up:trigSF_DM10_up, trigSFDM10Down:trigSF_DM10_down, trigSFDM11Up:trigSF_DM11_up, trigSFDM11Down:trigSF_DM11_down, trigSFmuUp:trigSF_mu_up, trigSFmuDown:trigSF_mu_down
 PUjetID_SF = PUjetIDSFUp:PUjetID_SF_up, PUjetIDSFDown:PUjetID_SF_down
-
-#TTtopPtreweight      = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
-#trigSF_DM0           = trigSFDM0Up:trigSF_DM0_up , trigSFDM0Down:trigSF_DM0_down
-#trigSF_DM1           = trigSFDM1Up:trigSF_DM1_up , trigSFDM1Down:trigSF_DM1_down
-#trigSF_DM10          = trigSFDM10Up:trigSF_DM10_up , trigSFDM10Down:trigSF_DM10_down
-#trigSF_DM11          = trigSFDM11Up:trigSF_DM11_up , trigSFDM11Down:trigSF_DM11_down
-#tauid_pt20to25       = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up   , tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down
-#tauid_pt25to30       = tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up   , tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down
-#tauid_pt30to35       = tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up   , tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down
-#tauid_pt35to40       = tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up   , tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down
-#tauid_pt40toInf      = tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up , tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down
-#mutauFR_etaLt0p4     = mutauFR_etaLt0p4Up:idAndIsoAndFakeSF_mutauFR_etaLt0p4_up       , mutauFR_etaLt0p4Down:idAndIsoAndFakeSF_mutauFR_etaLt0p4_down
-#mutauFR_eta0p4to0p8  = mutauFR_eta0p4to0p8Up:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_up , mutauFR_eta0p4to0p8Down:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_dowm
-#mutauFR_eta0p8to1p2  = mutauFR_eta0p8to1p2Up:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_up , mutauFR_eta0p8to1p2Down:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_dowm
-#mutauFR_eta1p2to1p7  = mutauFR_eta1p2to1p7Up:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_up , mutauFR_eta1p2to1p7Down:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_dowm
-#mutauFR_etaGt1p7     = mutauFR_etaGt1p7Up:idAndIsoAndFakeSF_mutauFR_etaGt1p7_up       , mutauFR_etaGt1p7Down:idAndIsoAndFakeSF_mutauFR_etaGt1p7_down
-#etauFR_barrel        = etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up , etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down
-#etauFR_endcap        = etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up , etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
+#bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
+#bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+#TTtopPtreweight = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
+#bTagweightReshape = bTagweightReshapeJESUp:bTagweightReshape_jes_up, bTagweightReshapeLFUp:bTagweightReshape_lf_up, bTagweightReshapeHFUp:bTagweightReshape_hf_up, bTagweightReshapeHFSTATS1Up:bTagweightReshape_hfstats1_up, bTagweightReshapeHFSTATS2Up:bTagweightReshape_hfstats2_up, bTagweightReshapeLFSTATS1Up:bTagweightReshape_lfstats1_up, bTagweightReshapeLFSTATS2Up:bTagweightReshape_lfstats2_up, bTagweightReshapeCFERR1Up:bTagweightReshape_cferr1_up, bTagweightReshapeCFERR2Up:bTagweightReshape_cferr2_up, bTagweightReshapeJESDown:bTagweightReshape_jes_down, bTagweightReshapeLFDown:bTagweightReshape_lf_down, bTagweightReshapeHFDown:bTagweightReshape_hf_down, bTagweightReshapeHFSTATS1Down:bTagweightReshape_hfstats1_down, bTagweightReshapeHFSTATS2Down:bTagweightReshape_hfstats2_down, bTagweightReshapeLFSTATS1Down:bTagweightReshape_lfstats1_down, bTagweightReshapeLFSTATS2Down:bTagweightReshape_lfstats2_down, bTagweightReshapeCFERR1Down:bTagweightReshape_cferr1_down, bTagweightReshapeCFERR2Down:bTagweightReshape_cferr2_down
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_MuTau_Legacy2017_syst.cfg
+++ b/config/selectionCfg_MuTau_Legacy2017_syst.cfg
@@ -886,15 +886,15 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v2_jesDown_11
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
 
 # remove DY weights, they are already taken into account in baseline weights
-btagLL    = bTagweightL
-btagMM    = bTagweightM
-nobtagMM  = bTagweightM
-btagL     = bTagweightL
-btagM     = bTagweightM
-btagMfirst = bTagweightM
+#btagLL    = bTagweightL
+#btagMM    = bTagweightM
+#nobtagMM  = bTagweightM
+#btagL     = bTagweightL
+#btagM     = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_MuTau_Legacy2018.cfg
+++ b/config/selectionCfg_MuTau_Legacy2018.cfg
@@ -88,18 +88,18 @@ DYclass     = VBFloose, mpp_dy_v5
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline      = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF
-baselineHTT   = MC_weight, PUReweight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
-baselineHTT_S = MC_weight, PUReweight, IdAndIsoSF, trigSF_single, FakeRateSF
-baselineHTT_C = MC_weight, PUReweight, IdAndIsoSF, trigSF_cross , FakeRateSF, DYscale_MTT
+baseline      = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF, bTagweightReshape
+baselineHTT   = MC_weight, PUReweight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT, bTagweightReshape
+baselineHTT_S = MC_weight, PUReweight, IdAndIsoSF, trigSF_single, FakeRateSF, bTagweightReshape
+baselineHTT_C = MC_weight, PUReweight, IdAndIsoSF, trigSF_cross , FakeRateSF, DYscale_MTT, bTagweightReshape
 
 # remove DY weights, they are already taken into account in baseline weights
-btagLL   = bTagweightL
-btagMM   = bTagweightM
-nobtagMM = bTagweightM
-btagL    = bTagweightL
-btagM    = bTagweightM
-btagMfirst = bTagweightM
+#btagLL   = bTagweightL
+#btagMM   = bTagweightM
+#nobtagMM = bTagweightM
+#btagL    = bTagweightL
+#btagM    = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################
@@ -116,29 +116,13 @@ btagMfirst = bTagweightM
 
 # define alternative weights to be tested instead of the nominal one
 [systematics]
-IdAndIsoAndFakeSF_deep_pt =  tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up, tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down, tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up, tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down, tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up, tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down, tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up, tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down, tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
-bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
-bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+IdAndIsoAndFakeSF_deep_pt = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up, tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down, tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up, tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down, tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up, tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down, tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up, tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down, tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
 trigSF = trigSFDM0Up:trigSF_DM0_up, trigSFDM0Down:trigSF_DM0_down, trigSFDM1Up:trigSF_DM1_up, trigSFDM1Down:trigSF_DM1_down, trigSFDM10Up:trigSF_DM10_up, trigSFDM10Down:trigSF_DM10_down, trigSFDM11Up:trigSF_DM11_up, trigSFDM11Down:trigSF_DM11_down, trigSFmuUp:trigSF_mu_up, trigSFmuDown:trigSF_mu_down
 PUjetID_SF = PUjetIDSFUp:PUjetID_SF_up, PUjetIDSFDown:PUjetID_SF_down
-
-#TTtopPtreweight      = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
-#trigSF_DM0           = trigSFDM0Up:trigSF_DM0_up , trigSFDM0Down:trigSF_DM0_down
-#trigSF_DM1           = trigSFDM1Up:trigSF_DM1_up , trigSFDM1Down:trigSF_DM1_down
-#trigSF_DM10          = trigSFDM10Up:trigSF_DM10_up , trigSFDM10Down:trigSF_DM10_down
-#trigSF_DM11          = trigSFDM11Up:trigSF_DM11_up , trigSFDM11Down:trigSF_DM11_down
-#tauid_pt20to25       = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up   , tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down
-#tauid_pt25to30       = tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up   , tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down
-#tauid_pt30to35       = tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up   , tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down
-#tauid_pt35to40       = tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up   , tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down
-#tauid_pt40toInf      = tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up , tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down
-#mutauFR_etaLt0p4     = mutauFR_etaLt0p4Up:idAndIsoAndFakeSF_mutauFR_etaLt0p4_up       , mutauFR_etaLt0p4Down:idAndIsoAndFakeSF_mutauFR_etaLt0p4_down
-#mutauFR_eta0p4to0p8  = mutauFR_eta0p4to0p8Up:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_up , mutauFR_eta0p4to0p8Down:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_dowm
-#mutauFR_eta0p8to1p2  = mutauFR_eta0p8to1p2Up:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_up , mutauFR_eta0p8to1p2Down:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_dowm
-#mutauFR_eta1p2to1p7  = mutauFR_eta1p2to1p7Up:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_up , mutauFR_eta1p2to1p7Down:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_dowm
-#mutauFR_etaGt1p7     = mutauFR_etaGt1p7Up:idAndIsoAndFakeSF_mutauFR_etaGt1p7_up       , mutauFR_etaGt1p7Down:idAndIsoAndFakeSF_mutauFR_etaGt1p7_down
-#etauFR_barrel        = etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up , etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down
-#etauFR_endcap        = etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up , etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
+#bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
+#bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+#TTtopPtreweight = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
+#bTagweightReshape = bTagweightReshapeJESUp:bTagweightReshape_jes_up, bTagweightReshapeLFUp:bTagweightReshape_lf_up, bTagweightReshapeHFUp:bTagweightReshape_hf_up, bTagweightReshapeHFSTATS1Up:bTagweightReshape_hfstats1_up, bTagweightReshapeHFSTATS2Up:bTagweightReshape_hfstats2_up, bTagweightReshapeLFSTATS1Up:bTagweightReshape_lfstats1_up, bTagweightReshapeLFSTATS2Up:bTagweightReshape_lfstats2_up, bTagweightReshapeCFERR1Up:bTagweightReshape_cferr1_up, bTagweightReshapeCFERR2Up:bTagweightReshape_cferr2_up, bTagweightReshapeJESDown:bTagweightReshape_jes_down, bTagweightReshapeLFDown:bTagweightReshape_lf_down, bTagweightReshapeHFDown:bTagweightReshape_hf_down, bTagweightReshapeHFSTATS1Down:bTagweightReshape_hfstats1_down, bTagweightReshapeHFSTATS2Down:bTagweightReshape_hfstats2_down, bTagweightReshapeLFSTATS1Down:bTagweightReshape_lfstats1_down, bTagweightReshapeLFSTATS2Down:bTagweightReshape_lfstats2_down, bTagweightReshapeCFERR1Down:bTagweightReshape_cferr1_down, bTagweightReshapeCFERR2Down:bTagweightReshape_cferr2_down
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_MuTau_Legacy2018_syst.cfg
+++ b/config/selectionCfg_MuTau_Legacy2018_syst.cfg
@@ -884,15 +884,15 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v2_jesDown_11
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
 
 # remove DY weights, they are already taken into account in baseline weights
-btagLL    = bTagweightL
-btagMM    = bTagweightM
-nobtagMM  = bTagweightM
-btagL     = bTagweightL
-btagM     = bTagweightM
-btagMfirst = bTagweightM
+#btagLL    = bTagweightL
+#btagMM    = bTagweightM
+#nobtagMM  = bTagweightM
+#btagL     = bTagweightL
+#btagM     = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_TauTau_Legacy2016.cfg
+++ b/config/selectionCfg_TauTau_Legacy2016.cfg
@@ -79,18 +79,18 @@ DYclass     = VBFloose, mpp_dy_v5
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline          = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+baseline          = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
 #baseline          = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
 #baselineHTauTau   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep
 #baselineVBFtight  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep, VBFtrigNorm, VBFtrigSFjet, VBFtrigSFtau
 
 # remove DY weights, they are already taken into account in baseline weights
-btagLL   = bTagweightL
-btagMM   = bTagweightM
-nobtagMM = bTagweightM
-btagL    = bTagweightL
-btagM    = bTagweightM
-btagMfirst    = bTagweightM
+#btagLL   = bTagweightL
+#btagMM   = bTagweightM
+#nobtagMM = bTagweightM
+#btagL    = bTagweightL
+#btagM    = bTagweightM
+#btagMfirst    = bTagweightM
 
 [selectionWeights_ext] # beta feature! use with care!
 #weights decay mode dependent computed with QCD backgrond estimation, DY LO weights, old DY weights, on top of decay mode dependend trigger weights, m_vis > 55 #11 Mar 2019 #used for testing, already saved in the skims
@@ -137,28 +137,12 @@ btagMfirst    = bTagweightM
 # define alternative weights to be tested instead of the nominal one
 [systematics]
 IdAndIsoAndFakeSF_deep_pt = tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
-bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
-bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
 trigSF = trigSFDM0Up:trigSF_DM0_up, trigSFDM0Down:trigSF_DM0_down, trigSFDM1Up:trigSF_DM1_up, trigSFDM1Down:trigSF_DM1_down, trigSFDM10Up:trigSF_DM10_up, trigSFDM10Down:trigSF_DM10_down, trigSFDM11Up:trigSF_DM11_up, trigSFDM11Down:trigSF_DM11_down
 PUjetID_SF = PUjetIDSFUp:PUjetID_SF_up, PUjetIDSFDown:PUjetID_SF_down
-
-#TTtopPtreweight      = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
-#trigSF_DM0           = trigSFDM0Up:trigSF_DM0_up , trigSFDM0Down:trigSF_DM0_down
-#trigSF_DM1           = trigSFDM1Up:trigSF_DM1_up , trigSFDM1Down:trigSF_DM1_down
-#trigSF_DM10          = trigSFDM10Up:trigSF_DM10_up , trigSFDM10Down:trigSF_DM10_down
-#trigSF_DM11          = trigSFDM11Up:trigSF_DM11_up , trigSFDM11Down:trigSF_DM11_down
-#tauid_pt20to25       = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up   , tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down
-#tauid_pt25to30       = tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up   , tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down
-#tauid_pt30to35       = tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up   , tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down
-#tauid_pt35to40       = tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up   , tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down
-#tauid_pt40toInf      = tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up , tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down
-#mutauFR_etaLt0p4     = mutauFR_etaLt0p4Up:idAndIsoAndFakeSF_mutauFR_etaLt0p4_up       , mutauFR_etaLt0p4Down:idAndIsoAndFakeSF_mutauFR_etaLt0p4_down
-#mutauFR_eta0p4to0p8  = mutauFR_eta0p4to0p8Up:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_up , mutauFR_eta0p4to0p8Down:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_dowm
-#mutauFR_eta0p8to1p2  = mutauFR_eta0p8to1p2Up:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_up , mutauFR_eta0p8to1p2Down:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_dowm
-#mutauFR_eta1p2to1p7  = mutauFR_eta1p2to1p7Up:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_up , mutauFR_eta1p2to1p7Down:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_dowm
-#mutauFR_etaGt1p7     = mutauFR_etaGt1p7Up:idAndIsoAndFakeSF_mutauFR_etaGt1p7_up       , mutauFR_etaGt1p7Down:idAndIsoAndFakeSF_mutauFR_etaGt1p7_down
-#etauFR_barrel        = etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up , etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down
-#etauFR_endcap        = etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up , etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
+#bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
+#bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+#TTtopPtreweight = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
+#bTagweightReshape = bTagweightReshapeJESUp:bTagweightReshape_jes_up, bTagweightReshapeLFUp:bTagweightReshape_lf_up, bTagweightReshapeHFUp:bTagweightReshape_hf_up, bTagweightReshapeHFSTATS1Up:bTagweightReshape_hfstats1_up, bTagweightReshapeHFSTATS2Up:bTagweightReshape_hfstats2_up, bTagweightReshapeLFSTATS1Up:bTagweightReshape_lfstats1_up, bTagweightReshapeLFSTATS2Up:bTagweightReshape_lfstats2_up, bTagweightReshapeCFERR1Up:bTagweightReshape_cferr1_up, bTagweightReshapeCFERR2Up:bTagweightReshape_cferr2_up, bTagweightReshapeJESDown:bTagweightReshape_jes_down, bTagweightReshapeLFDown:bTagweightReshape_lf_down, bTagweightReshapeHFDown:bTagweightReshape_hf_down, bTagweightReshapeHFSTATS1Down:bTagweightReshape_hfstats1_down, bTagweightReshapeHFSTATS2Down:bTagweightReshape_hfstats2_down, bTagweightReshapeLFSTATS1Down:bTagweightReshape_lfstats1_down, bTagweightReshapeLFSTATS2Down:bTagweightReshape_lfstats2_down, bTagweightReshapeCFERR1Down:bTagweightReshape_cferr1_down, bTagweightReshapeCFERR2Down:bTagweightReshape_cferr2_down
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_TauTau_Legacy2016_syst.cfg
+++ b/config/selectionCfg_TauTau_Legacy2016_syst.cfg
@@ -886,15 +886,15 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v2_jesDown_11
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
 
 # remove DY weights, they are already taken into account in baseline weights
-btagLL    = bTagweightL
-btagMM    = bTagweightM
-nobtagMM  = bTagweightM
-btagL     = bTagweightL
-btagM     = bTagweightM
-btagMfirst = bTagweightM
+#btagLL    = bTagweightL
+#btagMM    = bTagweightM
+#nobtagMM  = bTagweightM
+#btagL     = bTagweightL
+#btagM     = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_TauTau_Legacy2017.cfg
+++ b/config/selectionCfg_TauTau_Legacy2017.cfg
@@ -88,17 +88,17 @@ DYclass     = VBFloose, mpp_dy_v5
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline         = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF, customTauIdSF
-baselineHTauTau  = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF, customTauIdSF
-baselineVBFtight = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF, customTauIdSF
+baseline         = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF, customTauIdSF, bTagweightReshape
+baselineHTauTau  = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF, customTauIdSF, bTagweightReshape
+baselineVBFtight = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF, customTauIdSF, bTagweightReshape
 
 # remove DY weights, they are already taken into account in baseline weights
-btagLL   = bTagweightL
-btagMM   = bTagweightM
-nobtagMM = bTagweightM
-btagL    = bTagweightL
-btagM    = bTagweightM
-btagMfirst    = bTagweightM
+#btagLL   = bTagweightL
+#btagMM   = bTagweightM
+#nobtagMM = bTagweightM
+#btagL    = bTagweightL
+#btagM    = bTagweightM
+#btagMfirst    = bTagweightM
 
 [selectionWeights_ext] # beta feature! use with care!
 #weights decay mode dependent computed for 2017 Legacy computed on top of pt dep SF
@@ -122,29 +122,13 @@ btagMfirst    = bTagweightM
 # define alternative weights to be tested instead of the nominal one
 [systematics]
 IdAndIsoAndFakeSF_deep_pt = tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
-bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
-bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
-trigSF = trigSFDM0Up:trigSF_DM0_up, trigSFDM0Down:trigSF_DM0_down, trigSFDM1Up:trigSF_DM1_up, trigSFDM1Down:trigSF_DM1_down, trigSFDM10Up:trigSF_DM10_up, trigSFDM10Down:trigSF_DM10_down, trigSFDM11Up:trigSF_DM11_up, trigSFDM11Down:trigSF_DM11_down
+trigSF = trigSFDM0Up:trigSF_DM0_up, trigSFDM0Down:trigSF_DM0_down, trigSFDM1Up:trigSF_DM1_up, trigSFDM1Down:trigSF_DM1_down, trigSFDM10Up:trigSF_DM10_up, trigSFDM10Down:trigSF_DM10_down, trigSFDM11Up:trigSF_DM11_up, trigSFDM11Down:trigSF_DM11_down, trigSFJetUp:trigSF_vbfjet_up, trigSFJetDown:trigSF_vbfjet_down
 customTauIdSF = customTauIdSFDM0Up:customTauIdSF_DM0_up, customTauIdSFDM0Down:customTauIdSF_DM0_down, customTauIdSFDM1UpDown:customTauIdSF_DM1_up, customTauIdSFDM1Down:customTauIdSF_DM1_down, customTauIdSFDM10UpDown:customTauIdSF_DM10_up, customTauIdSFDM10Down:customTauIdSF_DM10_down, customTauIdSFDM11UpDown:customTauIdSF_DM11_up, customTauIdSFDM11Down:customTauIdSF_DM11_down
 PUjetID_SF = PUjetIDSFUp:PUjetID_SF_up, PUjetIDSFDown:PUjetID_SF_down
-
-#TTtopPtreweight      = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
-#trigSF_DM0           = trigSFDM0Up:trigSF_DM0_up , trigSFDM0Down:trigSF_DM0_down
-#trigSF_DM1           = trigSFDM1Up:trigSF_DM1_up , trigSFDM1Down:trigSF_DM1_down
-#trigSF_DM10          = trigSFDM10Up:trigSF_DM10_up , trigSFDM10Down:trigSF_DM10_down
-#trigSF_DM11          = trigSFDM11Up:trigSF_DM11_up , trigSFDM11Down:trigSF_DM11_down
-#tauid_pt20to25       = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up   , tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down
-#tauid_pt25to30       = tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up   , tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down
-#tauid_pt30to35       = tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up   , tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down
-#tauid_pt35to40       = tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up   , tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down
-#tauid_pt40toInf      = tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up , tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down
-#mutauFR_etaLt0p4     = mutauFR_etaLt0p4Up:idAndIsoAndFakeSF_mutauFR_etaLt0p4_up       , mutauFR_etaLt0p4Down:idAndIsoAndFakeSF_mutauFR_etaLt0p4_down
-#mutauFR_eta0p4to0p8  = mutauFR_eta0p4to0p8Up:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_up , mutauFR_eta0p4to0p8Down:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_dowm
-#mutauFR_eta0p8to1p2  = mutauFR_eta0p8to1p2Up:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_up , mutauFR_eta0p8to1p2Down:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_dowm
-#mutauFR_eta1p2to1p7  = mutauFR_eta1p2to1p7Up:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_up , mutauFR_eta1p2to1p7Down:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_dowm
-#mutauFR_etaGt1p7     = mutauFR_etaGt1p7Up:idAndIsoAndFakeSF_mutauFR_etaGt1p7_up       , mutauFR_etaGt1p7Down:idAndIsoAndFakeSF_mutauFR_etaGt1p7_down
-#etauFR_barrel        = etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up , etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down
-#etauFR_endcap        = etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up , etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
+#bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
+#bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+#TTtopPtreweight = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
+#bTagweightReshape = bTagweightReshapeJESUp:bTagweightReshape_jes_up, bTagweightReshapeLFUp:bTagweightReshape_lf_up, bTagweightReshapeHFUp:bTagweightReshape_hf_up, bTagweightReshapeHFSTATS1Up:bTagweightReshape_hfstats1_up, bTagweightReshapeHFSTATS2Up:bTagweightReshape_hfstats2_up, bTagweightReshapeLFSTATS1Up:bTagweightReshape_lfstats1_up, bTagweightReshapeLFSTATS2Up:bTagweightReshape_lfstats2_up, bTagweightReshapeCFERR1Up:bTagweightReshape_cferr1_up, bTagweightReshapeCFERR2Up:bTagweightReshape_cferr2_up, bTagweightReshapeJESDown:bTagweightReshape_jes_down, bTagweightReshapeLFDown:bTagweightReshape_lf_down, bTagweightReshapeHFDown:bTagweightReshape_hf_down, bTagweightReshapeHFSTATS1Down:bTagweightReshape_hfstats1_down, bTagweightReshapeHFSTATS2Down:bTagweightReshape_hfstats2_down, bTagweightReshapeLFSTATS1Down:bTagweightReshape_lfstats1_down, bTagweightReshapeLFSTATS2Down:bTagweightReshape_lfstats2_down, bTagweightReshapeCFERR1Down:bTagweightReshape_cferr1_down, bTagweightReshapeCFERR2Down:bTagweightReshape_cferr2_down
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_TauTau_Legacy2017_syst.cfg
+++ b/config/selectionCfg_TauTau_Legacy2017_syst.cfg
@@ -886,15 +886,15 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v2_jesDown_11
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF
+baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
 
 # remove DY weights, they are already taken into account in baseline weights
-btagLL    = bTagweightL
-btagMM    = bTagweightM
-nobtagMM  = bTagweightM
-btagL     = bTagweightL
-btagM     = bTagweightM
-btagMfirst = bTagweightM
+#btagLL    = bTagweightL
+#btagMM    = bTagweightM
+#nobtagMM  = bTagweightM
+#btagL     = bTagweightL
+#btagM     = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_TauTau_Legacy2018.cfg
+++ b/config/selectionCfg_TauTau_Legacy2018.cfg
@@ -90,18 +90,18 @@ DYclass     = VBFloose, mpp_dy_v5
 #baselineVBFtight  = MC_weight, PUReweight, VBFtrigSF, DYscale_MTT, FakeRateSF_deep
 
 # WEIGHTS WHEN USING THE tauPOG SUGGESTIONS -> it can create some trouble
-baseline         = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF
-baselineHTauTau  = MC_weight, PUReweight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT
-baselineVBFtight = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF
+baseline         = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF, bTagweightReshape
+baselineHTauTau  = MC_weight, PUReweight, trigSF, IdAndIsoAndFakeSF_deep, DYscale_MTT, bTagweightReshape
+baselineVBFtight = MC_weight, PUReweight, L1pref_weight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, prescaleWeight, PUjetID_SF, bTagweightReshape
 
 
 # remove DY weights, they are already taken into account in baseline weights
-btagLL   = bTagweightL
-btagMM   = bTagweightM
-nobtagMM = bTagweightM
-btagL    = bTagweightL
-btagM    = bTagweightM
-btagMfirst    = bTagweightM
+#btagLL   = bTagweightL
+#btagMM   = bTagweightM
+#nobtagMM = bTagweightM
+#btagL    = bTagweightL
+#btagM    = bTagweightM
+#btagMfirst    = bTagweightM
 
 [selectionWeights_ext] # beta feature! use with care!
 #weights decay mode dependent computed with QCD backgrond estimation, DY LO weights, old DY weights, on top of decay mode dependend trigger weights, m_vis > 55 #11 Mar 2019 #used for testing, already saved in the skims
@@ -148,28 +148,12 @@ btagMfirst    = bTagweightM
 # define alternative weights to be tested instead of the nominal one
 [systematics]
 IdAndIsoAndFakeSF_deep_pt = tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up, tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down, etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up, etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down, etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up, etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
-bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
-bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
-trigSF = trigSFDM0Up:trigSF_DM0_up, trigSFDM0Down:trigSF_DM0_down, trigSFDM1Up:trigSF_DM1_up, trigSFDM1Down:trigSF_DM1_down, trigSFDM10Up:trigSF_DM10_up, trigSFDM10Down:trigSF_DM10_down, trigSFDM11Up:trigSF_DM11_up, trigSFDM11Down:trigSF_DM11_down
+trigSF = trigSFDM0Up:trigSF_DM0_up, trigSFDM0Down:trigSF_DM0_down, trigSFDM1Up:trigSF_DM1_up, trigSFDM1Down:trigSF_DM1_down, trigSFDM10Up:trigSF_DM10_up, trigSFDM10Down:trigSF_DM10_down, trigSFDM11Up:trigSF_DM11_up, trigSFDM11Down:trigSF_DM11_down, trigSFJetUp:trigSF_vbfjet_up, trigSFJetDown:trigSF_vbfjet_down
 PUjetID_SF = PUjetIDSFUp:PUjetID_SF_up, PUjetIDSFDown:PUjetID_SF_down
-
-#TTtopPtreweight      = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
-#trigSF_DM0           = trigSFDM0Up:trigSF_DM0_up , trigSFDM0Down:trigSF_DM0_down
-#trigSF_DM1           = trigSFDM1Up:trigSF_DM1_up , trigSFDM1Down:trigSF_DM1_down
-#trigSF_DM10          = trigSFDM10Up:trigSF_DM10_up , trigSFDM10Down:trigSF_DM10_down
-#trigSF_DM11          = trigSFDM11Up:trigSF_DM11_up , trigSFDM11Down:trigSF_DM11_down
-#tauid_pt20to25       = tauid_pt20to25Up:idAndIsoAndFakeSF_tauid_pt20to25_up   , tauid_pt20to25Down:idAndIsoAndFakeSF_tauid_pt20to25_down
-#tauid_pt25to30       = tauid_pt25to30Up:idAndIsoAndFakeSF_tauid_pt25to30_up   , tauid_pt25to30Down:idAndIsoAndFakeSF_tauid_pt25to30_down
-#tauid_pt30to35       = tauid_pt30to35Up:idAndIsoAndFakeSF_tauid_pt30to35_up   , tauid_pt30to35Down:idAndIsoAndFakeSF_tauid_pt30to35_down
-#tauid_pt35to40       = tauid_pt35to40Up:idAndIsoAndFakeSF_tauid_pt35to40_up   , tauid_pt35to40Down:idAndIsoAndFakeSF_tauid_pt35to40_down
-#tauid_pt40toInf      = tauid_pt40toInfUp:idAndIsoAndFakeSF_tauid_pt40toInf_up , tauid_pt40toInfDown:idAndIsoAndFakeSF_tauid_pt40toInf_down
-#mutauFR_etaLt0p4     = mutauFR_etaLt0p4Up:idAndIsoAndFakeSF_mutauFR_etaLt0p4_up       , mutauFR_etaLt0p4Down:idAndIsoAndFakeSF_mutauFR_etaLt0p4_down
-#mutauFR_eta0p4to0p8  = mutauFR_eta0p4to0p8Up:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_up , mutauFR_eta0p4to0p8Down:idAndIsoAndFakeSF_mutauFR_eta0p4to0p8_dowm
-#mutauFR_eta0p8to1p2  = mutauFR_eta0p8to1p2Up:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_up , mutauFR_eta0p8to1p2Down:idAndIsoAndFakeSF_mutauFR_eta0p8to1p2_dowm
-#mutauFR_eta1p2to1p7  = mutauFR_eta1p2to1p7Up:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_up , mutauFR_eta1p2to1p7Down:idAndIsoAndFakeSF_mutauFR_eta1p2to1p7_dowm
-#mutauFR_etaGt1p7     = mutauFR_etaGt1p7Up:idAndIsoAndFakeSF_mutauFR_etaGt1p7_up       , mutauFR_etaGt1p7Down:idAndIsoAndFakeSF_mutauFR_etaGt1p7_down
-#etauFR_barrel        = etauFR_barrelUp:idAndIsoAndFakeSF_etauFR_barrel_up , etauFR_barrelDown:idAndIsoAndFakeSF_etauFR_barrel_down
-#etauFR_endcap        = etauFR_endcapUp:idAndIsoAndFakeSF_etauFR_endcap_up , etauFR_endcapDown:idAndIsoAndFakeSF_etauFR_endcap_down
+#bTagweightM = bTagSFMUp:bTagweightM_up, bTagSFMDown:bTagweightM_down
+#bTagweightL = bTagSFLUp:bTagweightL_up, bTagSFLDown:bTagweightL_down
+#TTtopPtreweight = topUp:TTtopPtreweight_up , topDown:TTtopPtreweight_down
+#bTagweightReshape = bTagweightReshapeJESUp:bTagweightReshape_jes_up, bTagweightReshapeLFUp:bTagweightReshape_lf_up, bTagweightReshapeHFUp:bTagweightReshape_hf_up, bTagweightReshapeHFSTATS1Up:bTagweightReshape_hfstats1_up, bTagweightReshapeHFSTATS2Up:bTagweightReshape_hfstats2_up, bTagweightReshapeLFSTATS1Up:bTagweightReshape_lfstats1_up, bTagweightReshapeLFSTATS2Up:bTagweightReshape_lfstats2_up, bTagweightReshapeCFERR1Up:bTagweightReshape_cferr1_up, bTagweightReshapeCFERR2Up:bTagweightReshape_cferr2_up, bTagweightReshapeJESDown:bTagweightReshape_jes_down, bTagweightReshapeLFDown:bTagweightReshape_lf_down, bTagweightReshapeHFDown:bTagweightReshape_hf_down, bTagweightReshapeHFSTATS1Down:bTagweightReshape_hfstats1_down, bTagweightReshapeHFSTATS2Down:bTagweightReshape_hfstats2_down, bTagweightReshapeLFSTATS1Down:bTagweightReshape_lfstats1_down, bTagweightReshapeLFSTATS2Down:bTagweightReshape_lfstats2_down, bTagweightReshapeCFERR1Down:bTagweightReshape_cferr1_down, bTagweightReshapeCFERR2Down:bTagweightReshape_cferr2_down
 
 #########################################################################
 #########################################################################

--- a/config/selectionCfg_TauTau_Legacy2018_syst.cfg
+++ b/config/selectionCfg_TauTau_Legacy2018_syst.cfg
@@ -882,15 +882,15 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v2_jesDown_11
 ## multiple weights are passed as list and are multiplied together
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
-baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT
+baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
 
 # remove DY weights, they are already taken into account in baseline weights
-btagLL    = bTagweightL
-btagMM    = bTagweightM
-nobtagMM  = bTagweightM
-btagL     = bTagweightL
-btagM     = bTagweightM
-btagMfirst = bTagweightM
+#btagLL    = bTagweightL
+#btagMM    = bTagweightM
+#nobtagMM  = bTagweightM
+#btagL     = bTagweightL
+#btagM     = bTagweightM
+#btagMfirst = bTagweightM
 
 #########################################################################
 #########################################################################

--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -155,6 +155,7 @@ doDNN      = true
 doBDT      = true
 doMult     = true
 
+doVBFtrig  = true
 doNominal  = false
 doMES      = true
 doEES      = true

--- a/config/skim_Legacy2018.cfg
+++ b/config/skim_Legacy2018.cfg
@@ -163,6 +163,7 @@ doDNN      = true
 doBDT      = true
 doMult     = true
 
+doVBFtrig  = true
 doNominal  = false
 doMES      = true
 doEES      = true

--- a/config/skim_Legacy2018_mib.cfg
+++ b/config/skim_Legacy2018_mib.cfg
@@ -158,6 +158,7 @@ doDNN      = true
 doBDT      = true
 doMult     = true
 
+doVBFtrig  = true
 doNominal  = false
 doMES      = true
 doEES      = true

--- a/limits/combine_categories.sh
+++ b/limits/combine_categories.sh
@@ -1,21 +1,15 @@
 var="DNNoutSM_kl_1"
-selections="s1b1jresolvedMcut s2b0jresolvedMcut sboostedLLMcut VBFloose"
+selections="s1b1jresolvedMcut s2b0jresolvedMcut sboostedLLMcut GGFclass VBFclass ttHclass TTlepclass TThadclass DYclass"
 
-#tag="cards_TauTau2016_4Oct2020"
-#tag="cards_MuTau2016_4Oct2020"
-tag="cards_ETau2016_4Oct2020"
-
-#tag="cards_TauTau2017_22Sep2020"
-#tag="cards_MuTau2017_22Sep2020"
-#tag="cards_ETau2017_22Sep2020"
-
-##tag="cards_TauTau2018_22Sep2020"
-##tag="cards_MuTau2018_22Sep2020"
-##tag="cards_ETau2018_22Sep2020"
+#tag="cards_TauTau2016_17Nov2020_noQCD"
+#tag="cards_MuTau2016_17Nov2020_noQCD"
+#tag="cards_ETau2016_17Nov2020_noQCD"
 
 cd $tag
+pwd
 mkdir comb_cat
 rm comb_cat/comb_cat.txt
-combineCards.py -S */comb.txt >> comb_cat/comb.txt
+#combineCards.py -S */comb.txt >> comb_cat/comb.txt
+combineCards.py -S */hh_*.txt >> comb_cat/comb.txt
 text2workspace.py comb_cat/comb.txt -P HHModel:HHdefault -o comb_cat/comb.root
 cd -

--- a/limits/combine_channels.sh
+++ b/limits/combine_channels.sh
@@ -1,10 +1,10 @@
 var="DNNoutSM_kl_1"
-selections="s1b1jresolvedMcut s2b0jresolvedMcut sboostedLLMcut VBFloose"
+selections="s1b1jresolvedMcut s2b0jresolvedMcut sboostedLLMcut GGFclass VBFclass ttHclass TTlepclass TThadclass DYclass"
 channels="TauTau MuTau ETau" 
 
-#tag="2016_4Oct2020"
-tag="2017_4Oct2020"
-#tag="2018_4Oct2020"
+tag="2016_17Nov2020_noQCD"
+#tag="2017_17Nov2020_noQCD"
+#tag="2018_17Nov2020_noQCD"
 
 mkdir cards_CombChan_$tag
 

--- a/limits/make_cards.sh
+++ b/limits/make_cards.sh
@@ -9,32 +9,21 @@ export PYTHONPATH=$PWD/physicsModels:$PYTHONPATH
 # -b : bin-by-bin unc
 # -u : shape unc
 # -t : theory unc
-#python write_card.py -f analyzedOutPlotter_TauTau_prova.root -o prova -c TauTau -y 2018 -b 1 -u 1 -t -i ../analysis_TauTau_synch_11June2020_limits_prova/mainCfg_TauTau_Legacy2018_limits.cfg
+# -q : QCD from rateParam (1, default), QCD from file (0)
+# example:
+#  python write_card.py -f analyzedOutPlotter_TauTau_prova.root -o prova -c TauTau -y 2018 -b 1 -u 1 -t -i ../analysis_TauTau_synch_11June2020_limits_prova/mainCfg_TauTau_Legacy2018_limits.cfg
 
 
-# 10 Sept
-#python write_card.py -f analyzedOutPlotter_2016_TauTau_10Sept_NS_V2.root -o 2016_10Sept_NS_V2 -c TauTau -y 2016 -b 1 -u 1 -t -i ../analysis_TauTau_2016_10Sept2020_limits_V2/mainCfg_TauTau_Legacy2016_limits.cfg
-#python write_card.py -f analyzedOutPlotter_2016_MuTau_10Sept_NS_V2.root  -o 2016_10Sept_NS_V2 -c MuTau  -y 2016 -b 1 -u 1 -t -i ../analysis_MuTau_2016_10Sept2020_limits_V2/mainCfg_MuTau_Legacy2016_limits.cfg
-#python write_card.py -f analyzedOutPlotter_2016_ETau_10Sept_NS_V2.root   -o 2016_10Sept_NS_V2 -c ETau   -y 2016 -b 1 -u 1 -t -i ../analysis_ETau_2016_10Sept2020_limits_V2/mainCfg_ETau_Legacy2016_limits.cfg
+# 17 November 2020
+#python write_card.py -f analyzedOutPlotter_2016_TauTau_17Nov2020.root -o 2016_17Nov2020_noQCD -c TauTau -y 2016 -b 1 -u 1 -t -q 0 -i ../analysis_TauTau_2016_17Nov2020_limits/mainCfg_TauTau_Legacy2016_limits.cfg
+#python write_card.py -f analyzedOutPlotter_2016_MuTau_17Nov2020.root  -o 2016_17Nov2020_noQCD -c MuTau  -y 2016 -b 1 -u 1 -t -q 0 -i ../analysis_MuTau_2016_17Nov2020_limits/mainCfg_MuTau_Legacy2016_limits.cfg
+#python write_card.py -f analyzedOutPlotter_2016_ETau_17Nov2020.root   -o 2016_17Nov2020_noQCD -c ETau   -y 2016 -b 1 -u 1 -t -q 0 -i ../analysis_ETau_2016_17Nov2020_limits/mainCfg_ETau_Legacy2016_limits.cfg
+#
+#python write_card.py -f analyzedOutPlotter_2017_TauTau_22Sep2020.root -o 2017_22Sep2020 -c TauTau -y 2017 -b 1 -u 1 -t -i ../analysis_TauTau_2017_22Sep2020_limits/mainCfg_TauTau_Legacy2017_limits.cfg
+#python write_card.py -f analyzedOutPlotter_2017_MuTau_22Sep2020.root  -o 2017_22Sep2020 -c MuTau  -y 2017 -b 1 -u 1 -t -i ../analysis_MuTau_2017_22Sep2020_limits/mainCfg_MuTau_Legacy2017_limits.cfg
+#python write_card.py -f analyzedOutPlotter_2017_ETau_22Sep2020.root   -o 2017_22Sep2020 -c ETau   -y 2017 -b 1 -u 1 -t -i ../analysis_ETau_2017_22Sep2020_limits/mainCfg_ETau_Legacy2017_limits.cfg
+#
+#python write_card.py -f analyzedOutPlotter_2018_TauTau_22Sep2020.root -o 2018_22Sep2020 -c TauTau -y 2018 -b 1 -u 1 -t -i ../analysis_TauTau_2018_22Sep2020_limits/mainCfg_TauTau_Legacy2018_limits.cfg
+#python write_card.py -f analyzedOutPlotter_2018_MuTau_22Sep2020.root  -o 2018_22Sep2020 -c MuTau  -y 2018 -b 1 -u 1 -t -i ../analysis_MuTau_2018_22Sep2020_limits/mainCfg_MuTau_Legacy2018_limits.cfg
+#python write_card.py -f analyzedOutPlotter_2018_ETau_22Sep2020.root   -o 2018_22Sep2020 -c ETau   -y 2018 -b 1 -u 1 -t -i ../analysis_ETau_2018_22Sep2020_limits/mainCfg_ETau_Legacy2018_limits.cfg
 
-#python write_card.py -f analyzedOutPlotter_2017_TauTau_10Sept_NS_V2.root -o 2017_10Sept_NS_V2 -c TauTau -y 2017 -b 1 -u 1 -t -i ../analysis_TauTau_2017_10Sept2020_limits_V2/mainCfg_TauTau_Legacy2017_limits.cfg
-#python write_card.py -f analyzedOutPlotter_2017_MuTau_10Sept_NS_V2.root  -o 2017_10Sept_NS_V2 -c MuTau  -y 2017 -b 1 -u 1 -t -i ../analysis_MuTau_2017_10Sept2020_limits_V2/mainCfg_MuTau_Legacy2017_limits.cfg
-#python write_card.py -f analyzedOutPlotter_2017_ETau_10Sept_NS_V2.root   -o 2017_10Sept_NS_V2 -c ETau   -y 2017 -b 1 -u 1 -t -i ../analysis_ETau_2017_10Sept2020_limits_V2/mainCfg_ETau_Legacy2017_limits.cfg
-
-#python write_card.py -f analyzedOutPlotter_2018_TauTau_10Sept_NS_V2.root -o 2018_10Sept_NS_V2 -c TauTau -y 2018 -b 1 -u 1 -t -i ../analysis_TauTau_2018_10Sept2020_limits_V2/mainCfg_TauTau_Legacy2018_limits.cfg
-#python write_card.py -f analyzedOutPlotter_2018_MuTau_10Sept_NS_V2.root  -o 2018_10Sept_NS_V2 -c MuTau  -y 2018 -b 1 -u 1 -t -i ../analysis_MuTau_2018_10Sept2020_limits_V2/mainCfg_MuTau_Legacy2018_limits.cfg
-#python write_card.py -f analyzedOutPlotter_2018_ETau_10Sept_NS_V2.root   -o 2018_10Sept_NS_V2 -c ETau   -y 2018 -b 1 -u 1 -t -i ../analysis_ETau_2018_10Sept2020_limits_V2/mainCfg_ETau_Legacy2018_limits.cfg
-
-
-# 20 Sept
-python write_card.py -f analyzedOutPlotter_2016_TauTau_22Sep2020.root -o 2016_22Sep2020 -c TauTau -y 2016 -b 1 -u 1 -t -i ../analysis_TauTau_2016_22Sep2020_limits/mainCfg_TauTau_Legacy2016_limits.cfg
-python write_card.py -f analyzedOutPlotter_2016_MuTau_22Sep2020.root  -o 2016_22Sep2020 -c MuTau  -y 2016 -b 1 -u 1 -t -i ../analysis_MuTau_2016_22Sep2020_limits/mainCfg_MuTau_Legacy2016_limits.cfg
-python write_card.py -f analyzedOutPlotter_2016_ETau_22Sep2020.root   -o 2016_22Sep2020 -c ETau   -y 2016 -b 1 -u 1 -t -i ../analysis_ETau_2016_22Sep2020_limits/mainCfg_ETau_Legacy2016_limits.cfg
-
-python write_card.py -f analyzedOutPlotter_2017_TauTau_22Sep2020.root -o 2017_22Sep2020 -c TauTau -y 2017 -b 1 -u 1 -t -i ../analysis_TauTau_2017_22Sep2020_limits/mainCfg_TauTau_Legacy2017_limits.cfg
-python write_card.py -f analyzedOutPlotter_2017_MuTau_22Sep2020.root  -o 2017_22Sep2020 -c MuTau  -y 2017 -b 1 -u 1 -t -i ../analysis_MuTau_2017_22Sep2020_limits/mainCfg_MuTau_Legacy2017_limits.cfg
-python write_card.py -f analyzedOutPlotter_2017_ETau_22Sep2020.root   -o 2017_22Sep2020 -c ETau   -y 2017 -b 1 -u 1 -t -i ../analysis_ETau_2017_22Sep2020_limits/mainCfg_ETau_Legacy2017_limits.cfg
-
-python write_card.py -f analyzedOutPlotter_2018_TauTau_22Sep2020.root -o 2018_22Sep2020 -c TauTau -y 2018 -b 1 -u 1 -t -i ../analysis_TauTau_2018_22Sep2020_limits/mainCfg_TauTau_Legacy2018_limits.cfg
-python write_card.py -f analyzedOutPlotter_2018_MuTau_22Sep2020.root  -o 2018_22Sep2020 -c MuTau  -y 2018 -b 1 -u 1 -t -i ../analysis_MuTau_2018_22Sep2020_limits/mainCfg_MuTau_Legacy2018_limits.cfg
-python write_card.py -f analyzedOutPlotter_2018_ETau_22Sep2020.root   -o 2018_22Sep2020 -c ETau   -y 2018 -b 1 -u 1 -t -i ../analysis_ETau_2018_22Sep2020_limits/mainCfg_ETau_Legacy2018_limits.cfg

--- a/limits/physicsModels/HHModel.py
+++ b/limits/physicsModels/HHModel.py
@@ -440,9 +440,9 @@ VBF_sample_list = [
 # VBF : val_kl, val_kt
 GGF_sample_list = [
     GGFHHSample(1,1,      val_xs = 0.02675, label = 'ggHH_kl_1_kt_1'  ),
-    GGFHHSample(0,1,      val_xs = 0.06007, label = 'ggHH_kl_0_kt_1'  ),
+    #GGFHHSample(0,1,      val_xs = 0.06007, label = 'ggHH_kl_0_kt_1'  ),
     GGFHHSample(5,1,      val_xs = 0.07903, label = 'ggHH_kl_5_kt_1'  ),
-    #GGFHHSample(2.45,1,   val_xs = 0.01133, label = 'ggHH_kl_2p45_kt_1'  ),
+    GGFHHSample(2.45,1,   val_xs = 0.01133, label = 'ggHH_kl_2p45_kt_1'  ),
 ]
 
 HHdefault = HHModel(

--- a/limits/prepareAsymptotic.py
+++ b/limits/prepareAsymptotic.py
@@ -13,10 +13,10 @@ def parseOptions():
     parser.add_option('-b'   , '--blind', dest='blind',                default=False, action='store_true')
     parser.add_option('--ggF',            dest='ggF'  ,                default=False, action='store_true')
     parser.add_option('--VBF',            dest='VBF'  ,                default=False, action='store_true')
-    parser.add_option('--kl' ,            dest='kl'   , type='string', default=None                      )
-    parser.add_option('--kt' ,            dest='kt'   , type='string', default=None                      )
-    parser.add_option('--CV' ,            dest='CV'   , type='string', default=None                      )
-    parser.add_option('--C2V',            dest='C2V'  , type='string', default=None                      )
+    parser.add_option('--kl' ,            dest='kl'   , type='string', default='1'                       )
+    parser.add_option('--kt' ,            dest='kt'   , type='string', default='1'                       )
+    parser.add_option('--CV' ,            dest='CV'   , type='string', default='1'                       )
+    parser.add_option('--C2V',            dest='C2V'  , type='string', default='1'                       )
  
     # store options and arguments as global variables
     global opt, args
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     if opt.ggF and not opt.VBF:
         red_parameters.append("r_gghh")
         fre_parameters.append("r")
-        set_parameters.append("r_qqhh=0")
+        set_parameters.append("r_qqhh=1")
 
     # limits only on r_qqhh
     if opt.VBF and not opt.ggF:
@@ -61,11 +61,11 @@ if __name__ == "__main__":
         fre_parameters.append("r")
         set_parameters.append("r_gghh=1")
 
-    # limits on r - NOT to be used for now!
-    #if opt.ggF and opt.VBF:
-    #    red_parameters.append("r")
-    #    freeze   = False
-    #    set_parameters.append("r_qqhh=0")
+    # limits on r
+    if opt.ggF and opt.VBF:
+        red_parameters.append("r")
+        freeze = False # all parameters except r already frozen by default
+        set_parameters.append("r_qqhh=1,r_gghh=1")
 
     command     = command + " --redefineSignalPOIs " + ",".join(red_parameters)
     if freeze:

--- a/limits/prepareAsymptotic_mib.py
+++ b/limits/prepareAsymptotic_mib.py
@@ -13,10 +13,10 @@ def parseOptions():
     parser.add_option('-b'   , '--blind', dest='blind',                default=False, action='store_true')
     parser.add_option('--ggF',            dest='ggF'  ,                default=False, action='store_true')
     parser.add_option('--VBF',            dest='VBF'  ,                default=False, action='store_true')
-    parser.add_option('--kl' ,            dest='kl'   , type='string', default=None                      )
-    parser.add_option('--kt' ,            dest='kt'   , type='string', default=None                      )
-    parser.add_option('--CV' ,            dest='CV'   , type='string', default=None                      )
-    parser.add_option('--C2V',            dest='C2V'  , type='string', default=None                      )
+    parser.add_option('--kl' ,            dest='kl'   , type='string', default='1'                       )
+    parser.add_option('--kt' ,            dest='kt'   , type='string', default='1'                       )
+    parser.add_option('--CV' ,            dest='CV'   , type='string', default='1'                       )
+    parser.add_option('--C2V',            dest='C2V'  , type='string', default='1'                       )
  
     # store options and arguments as global variables
     global opt, args
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     if opt.ggF and not opt.VBF:
         red_parameters.append("r_gghh")
         fre_parameters.append("r")
-        set_parameters.append("r_qqhh=0")
+        set_parameters.append("r_qqhh=1")
 
     # limits only on r_qqhh
     if opt.VBF and not opt.ggF:
@@ -59,11 +59,11 @@ if __name__ == "__main__":
         fre_parameters.append("r")
         set_parameters.append("r_gghh=1")
 
-    # limits on r - NOT to be used for now!
-    #if opt.ggF and opt.VBF:
-    #    red_parameters.append("r")
-    #    freeze   = False
-    #    set_parameters.append("r_qqhh=0")
+    # limits on r
+    if opt.ggF and opt.VBF:
+        red_parameters.append("r")
+        freeze = False # all parameters except r already frozen by default
+        set_parameters.append("r_qqhh=1,r_gghh=1")
 
     command     = command + " --redefineSignalPOIs " + ",".join(red_parameters)
     if freeze:

--- a/limits/prepare_histos.py
+++ b/limits/prepare_histos.py
@@ -25,8 +25,8 @@ systNamesOUT=["CMS_scale_t_13TeV_"+opt.year+"_DM0","CMS_scale_t_13TeV_"+opt.year
 systNames = ['tesXXX_DM0','tesXXX_DM1','tesXXX_DM10','tesXXX_DM11','eesXXX_DM0','eesXXX_DM1','mesXXX', 'jesXXXTot']
 
 # if running WITHOUT the shape syst, uncomment uncomment these 2 lines:
-#systNamesOUT=[]
-#systNames = []
+systNamesOUT=[]
+systNames = []
 
 print "Running"
 inFile = TFile.Open(opt.filename)
@@ -51,7 +51,7 @@ for key in inFile.GetListOfKeys():
 	if "GGHH_NLO" in kname: kname = kname.replace("GGHH_NLO","ggHH").replace("_xs","_kt_1_hbbhtautau").replace("cHHH", "kl_")
 	if "VBFHH"    in kname: kname = kname.replace("VBFHH","qqHH").replace("C3","kl").replace("_xs","_hbbhtautau") #write 1_5 as 1p5 from the beginning
 
-	print kname
+	#print kname
 
 	#protection against empty bins
 	changedInt = False

--- a/limits/prepare_histos.sh
+++ b/limits/prepare_histos.sh
@@ -9,33 +9,20 @@
 #
 ############
 
-# 10 Sept
-#python prepare_histos.py -f ../analysis_TauTau_2016_10Sept2020_limits_V2/analyzedOutPlotter.root -o 10Sept_NS_V2 -c TauTau -y 2016
-#python prepare_histos.py -f ../analysis_MuTau_2016_10Sept2020_limits_V2/analyzedOutPlotter.root -o 10Sept_NS_V2 -c MuTau -y 2016
-#python prepare_histos.py -f ../analysis_ETau_2016_10Sept2020_limits_V2/analyzedOutPlotter.root -o 10Sept_NS_V2 -c ETau -y 2016
-
-#python prepare_histos.py -f ../analysis_TauTau_2017_10Sept2020_limits_V2/analyzedOutPlotter.root -o 10Sept_NS_V2 -c TauTau -y 2017
-#python prepare_histos.py -f ../analysis_MuTau_2017_10Sept2020_limits_V2/analyzedOutPlotter.root -o 10Sept_NS_V2 -c MuTau -y 2017
-#python prepare_histos.py -f ../analysis_ETau_2017_10Sept2020_limits_V2/analyzedOutPlotter.root -o 10Sept_NS_V2 -c ETau -y 2017
+# 17 November 2020
+#python compute_scales.py -y 2016
+#python compute_scales.py -y 2017
+#python compute_scales.py -y 2018
 #
-#python prepare_histos.py -f ../analysis_TauTau_2018_10Sept2020_limits_V2/analyzedOutPlotter.root -o 10Sept_NS_V2 -c TauTau -y 2018
-#python prepare_histos.py -f ../analysis_MuTau_2018_10Sept2020_limits_V2/analyzedOutPlotter.root -o 10Sept_NS_V2 -c MuTau -y 2018
-#python prepare_histos.py -f ../analysis_ETau_2018_10Sept2020_limits_V2/analyzedOutPlotter.root -o 10Sept_NS_V2 -c ETau -y 2018
+#python prepare_histos.py -f ../analysis_TauTau_2016_17Nov2020_limits/analyzedOutPlotter.root -o 17Nov2020 -c TauTau -y 2016
+#python prepare_histos.py -f ../analysis_MuTau_2016_17Nov2020_limits/analyzedOutPlotter.root  -o 17Nov2020 -c MuTau  -y 2016
+#python prepare_histos.py -f ../analysis_ETau_2016_17Nov2020_limits/analyzedOutPlotter.root   -o 17Nov2020 -c ETau   -y 2016
+#
+#python prepare_histos.py -f ../analysis_TauTau_2017_17Nov2020_limits/analyzedOutPlotter.root -o 17Nov2020 -c TauTau -y 2017
+#python prepare_histos.py -f ../analysis_MuTau_2017_17Nov2020_limits/analyzedOutPlotter.root  -o 17Nov2020 -c MuTau  -y 2017
+#python prepare_histos.py -f ../analysis_ETau_2017_17Nov2020_limits/analyzedOutPlotter.root   -o 17Nov2020 -c ETau   -y 2017
+#
+#python prepare_histos.py -f ../analysis_TauTau_2018_17Nov2020_limits/analyzedOutPlotter.root -o 17Nov2020 -c TauTau -y 2018
+#python prepare_histos.py -f ../analysis_MuTau_2018_17Nov2020_limits/analyzedOutPlotter.root  -o 17Nov2020 -c MuTau  -y 2018
+#python prepare_histos.py -f ../analysis_ETau_2018_17Nov2020_limits/analyzedOutPlotter.root   -o 17Nov2020 -c ETau   -y 2018
 
-
-# 20 Sept
-python compute_scales.py -y 2016
-python compute_scales.py -y 2017
-python compute_scales.py -y 2018
-
-python prepare_histos.py -f ../analysis_TauTau_2016_22Sep2020_limits/analyzedOutPlotter.root -o 22Sep2020 -c TauTau -y 2016
-python prepare_histos.py -f ../analysis_MuTau_2016_22Sep2020_limits/analyzedOutPlotter.root  -o 22Sep2020 -c MuTau  -y 2016
-python prepare_histos.py -f ../analysis_ETau_2016_22Sep2020_limits/analyzedOutPlotter.root   -o 22Sep2020 -c ETau   -y 2016
-
-python prepare_histos.py -f ../analysis_TauTau_2017_22Sep2020_limits/analyzedOutPlotter.root -o 22Sep2020 -c TauTau -y 2017
-python prepare_histos.py -f ../analysis_MuTau_2017_22Sep2020_limits/analyzedOutPlotter.root  -o 22Sep2020 -c MuTau  -y 2017
-python prepare_histos.py -f ../analysis_ETau_2017_22Sep2020_limits/analyzedOutPlotter.root   -o 22Sep2020 -c ETau   -y 2017
-
-python prepare_histos.py -f ../analysis_TauTau_2018_22Sep2020_limits/analyzedOutPlotter.root -o 22Sep2020 -c TauTau -y 2018
-python prepare_histos.py -f ../analysis_MuTau_2018_22Sep2020_limits/analyzedOutPlotter.root  -o 22Sep2020 -c MuTau  -y 2018
-python prepare_histos.py -f ../analysis_ETau_2018_22Sep2020_limits/analyzedOutPlotter.root   -o 22Sep2020 -c ETau   -y 2018

--- a/scripts/combineFillerOutputs.py
+++ b/scripts/combineFillerOutputs.py
@@ -174,6 +174,7 @@ if args.moreDYbin2:
     
 if cfg.hasSection('pp_QCD'):
     SBtoSRforQCD =float(cfg.readOption('pp_QCD::SBtoSRfactor'))
+    doUpDownQCD = eval(cfg.readOption('pp_QCD::doUnc')) if cfg.hasOption('pp_QCD::doUnc') else False
     computeSBtoSRdyn = False
     if SBtoSRforQCD == 1 and not args.SBtoSR: 
         computeSBtoSRdyn = True
@@ -189,6 +190,23 @@ if cfg.hasSection('pp_QCD'):
         fitFunc      = cfg.readOption('pp_QCD::fitFunc'),
         computeSBtoSR = computeSBtoSRdyn
         )
+    if doUpDownQCD:
+        # Compute up/down variation of QCD by taking the shape
+        # from SStight and the correction factor from OSinviso/SSinviso
+        print "--- Computing Up/Down variation of QCD ---"
+        omngr.makeQCD(
+            SR           = cfg.readOption('pp_QCD::SR'),
+            yieldSB      = cfg.readOption('pp_QCD::regionC'), # SStight
+            shapeSB      = cfg.readOption('pp_QCD::regionC'), # SStight
+            SBtoSRfactor = SBtoSRforQCD,
+            regionC      = cfg.readOption('pp_QCD::yieldSB'), # OSinviso
+            regionD      = cfg.readOption('pp_QCD::regionD'), # SSinviso
+            doFitIf      = cfg.readOption('pp_QCD::doFitIf'),
+            fitFunc      = cfg.readOption('pp_QCD::fitFunc'),
+            computeSBtoSR = computeSBtoSRdyn,
+            doUpDown      = doUpDownQCD
+            )
+
 
 # VBF HH Reweighting
 # reads from the config the 6 input samples and the target couplings

--- a/scripts/combineFillerOutputs.py
+++ b/scripts/combineFillerOutputs.py
@@ -59,9 +59,6 @@ parser.add_argument('--moreDYbin0', type=float, dest='moreDYbin0', help='increas
 parser.add_argument('--moreDYbin1', type=float, dest='moreDYbin1', help='increase DY by factor moreDY1', default=None)
 parser.add_argument('--moreDYbin2', type=float, dest='moreDYbin2', help='increase DY by factor moreDY2', default=None)
 parser.add_argument('--SBtoSR', type=float, dest='SBtoSR', help='specity manually the SBtoSR factor', default=None)
-
-
-
 parser.add_argument('--extBkg',  dest='extBkg', help='add a bkg from external file', default=None)
 parser.add_argument('--extFile', dest='extFile', help='add a bkg from external file', default=None)
 args = parser.parse_args()
@@ -164,7 +161,123 @@ if args.moreDYbin1:
 if args.moreDYbin2:
     omngr.scaleHistos("DY", args.moreDYbin2, "pt150")
 
-    
+
+# Apply the bTagIterative normalization factor to preserve the correct
+# yield of the MC processes.
+if cfg.hasSection('bTagRfactor'):
+    # Read central correction
+    central = eval(cfg.readOption('bTagRfactor::central')) if cfg.hasOption('bTagRfactor::central') else 1.
+
+    # Read UP corrections
+    JESUp      = eval(cfg.readOption('bTagRfactor::bTagweightReshape_jes_up'))      if cfg.hasOption('bTagRfactor::bTagweightReshape_jes_up')      else 1.
+    LFUp       = eval(cfg.readOption('bTagRfactor::bTagweightReshape_lf_up'))       if cfg.hasOption('bTagRfactor::bTagweightReshape_lf_up')       else 1.
+    HFUp       = eval(cfg.readOption('bTagRfactor::bTagweightReshape_hf_up'))       if cfg.hasOption('bTagRfactor::bTagweightReshape_hf_up')       else 1.
+    HFSTATS1Up = eval(cfg.readOption('bTagRfactor::bTagweightReshape_hfstats1_up')) if cfg.hasOption('bTagRfactor::bTagweightReshape_hfstats1_up') else 1.
+    HFSTATS2Up = eval(cfg.readOption('bTagRfactor::bTagweightReshape_hfstats2_up')) if cfg.hasOption('bTagRfactor::bTagweightReshape_hfstats2_up') else 1.
+    LFSTATS1Up = eval(cfg.readOption('bTagRfactor::bTagweightReshape_lfstats1_up')) if cfg.hasOption('bTagRfactor::bTagweightReshape_lfstats1_up') else 1.
+    LFSTATS2Up = eval(cfg.readOption('bTagRfactor::bTagweightReshape_lfstats2_up')) if cfg.hasOption('bTagRfactor::bTagweightReshape_lfstats2_up') else 1.
+    CFERR1Up   = eval(cfg.readOption('bTagRfactor::bTagweightReshape_cferr1_up'))   if cfg.hasOption('bTagRfactor::bTagweightReshape_cferr1_up')   else 1.
+    CFERR2Up   = eval(cfg.readOption('bTagRfactor::bTagweightReshape_cferr2_up'))   if cfg.hasOption('bTagRfactor::bTagweightReshape_cferr2_up')   else 1.
+
+    # Read DOWN corrections
+    JESDown      = eval(cfg.readOption('bTagRfactor::bTagweightReshape_jes_down'))      if cfg.hasOption('bTagRfactor::bTagweightReshape_jes_down')      else 1.
+    LFDown       = eval(cfg.readOption('bTagRfactor::bTagweightReshape_lf_down'))       if cfg.hasOption('bTagRfactor::bTagweightReshape_lf_down')       else 1.
+    HFDown       = eval(cfg.readOption('bTagRfactor::bTagweightReshape_hf_down'))       if cfg.hasOption('bTagRfactor::bTagweightReshape_hf_down')       else 1.
+    HFSTATS1Down = eval(cfg.readOption('bTagRfactor::bTagweightReshape_hfstats1_down')) if cfg.hasOption('bTagRfactor::bTagweightReshape_hfstats1_down') else 1.
+    HFSTATS2Down = eval(cfg.readOption('bTagRfactor::bTagweightReshape_hfstats2_down')) if cfg.hasOption('bTagRfactor::bTagweightReshape_hfstats2_down') else 1.
+    LFSTATS1Down = eval(cfg.readOption('bTagRfactor::bTagweightReshape_lfstats1_down')) if cfg.hasOption('bTagRfactor::bTagweightReshape_lfstats1_down') else 1.
+    LFSTATS2Down = eval(cfg.readOption('bTagRfactor::bTagweightReshape_lfstats2_down')) if cfg.hasOption('bTagRfactor::bTagweightReshape_lfstats2_down') else 1.
+    CFERR1Down   = eval(cfg.readOption('bTagRfactor::bTagweightReshape_cferr1_down'))   if cfg.hasOption('bTagRfactor::bTagweightReshape_cferr1_down')   else 1.
+    CFERR2Down   = eval(cfg.readOption('bTagRfactor::bTagweightReshape_cferr2_down'))   if cfg.hasOption('bTagRfactor::bTagweightReshape_cferr2_down')   else 1.
+
+    print '--- Appliyng bTagIterative normalization factor ---'
+    print '    >> Values for bTagIterative normalization factor:'
+    print '    >> central          :', central
+    print '    >> JES Up/Down      :', JESUp     , '/', JESDown
+    print '    >> LF Up/Down       :', LFUp      , '/', LFDown
+    print '    >> HF Up/Down       :', HFUp      , '/', HFDown
+    print '    >> HFSTATS1 Up/Down :', HFSTATS1Up, '/', HFSTATS1Down
+    print '    >> HFSTATS2 Up/Down :', HFSTATS2Up, '/', HFSTATS2Down
+    print '    >> LFSTATS1 Up/Down :', LFSTATS1Up, '/', LFSTATS1Down
+    print '    >> LFSTATS2 Up/Down :', LFSTATS2Up, '/', LFSTATS2Down
+    print '    >> CFERR1 Up/Down   :', CFERR1Up  , '/', CFERR1Down
+    print '    >> CFERR2 Up/Down   :', CFERR2Up  , '/', CFERR2Down
+
+    # Scale the histos
+    for histoname in omngr.histos:
+
+        # don't apply to data
+        if 'data_obs' in histoname: continue
+
+        # apply to sigs and bkgs
+        if 'bTagweightReshapeJESUp' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(JESUp)
+        elif 'bTagweightReshapeJESDown' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(JESDown)
+
+        elif 'bTagweightReshapeLFUp' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(LFUp)
+        elif 'bTagweightReshapeLFDown' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(LFDown)
+
+        elif 'bTagweightReshapeHFUp' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(HFUp)
+        elif 'bTagweightReshapeHFDown' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(HFDown)
+
+        elif 'bTagweightReshapeHFSTATS1Up' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(HFSTATS1Up)
+        elif 'bTagweightReshapeHFSTATS1Down' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(HFSTATS1Down)
+
+        elif 'bTagweightReshapeHFSTATS2Up' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(HFSTATS2Up)
+        elif 'bTagweightReshapeHFSTATS2Down' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(HFSTATS2Down)
+
+        elif 'bTagweightReshapeLFSTATS1Up' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(LFSTATS1Up)
+        elif 'bTagweightReshapeLFSTATS1Down' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(LFSTATS1Down)
+
+        elif 'bTagweightReshapeLFSTATS2Up' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(LFSTATS2Up)
+        elif 'bTagweightReshapeLFSTATS2Down' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(LFSTATS2Down)
+
+        elif 'bTagweightReshapeCFERR1Up' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(CFERR1Up)
+        elif 'bTagweightReshapeCFERR1Down' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(CFERR1Down)
+
+        elif 'bTagweightReshapeCFERR2Up' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(CFERR2Up)
+        elif 'bTagweightReshapeCFERR2Down' in histoname:
+            h = omngr.histos[histoname]
+            h.Scale(CFERR2Down)
+
+        # if no systematic shift: apply central correction
+        else:
+            h = omngr.histos[histoname]
+            h.Scale(central)
+
 
 # C/D factor:
 # if not specified by --SBtoSRforQCD, 

--- a/scripts/makeFinalPlots_Legacy2016.py
+++ b/scripts/makeFinalPlots_Legacy2016.py
@@ -470,7 +470,7 @@ if __name__ == "__main__" :
 
 
     ######################### PUT USER CONFIGURATION HERE ####################
-    cfgName  =  args.dir + "/mainCfg_"+args.channel+"_Legacy2016.cfg"
+    cfgName  =  args.dir + "/mainCfg_"+args.channel+"_Legacy2016_limits.cfg"
     cfg        = cfgr.ConfigReader (cfgName)
     bkgList    = cfg.readListOption("general::backgrounds")
 
@@ -483,57 +483,43 @@ if __name__ == "__main__" :
     
     
     sigList = cfg.readListOption("general::signals")
-    sigList = ["GGHHSM"]
-
+    sigList = ["GGHH_NLO_cHHH1_xs", "VBFHH_CV_1_C2V_1_C3_1_xs"]
 
     sigNameList = []
     if args.log:
             sigNameList = ["VBF HH SM (x10)"]
     else:
            sigNameList = ["VBF HH SM (x10)"]
-    sigNameList = ["ggHH SM"]
+    sigNameList = ["ggHH SM x 20", "qqHH SM x 100"]
 
 
     sigColors = {}
-    sigColors["ggHH"] = kBlack
-    sigColors["VBFSM"] = kBlack
-    sigColors["vbfRadion280"]        = kCyan
-    sigColors["vbfRadion750"]        = kBlue
-    sigColors["VBF_CV_1_C2V_1_C3_0"] = kBlue
-    sigColors["VBF_CV_1_C2V_1_C3_1"] = kBlack
-    sigColors["nodeSM"]      = kBlack
-    sigColors["node7"]       = kBlue
-    sigColors["node2"]       = kCyan
-    sigColors["node3"]       = kRed
-    sigColors["node4"]       = kBlue
-    sigColors["node9"]       = kOrange
-    sigColors["node12"]      = kCyan
-    sigColors["ggRadion280"] = kBlue
-    sigColors["ggRadion400"] = kCyan
-    sigColors["ggRadion750"] = kBlack
-    sigColors["ggHTauTau"] = kBlack
+    sigColors["GGHH_NLO_cHHH1_xs"] = kBlack
+    sigColors["VBFHH_CV_1_C2V_1_C3_1_xs"] = kCyan
 
 
     # RGB/HEX colors
     col = TColor()
 
     bkgColors = {}
-    bkgColors["DY"]    = col.GetColor("#44BA68") #(TColor(68 ,186,104)).GetNumber() #gROOT.GetColor("#44BA68")
-    bkgColors["TT"]    = col.GetColor("#F4B642") #(TColor(244,182,66 )).GetNumber() #gROOT.GetColor("#F4B642")
-    bkgColors["WJets"] = col.GetColor("#41B4DB") #(TColor(65 ,180,219)).GetNumber() #gROOT.GetColor("#41B4DB")
-    bkgColors["other"] = col.GetColor("#ED635E") #(TColor(237,99 ,94 )).GetNumber() #gROOT.GetColor("#ED635E")
+    bkgColors["DY"]      = col.GetColor("#44BA68") #(TColor(68 ,186,104)).GetNumber() #gROOT.GetColor("#44BA68")
+    bkgColors["TT"]      = col.GetColor("#F4B642") #(TColor(244,182,66 )).GetNumber() #gROOT.GetColor("#F4B642")
+    #bkgColors["WJets"]  = col.GetColor("#41B4DB") #(TColor(65 ,180,219)).GetNumber() #gROOT.GetColor("#41B4DB")
+    bkgColors["singleH"] = col.GetColor("#41B4DB") #(TColor(65 ,180,219)).GetNumber() #gROOT.GetColor("#41B4DB")
+    bkgColors["other"]    = col.GetColor("#ED635E") #(TColor(237,99 ,94 )).GetNumber() #gROOT.GetColor("#ED635E")
 
     bkgLineColors = {}
-    bkgLineColors["DY"]    = col.GetColor("#389956")
-    bkgLineColors["TT"]    = col.GetColor("#dea63c")
-    bkgLineColors["WJets"] = col.GetColor("#3ca4c8")
-    bkgLineColors["other"] = col.GetColor("#d85a56")
+    bkgLineColors["DY"]      = col.GetColor("#389956")
+    bkgLineColors["TT"]      = col.GetColor("#dea63c")
+    #bkgLineColors["WJets"]  = col.GetColor("#3ca4c8")
+    bkgLineColors["singleH"] = col.GetColor("#3ca4c8")
+    bkgLineColors["other"]   = col.GetColor("#d85a56")
 
 
     #if args.sigscale:
     #     for i in range(0,len(sigScale)): sigScale[i] = args.sigscale
-    sigScale = [10,10]
-    sigScaleValue = 100
+    sigScale = [20,100]
+    sigScaleValue = 1000
 
     plotTitle = ""
 
@@ -579,19 +565,22 @@ if __name__ == "__main__" :
 
     hDY = getHisto("DY", hBkgs,doOverflow)
     hTT = getHisto("TT", hBkgs,doOverflow)
-    hWJets = getHisto("WJets", hBkgs,doOverflow)
+    #hWJets = getHisto("WJets", hBkgs,doOverflow)
+    hWJets = getHisto("singleH", hBkgs,doOverflow)
     hothers = getHisto("other", hBkgs,doOverflow)
 
     hBkgList = [hothers, hWJets, hTT, hDY] ## full list for stack
 
-    hBkgNameList = ["Others", "W + jets", "t#bar{t}" , "DY"] # list for legend
+    #hBkgNameList = ["Others", "W + jets", "t#bar{t}" , "DY NLO"] # list for legend
+    hBkgNameList = ["Others", "single H", "t#bar{t}" , "DY NLO"] # list for legend
 
     if doQCD:
         col2 = TColor()
         hQCD    = getHisto ("QCD", hBkgs,doOverflow)
         hQCD.SetName("QCD")
-        hBkgList.append(hQCD)
-        hBkgNameList.append("QCD")
+        hBkgList = [hothers, hWJets, hQCD, hDY, hTT]
+        #hBkgNameList = ["others", "W + Jets", "QCD", "DY", "t#bar{t}"]
+        hBkgNameList = ["others", "single H", "QCD", "DY", "t#bar{t}"]
         bkgColors["QCD"] = col2.GetColor("#F29563") #(TColor(242,149,99)).GetNumber() #gROOT.GetColor("#F29563")
         bkgLineColors["QCD"] = col2.GetColor("#DC885A")
 
@@ -616,12 +605,13 @@ if __name__ == "__main__" :
 
     # apply sig color if available
     for key in hSigs:
+        print key
         hSigs[key].SetLineWidth(2)
         if doOverflow: hSigs[key] = addOverFlow(hSigs[key])
         if key in sigColors:
-            thecolor = int(sigColors[key])
+            thecolor = sigColors[key]
             hSigs[key].SetLineColor(thecolor)
-            hSigs[key].SetLineStyle(9)
+            #hSigs[key].SetLineStyle(9)
 
 
     # apply bkg color if available
@@ -647,12 +637,18 @@ if __name__ == "__main__" :
     print "** INFO: removing all negative bins from bkg histos"
     makeNonNegativeHistos (hBkgList)
 
-    #saveName = "./plots_"+args.channel+"/"+args.tag+"/"+args.sel+"_"+args.reg+"/plot_" + args.var + "_" + args.sel +"_" + args.reg+ tagch
-    with open("./plots_"+args.channel+"/"+args.tag+"/"+args.sel+"_"+args.reg+"/yields.txt","a+") as yields_file:
-        yields_file.write("=== "+args.channel+"/"+args.tag+"/"+args.sel+"_"+args.reg+"/"+args.var+" ===\n")
-        for h in hBkgList: yields_file.write("Integral: "+h.GetName()+" : "+str(h.Integral())+" - "+str(h.Integral(-1,-1))+"\n")
-        for n in hDatas  : yields_file.write("Integral "+hDatas[n].GetName()+" : "+str(hDatas[n].Integral())+" - "+str(hDatas[n].Integral(-1,-1))+"\n")
-        for i, name in enumerate (sigNameList): yields_file.write("Integral "+hSigs[sigList[i]].GetName()+" : "+str(hSigs[sigList[i]].Integral())+" - "+str(hSigs[sigList[i]].Integral(-1,-1))+"\n")
+    if "class" in args.sel:
+        with open("./plots_"+args.channel+"/"+args.tag+"/scores_"+args.reg+"/yields.txt","a+") as yields_file:
+            yields_file.write("=== "+args.channel+"/"+args.tag+"/scores_"+args.reg+"/"+args.var+" ===\n")
+            for h in hBkgList: yields_file.write("Integral: "+h.GetName()+" : "+str(h.Integral())+" - "+str(h.Integral(-1,-1))+"\n")
+            for n in hDatas  : yields_file.write("Integral "+hDatas[n].GetName()+" : "+str(hDatas[n].Integral())+" - "+str(hDatas[n].Integral(-1,-1))+"\n")
+            for i, name in enumerate (sigNameList): yields_file.write("Integral "+hSigs[sigList[i]].GetName()+" : "+str(hSigs[sigList[i]].Integral())+" - "+str(hSigs[sigList[i]].Integral(-1,-1))+"\n")
+    else:
+        with open("./plots_"+args.channel+"/"+args.tag+"/"+args.sel+"_"+args.reg+"/yields.txt","a+") as yields_file:
+            yields_file.write("=== "+args.channel+"/"+args.tag+"/"+args.sel+"_"+args.reg+"/"+args.var+" ===\n")
+            for h in hBkgList: yields_file.write("Integral: "+h.GetName()+" : "+str(h.Integral())+" - "+str(h.Integral(-1,-1))+"\n")
+            for n in hDatas  : yields_file.write("Integral "+hDatas[n].GetName()+" : "+str(hDatas[n].Integral())+" - "+str(hDatas[n].Integral(-1,-1))+"\n")
+            for i, name in enumerate (sigNameList): yields_file.write("Integral "+hSigs[sigList[i]].GetName()+" : "+str(hSigs[sigList[i]].Integral())+" - "+str(hSigs[sigList[i]].Integral(-1,-1))+"\n")
 
     for h in hBkgList: print "Integral ", h.GetName(), " : ", h.Integral(), " - ", h.Integral(-1,-1)
     for n in hDatas: print "Integral ", hDatas[n].GetName(), " : ", hDatas[n].Integral(), " - ", hDatas[n].Integral(-1,-1)
@@ -702,6 +698,8 @@ if __name__ == "__main__" :
 
     width = ((bkgStack.GetXaxis().GetXmax() - bkgStack.GetXaxis().GetXmin())/bkgStack.GetStack().Last().GetNbinsX())
     ylabel = "Events/%.1f" % width
+    if not args.binwidth:
+        ylabel = "Events"
     if args.label:
         if "GeV" in args.label: ylabel +=" GeV"
     bkgStack.GetYaxis().SetTitle(ylabel)
@@ -717,13 +715,13 @@ if __name__ == "__main__" :
     #            hSigs[key].Scale(intBkg/intSig)
 
     # apply sig scale
-    #for i, scale in enumerate (sigScale):
-    #    histo = hSigs[sigList[i]]
-    #    histo.Scale(scale)
-    for i, name in enumerate (sigNameList):
+    for i, scale in enumerate (sigScale):
         histo = hSigs[sigList[i]]
-        histo.Scale(sigScaleValue)
-                
+        histo.Scale(scale)
+    #for i, name in enumerate (sigNameList):
+    #    histo = hSigs[sigList[i]]
+    #    histo.Scale(sigScaleValue)
+
     ################## LEGEND ######################################
 
     legmin = 0.45
@@ -777,7 +775,7 @@ if __name__ == "__main__" :
     ymax = max(maxs)
 
     # scale max to leave some space (~10%)
-    extraspace = 0.3
+    extraspace = 0.5
 
     if not args.log:
         ymax += extraspace* (ymax-ymin)
@@ -882,36 +880,34 @@ if __name__ == "__main__" :
 
 
     if not args.name:
-            if "baseline" in args.sel:  
-                    selName = "baseline"
-            if "MTT" in args.sel:
-                    selName = "baseline_MTT"
-            if "1b1j" in args.sel:  
-                    selName = "1b1j"
-            if "2b0j" in args.sel:  
-                    selName = "2b0j"
-            if "boosted" in args.sel:
-                    selName = "boosted"
-            if "antiB" in args.sel:
-                    selName = "antiB"
-            if "DYreg" in args.sel:
-                    selName = "DYreg"
-            if "VBFloose" in args.sel:
-                    selName = "VBF loose"
-            if "GGFclass" in args.sel:
-                    selName = "VBF - GGF mpp"
-            if "VBFclass" in args.sel:
-                    selName = "VBF - VBF mpp"
-            if "TTlepclass" in args.sel:
-                    selName = "VBF - TTlep mpp"
-            if "TThadclass" in args.sel:
-                    selName = "VBF - TThad mpp"
-            if "ttHclass" in args.sel:
-                    selName = "VBF - ttH mpp"
-            if "DYclass" in args.sel:
-                    selName = "VBF - DY mpp"
+        if "baseline" in args.sel:
+            selName = "baseline"
+        if "1b1j" in args.sel:
+            selName = "1b1j"
+        if "2b0j" in args.sel:
+            selName = "2b0j"
+        if "boosted" in args.sel:
+            selName = "boosted"
+        if "antiB" in args.sel:
+            selName = "antiB"
+        if "DYreg" in args.sel:
+            selName = "DYreg"
+        if "VBFloose" in args.sel:
+            selName = "VBFloose"
+        if "GGFclass" in args.sel:
+            selName = "GGFclass"
+        if "VBFclass" in args.sel:
+            selName = "VBFclass"
+        if "DYclass" in args.sel:
+            selName = "DYclass"
+        if "ttHclass" in args.sel:
+            selName = "ttHclass"
+        if "TTlepclass" in args.sel:
+            selName = "TTlepclass"
+        if "TThadclass" in args.sel:
+            selName = "TThadclass"
     else:
-            selName = args.name
+        selName = args.name
 
     selBox = TLatex  (l + 0.04 , 1 - t - 0.02 - 0.06, selName)
     selBox.SetNDC()
@@ -922,13 +918,13 @@ if __name__ == "__main__" :
     selBox.Draw()
     
     ###################### BLINDING BOX ###############################
-    if args.blindrange:
-        blow = float(args.blindrange[0])
-        bup = float(args.blindrange[1])
-        bBox = TBox (blow, ymin, bup, 0.93*ymax)
-        bBox.SetFillStyle(3002) # NB: does not appear the same in displayed box and printed pdf!!
-        bBox.SetFillColor(kGray+2) # NB: does not appear the same in displayed box and printed pdf!!
-        bBox.Draw()
+    #if args.blindrange:
+    #    blow = float(args.blindrange[0])
+    #    bup = float(args.blindrange[1])
+    #    bBox = TBox (blow, ymin, bup, 0.7*ymax)
+    #    bBox.SetFillStyle(3002) # NB: does not appear the same in displayed box and printed pdf!!
+    #    bBox.SetFillColor(kGray+2) # NB: does not appear the same in displayed box and printed pdf!!
+    #    bBox.Draw()
 
     ###################### S/(S+B) PLOT #################################
     if args.sbs:
@@ -1048,12 +1044,10 @@ if __name__ == "__main__" :
         hRatio.SetStats(0)
         #hRatio.SetMinimum(0.85)
         #hRatio.SetMaximum(1.15)
-        #hRatio.SetMinimum(0.6) #default value
-        #hRatio.SetMaximum(1.4) #default value
-        #hRatio.SetMinimum(0.1) #TESI
-        #hRatio.SetMaximum(1.9) #TESI
-        hRatio.SetMinimum(0.7)
-        hRatio.SetMaximum(1.25)
+        hRatio.SetMinimum(0.6) #default value
+        hRatio.SetMaximum(1.4) #default value
+        #hRatio.SetMinimum(0.0) #TESI
+        #hRatio.SetMaximum(2.0) #TESI
 
         removeEmptyPoints (grRatio)
         hRatio.Draw("axis")
@@ -1086,7 +1080,12 @@ if __name__ == "__main__" :
         tagch = ""
         if args.channel:
             tagch = "_" + args.channel
-        saveName = "./plots_"+args.channel+"/"+args.tag+"/"+args.sel+"_"+args.reg+"/plot_" + args.var + "_" + args.sel +"_" + args.reg+ tagch
+        if not args.binwidth:
+            tagch += "_noBinWidt"
+        if "class" in args.sel:
+            saveName = "./plots_"+args.channel+"/"+args.tag+"/scores_"+args.reg+"/plot_" + args.var + "_" + args.sel +"_" + args.reg+ tagch
+        else:
+            saveName = "./plots_"+args.channel+"/"+args.tag+"/"+args.sel+"_"+args.reg+"/plot_" + args.var + "_" + args.sel +"_" + args.reg+ tagch
         if args.log:
             saveName = saveName+"_log"
         if args.flat:

--- a/scripts/makeFinalPlots_Legacy2017.py
+++ b/scripts/makeFinalPlots_Legacy2017.py
@@ -470,70 +470,53 @@ if __name__ == "__main__" :
 
 
     ######################### PUT USER CONFIGURATION HERE ####################
-    cfgName  =  args.dir + "/mainCfg_"+args.channel+"_Legacy2017.cfg"
+    cfgName  =  args.dir + "/mainCfg_"+args.channel+"_Legacy2017_limits.cfg"
     cfg        = cfgr.ConfigReader (cfgName)
     bkgList    = cfg.readListOption("general::backgrounds")
 
     doQCD = True
     if not "SR" in args.reg: doQCD = False
     if not "Tau" in args.channel: doQCD = False
-    
     if doQCD:
         bkgList.append('QCD')
-    
-    
-    sigList = cfg.readListOption("general::signals")
-    sigList = ["GGHHSM"]
 
+
+    sigList = cfg.readListOption("general::signals")
+    sigList = ["GGHH_NLO_cHHH1_xs", "VBFHH_CV_1_C2V_1_C3_1_xs"]
 
     sigNameList = []
     if args.log:
             sigNameList = ["VBF HH SM (x10)"]
     else:
            sigNameList = ["VBF HH SM (x10)"]
-    sigNameList = ["ggHH SM"]
-
+    sigNameList = ["ggHH SM x 20", "qqHH SM x 100"]
 
     sigColors = {}
-    sigColors["ggHH"] = kBlack
-    sigColors["VBFSM"] = kBlack
-    sigColors["vbfRadion280"]        = kCyan
-    sigColors["vbfRadion750"]        = kBlue
-    sigColors["VBF_CV_1_C2V_1_C3_0"] = kBlue
-    sigColors["VBF_CV_1_C2V_1_C3_1"] = kBlack
-    sigColors["nodeSM"]      = kBlack
-    sigColors["node7"]       = kBlue
-    sigColors["node2"]       = kCyan
-    sigColors["node3"]       = kRed
-    sigColors["node4"]       = kBlue
-    sigColors["node9"]       = kOrange
-    sigColors["node12"]      = kCyan
-    sigColors["ggRadion280"] = kBlue
-    sigColors["ggRadion400"] = kCyan
-    sigColors["ggRadion750"] = kBlack
-    sigColors["ggHTauTau"] = kBlack
+    sigColors["GGHH_NLO_cHHH1_xs"] = kBlack
+    sigColors["VBFHH_CV_1_C2V_1_C3_1_xs"] = kCyan
 
 
     # RGB/HEX colors
     col = TColor()
 
     bkgColors = {}
-    bkgColors["DY"]    = col.GetColor("#44BA68") #(TColor(68 ,186,104)).GetNumber() #gROOT.GetColor("#44BA68")
-    bkgColors["TT"]    = col.GetColor("#F4B642") #(TColor(244,182,66 )).GetNumber() #gROOT.GetColor("#F4B642")
-    bkgColors["WJets"] = col.GetColor("#41B4DB") #(TColor(65 ,180,219)).GetNumber() #gROOT.GetColor("#41B4DB")
-    bkgColors["other"] = col.GetColor("#ED635E") #(TColor(237,99 ,94 )).GetNumber() #gROOT.GetColor("#ED635E")
+    bkgColors["DY"]      = col.GetColor("#44BA68") #(TColor(68 ,186,104)).GetNumber() #gROOT.GetColor("#44BA68")
+    bkgColors["TT"]      = col.GetColor("#F4B642") #(TColor(244,182,66 )).GetNumber() #gROOT.GetColor("#F4B642")
+    #bkgColors["WJets"]  = col.GetColor("#41B4DB") #(TColor(65 ,180,219)).GetNumber() #gROOT.GetColor("#41B4DB")
+    bkgColors["singleH"] = col.GetColor("#41B4DB") #(TColor(65 ,180,219)).GetNumber() #gROOT.GetColor("#41B4DB")
+    bkgColors["other"]    = col.GetColor("#ED635E") #(TColor(237,99 ,94 )).GetNumber() #gROOT.GetColor("#ED635E")
 
     bkgLineColors = {}
-    bkgLineColors["DY"]    = col.GetColor("#389956")
-    bkgLineColors["TT"]    = col.GetColor("#dea63c")
-    bkgLineColors["WJets"] = col.GetColor("#3ca4c8")
-    bkgLineColors["other"] = col.GetColor("#d85a56")
+    bkgLineColors["DY"]      = col.GetColor("#389956")
+    bkgLineColors["TT"]      = col.GetColor("#dea63c")
+    bkgLineColors["singleH"] = col.GetColor("#3ca4c8")
+    bkgLineColors["other"]   = col.GetColor("#d85a56")
 
 
     #if args.sigscale:
     #     for i in range(0,len(sigScale)): sigScale[i] = args.sigscale
-    sigScale = [10,10]
-    sigScaleValue = 100
+    sigScale = [20,100]
+    sigScaleValue = 1000
 
     plotTitle = ""
 
@@ -579,19 +562,19 @@ if __name__ == "__main__" :
 
     hDY = getHisto("DY", hBkgs,doOverflow)
     hTT = getHisto("TT", hBkgs,doOverflow)
-    hWJets = getHisto("WJets", hBkgs,doOverflow)
+    hWJets = getHisto("singleH", hBkgs,doOverflow)
     hothers = getHisto("other", hBkgs,doOverflow)
 
     hBkgList = [hothers, hWJets, hTT, hDY] ## full list for stack
 
-    hBkgNameList = ["Others", "W + jets", "t#bar{t}" , "DY NLO"] # list for legend
+    hBkgNameList = ["Others", "single H", "t#bar{t}" , "DY NLO"] # list for legend
 
     if doQCD:
         col2 = TColor()
         hQCD    = getHisto ("QCD", hBkgs,doOverflow)
         hQCD.SetName("QCD")
-        hBkgList.append(hQCD)
-        hBkgNameList.append("QCD")
+        hBkgList = [hothers, hWJets, hQCD, hDY, hTT]
+        hBkgNameList = ["others", "single H", "QCD", "DY", "t#bar{t}"]
         bkgColors["QCD"] = col2.GetColor("#F29563") #(TColor(242,149,99)).GetNumber() #gROOT.GetColor("#F29563")
         bkgLineColors["QCD"] = col2.GetColor("#DC885A")
 
@@ -616,12 +599,13 @@ if __name__ == "__main__" :
 
     # apply sig color if available
     for key in hSigs:
+        print key
         hSigs[key].SetLineWidth(2)
         if doOverflow: hSigs[key] = addOverFlow(hSigs[key])
         if key in sigColors:
-            thecolor = int(sigColors[key])
+            thecolor = sigColors[key]
             hSigs[key].SetLineColor(thecolor)
-            hSigs[key].SetLineStyle(9)
+            #hSigs[key].SetLineStyle(9)
 
 
     # apply bkg color if available
@@ -647,12 +631,18 @@ if __name__ == "__main__" :
     print "** INFO: removing all negative bins from bkg histos"
     makeNonNegativeHistos (hBkgList)
 
-    #saveName = "./plots_"+args.channel+"/"+args.tag+"/"+args.sel+"_"+args.reg+"/plot_" + args.var + "_" + args.sel +"_" + args.reg+ tagch
-    with open("./plots_"+args.channel+"/"+args.tag+"/"+args.sel+"_"+args.reg+"/yields.txt","a+") as yields_file:
-        yields_file.write("=== "+args.channel+"/"+args.tag+"/"+args.sel+"_"+args.reg+"/"+args.var+" ===\n")
-        for h in hBkgList: yields_file.write("Integral: "+h.GetName()+" : "+str(h.Integral())+" - "+str(h.Integral(-1,-1))+"\n")
-        for n in hDatas  : yields_file.write("Integral "+hDatas[n].GetName()+" : "+str(hDatas[n].Integral())+" - "+str(hDatas[n].Integral(-1,-1))+"\n")
-        for i, name in enumerate (sigNameList): yields_file.write("Integral "+hSigs[sigList[i]].GetName()+" : "+str(hSigs[sigList[i]].Integral())+" - "+str(hSigs[sigList[i]].Integral(-1,-1))+"\n")
+    if "class" in args.sel:
+        with open("./plots_"+args.channel+"/"+args.tag+"/scores_"+args.reg+"/yields.txt","a+") as yields_file:
+            yields_file.write("=== "+args.channel+"/"+args.tag+"/scores_"+args.reg+"/"+args.var+" ===\n")
+            for h in hBkgList: yields_file.write("Integral: "+h.GetName()+" : "+str(h.Integral())+" - "+str(h.Integral(-1,-1))+"\n")
+            for n in hDatas  : yields_file.write("Integral "+hDatas[n].GetName()+" : "+str(hDatas[n].Integral())+" - "+str(hDatas[n].Integral(-1,-1))+"\n")
+            for i, name in enumerate (sigNameList): yields_file.write("Integral "+hSigs[sigList[i]].GetName()+" : "+str(hSigs[sigList[i]].Integral())+" - "+str(hSigs[sigList[i]].Integral(-1,-1))+"\n")
+    else:
+        with open("./plots_"+args.channel+"/"+args.tag+"/"+args.sel+"_"+args.reg+"/yields.txt","a+") as yields_file:
+            yields_file.write("=== "+args.channel+"/"+args.tag+"/"+args.sel+"_"+args.reg+"/"+args.var+" ===\n")
+            for h in hBkgList: yields_file.write("Integral: "+h.GetName()+" : "+str(h.Integral())+" - "+str(h.Integral(-1,-1))+"\n")
+            for n in hDatas  : yields_file.write("Integral "+hDatas[n].GetName()+" : "+str(hDatas[n].Integral())+" - "+str(hDatas[n].Integral(-1,-1))+"\n")
+            for i, name in enumerate (sigNameList): yields_file.write("Integral "+hSigs[sigList[i]].GetName()+" : "+str(hSigs[sigList[i]].Integral())+" - "+str(hSigs[sigList[i]].Integral(-1,-1))+"\n")
 
     for h in hBkgList: print "Integral ", h.GetName(), " : ", h.Integral(), " - ", h.Integral(-1,-1)
     for n in hDatas: print "Integral ", hDatas[n].GetName(), " : ", hDatas[n].Integral(), " - ", hDatas[n].Integral(-1,-1)
@@ -702,6 +692,8 @@ if __name__ == "__main__" :
 
     width = ((bkgStack.GetXaxis().GetXmax() - bkgStack.GetXaxis().GetXmin())/bkgStack.GetStack().Last().GetNbinsX())
     ylabel = "Events/%.1f" % width
+    if not args.binwidth:
+        ylabel = "Events"
     if args.label:
         if "GeV" in args.label: ylabel +=" GeV"
     bkgStack.GetYaxis().SetTitle(ylabel)
@@ -717,13 +709,13 @@ if __name__ == "__main__" :
     #            hSigs[key].Scale(intBkg/intSig)
 
     # apply sig scale
-    #for i, scale in enumerate (sigScale):
-    #    histo = hSigs[sigList[i]]
-    #    histo.Scale(scale)
-    for i, name in enumerate (sigNameList):
+    for i, scale in enumerate (sigScale):
         histo = hSigs[sigList[i]]
-        histo.Scale(sigScaleValue)
-                
+        histo.Scale(scale)
+    #for i, name in enumerate (sigNameList):
+    #    histo = hSigs[sigList[i]]
+    #    histo.Scale(sigScaleValue)
+
     ################## LEGEND ######################################
 
     legmin = 0.45
@@ -777,7 +769,7 @@ if __name__ == "__main__" :
     ymax = max(maxs)
 
     # scale max to leave some space (~10%)
-    extraspace = 0.3
+    extraspace = 0.5
 
     if not args.log:
         ymax += extraspace* (ymax-ymin)
@@ -882,34 +874,34 @@ if __name__ == "__main__" :
 
 
     if not args.name:
-            if "baseline" in args.sel:  
-                    selName = "baseline"
-            if "1b1j" in args.sel:  
-                    selName = "1b1j"
-            if "2b0j" in args.sel:  
-                    selName = "2b0j"
-            if "boosted" in args.sel:
-                    selName = "boosted"
-            if "antiB" in args.sel:
-                    selName = "antiB"
-            if "DYreg" in args.sel:
-                    selName = "DYreg"
-            if "VBFloose" in args.sel:
-                    selName = "VBF loose"
-            if "GGFclass" in args.sel:
-                    selName = "VBF - GGF mpp"
-            if "VBFclass" in args.sel:
-                    selName = "VBF - VBF mpp"
-            if "TTlepclass" in args.sel:
-                    selName = "VBF - TTlep mpp"
-            if "TThadclass" in args.sel:
-                    selName = "VBF - TThad mpp"
-            if "ttHclass" in args.sel:
-                    selName = "VBF - ttH mpp"
-            if "DYclass" in args.sel:
-                    selName = "VBF - DY mpp"
+        if "baseline" in args.sel:
+            selName = "baseline"
+        if "1b1j" in args.sel:
+            selName = "1b1j"
+        if "2b0j" in args.sel:
+            selName = "2b0j"
+        if "boosted" in args.sel:
+            selName = "boosted"
+        if "antiB" in args.sel:
+            selName = "antiB"
+        if "DYreg" in args.sel:
+            selName = "DYreg"
+        if "VBFloose" in args.sel:
+            selName = "VBFloose"
+        if "GGFclass" in args.sel:
+            selName = "GGFclass"
+        if "VBFclass" in args.sel:
+            selName = "VBFclass"
+        if "DYclass" in args.sel:
+            selName = "DYclass"
+        if "ttHclass" in args.sel:
+            selName = "ttHclass"
+        if "TTlepclass" in args.sel:
+            selName = "TTlepclass"
+        if "TThadclass" in args.sel:
+            selName = "TThadclass"
     else:
-            selName = args.name
+        selName = args.name
 
     selBox = TLatex  (l + 0.04 , 1 - t - 0.02 - 0.06, selName)
     selBox.SetNDC()
@@ -920,13 +912,13 @@ if __name__ == "__main__" :
     selBox.Draw()
     
     ###################### BLINDING BOX ###############################
-    if args.blindrange:
-        blow = float(args.blindrange[0])
-        bup = float(args.blindrange[1])
-        bBox = TBox (blow, ymin, bup, 0.93*ymax)
-        bBox.SetFillStyle(3002) # NB: does not appear the same in displayed box and printed pdf!!
-        bBox.SetFillColor(kGray+2) # NB: does not appear the same in displayed box and printed pdf!!
-        bBox.Draw()
+    #if args.blindrange:
+    #    blow = float(args.blindrange[0])
+    #    bup = float(args.blindrange[1])
+    #    bBox = TBox (blow, ymin, bup, 0.93*ymax)
+    #    bBox.SetFillStyle(3002) # NB: does not appear the same in displayed box and printed pdf!!
+    #    bBox.SetFillColor(kGray+2) # NB: does not appear the same in displayed box and printed pdf!!
+    #    bBox.Draw()
 
     ###################### S/(S+B) PLOT #################################
     if args.sbs:
@@ -1046,10 +1038,10 @@ if __name__ == "__main__" :
         hRatio.SetStats(0)
         #hRatio.SetMinimum(0.85)
         #hRatio.SetMaximum(1.15)
-        #hRatio.SetMinimum(0.6) #default value
-        #hRatio.SetMaximum(1.4) #default value
-        hRatio.SetMinimum(0.7) #TESI
-        hRatio.SetMaximum(1.25) #TESI
+        hRatio.SetMinimum(0.6) #default value
+        hRatio.SetMaximum(1.4) #default value
+        #hRatio.SetMinimum(0.0) #TESI
+        #hRatio.SetMaximum(2.0) #TESI
 
         removeEmptyPoints (grRatio)
         hRatio.Draw("axis")
@@ -1082,7 +1074,12 @@ if __name__ == "__main__" :
         tagch = ""
         if args.channel:
             tagch = "_" + args.channel
-        saveName = "./plots_"+args.channel+"/"+args.tag+"/"+args.sel+"_"+args.reg+"/plot_" + args.var + "_" + args.sel +"_" + args.reg+ tagch
+        if not args.binwidth:
+            tagch += "_noBinWidt"
+        if "class" in args.sel:
+            saveName = "./plots_"+args.channel+"/"+args.tag+"/scores_"+args.reg+"/plot_" + args.var + "_" + args.sel +"_" + args.reg+ tagch
+        else:
+            saveName = "./plots_"+args.channel+"/"+args.tag+"/"+args.sel+"_"+args.reg+"/plot_" + args.var + "_" + args.sel +"_" + args.reg+ tagch
         if args.log:
             saveName = saveName+"_log"
         if args.flat:

--- a/scripts/makePlotsFinal_Legacy2016.sh
+++ b/scripts/makePlotsFinal_Legacy2016.sh
@@ -1,19 +1,19 @@
-tag=2016_6June2020
+tag=2016_17Nov2020_plots
 
 log=(--log)
 
 plotter=makeFinalPlots_Legacy2016.py
 
-channel=TauTau
+#channel=TauTau
 #channel=MuTau
-#channel=ETau
+channel=ETau
 #channel=MuMu
 
 lumi=35.92
 
 reg=SR  # A:SR , B:SStight , C:OSinviso, D:SSinviso, B': SSrlx
 
-baseline=baseline  # baseline, s1b1jresolved, s2b0jresolved, sboostedLL, baseline_noQCD, baseline_MTT
+baseline=baselineMcut  # baseline, baselineMcut, s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose, baseline_noQCD, baseline_MTT, VBFclass
 
 others=""
 
@@ -23,48 +23,40 @@ mkdir plots_$channel
 mkdir plots_$channel/$tag
 mkdir plots_$channel/$tag/$baseline\_$reg
 
-#VARS: dau1_pt, dau2_pt, dau1_eta, dau2_eta, bjet1_pt, bjet2_pt, tauH_mass, tauH_SVFIT_mass, ditau_deltaR, tauH_pt, tauH_SVFIT_pt, bH_mass, bH_pt, HH_mass_raw, HH_pt
-
 #for i in `seq 0 1`; # 1:noLog  - 0:Log
 for i in `seq 1`;
 do
   #
   ## Hbb
   #
-    python scripts/$plotter --dir analysis_$channel\_$tag --var bjet1_pt   --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(b_{1}) [GeV]" $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var bjet2_pt   --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(b_{2}) [GeV]" $sigDrawer $others --quit
-
-   python scripts/$plotter --dir analysis_$channel\_$tag --var bH_mass  --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "m_{bb}^{vis} [GeV]" $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var bH_pt   --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(bb)^{vis} [GeV]" $sigDrawer $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var bjet1_bID_deepFlavor  --reg $reg --sel $baseline --channel $channel --name $baseline --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "b_{1} DeepFlavor" $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var bjet2_bID_deepFlavor  --reg $reg --sel $baseline --channel $channel --name $baseline --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "b_{2} DeepFlavor" $others --quit
 
   #
   ## Htautau
   #
-    python scripts/$plotter --dir analysis_$channel\_$tag --var dau1_pt         --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(#tau_{1}) [GeV]" $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var dau2_pt         --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(#tau_{2}) [GeV]" $sigDrawer $others --quit
-
-    python scripts/$plotter --dir analysis_$channel\_$tag --var dau1_eta        --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "#eta_{#tau1}" $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var dau2_eta        --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "#eta_{#tau2}" $sigDrawer $others --quit
-
-    python scripts/$plotter --dir analysis_$channel\_$tag --var tauH_SVFIT_mass --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "m_{#tau#tau}^{SVfit} [GeV]" $sigDrawer $others --quit
-
-    python scripts/$plotter --dir analysis_$channel\_$tag --var tauH_mass       --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "m_{#tau#tau}^{vis} [GeV]" $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var tauH_pt       --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(#tau#tau)^{vis} [GeV]" $sigDrawer $others --quit
-
-
-    python scripts/$plotter --dir analysis_$channel\_$tag --var ditau_deltaR         --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "#DeltaR_{#tau#tau}" $sigDrawer $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var dau1_pt         --reg $reg --sel $baseline --channel $channel --name $baseline --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(#tau_{1}) [GeV]" $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var dau1_eta        --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "#eta_{#tau1}" $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var tauH_SVFIT_mass --reg $reg --sel $baseline --channel $channel --name $baseline --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "m_{#tau#tau}^{SVfit} [GeV]" $others --quit
 
   #
-  ## HH
+  ## DNN scores
   #
-    python scripts/$plotter --dir analysis_$channel\_$tag --var HH_mass_raw  --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "m_{HH}^{vis} [GeV]" $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var HH_pt    --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(HH)^{vis} [GeV]" $sigDrawer $others --quit
-
-
+    python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[0]} --ratio --tag $tag --label "DNN score" $others --blind-range 0.6 1.0 --quit
 
 done
 
 
-
-
-
+### scores
+##
+#mkdir plots_$channel/$tag/scores_$reg
+##
+##
+### VBF score
+### GGFclass, VBFclass, ttHclass, TTlepclass, TThadclass, DYclass
+#python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel GGFclass   --channel $channel --name GGFclass   --lymin 0.7 --lumi $lumi ${log[0]} --ratio --tag $tag --label "DNN score" $others --blind-range 0.6 1.0 --quit
+#python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel VBFclass   --channel $channel --name VBFclass   --lymin 0.7 --lumi $lumi ${log[0]} --ratio --tag $tag --label "DNN score" $others --blind-range 0.6 1.0 --quit
+#python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel ttHclass   --channel $channel --name ttHclass   --lymin 0.7 --lumi $lumi ${log[0]} --ratio --tag $tag --label "DNN score" $others --blind-range 0.6 1.0 --quit
+#python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel TTlepclass --channel $channel --name TTlepclass --lymin 0.7 --lumi $lumi ${log[0]} --ratio --tag $tag --label "DNN score" $others --blind-range 0.6 1.0 --quit
+#python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel TThadclass --channel $channel --name TThadclass --lymin 0.7 --lumi $lumi ${log[0]} --ratio --tag $tag --label "DNN score" $others --blind-range 0.6 1.0 --quit
+#python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel DYclass    --channel $channel --name DYclass    --lymin 0.7 --lumi $lumi ${log[0]} --ratio --tag $tag --label "DNN score" $others --blind-range 0.6 1.0 --quit

--- a/scripts/makePlotsFinal_Legacy2017.sh
+++ b/scripts/makePlotsFinal_Legacy2017.sh
@@ -1,14 +1,4 @@
-#tag=23Jan2020
-#tag=23Jan2020_invQCD
-#tag=27Jan2020_noTauIDSF
-#tag=08May2020_SecondProd_FirstSkim_Second_InvQCD
-#tag=08May2020
-#tag=08May2020_SecondProd_FirstSkim_Third_InvQCD_pTBinnedTauIDSF
-#tag=08May2020_SecondProd_FirstSkim_Fourth_InvQCD_homeMadeTauIDSF
-#tag=08May2020_SecondProd_FirstSkim_Fifth_InvQCD_noTauIDSF
-#tag=08May2020_SecondProd_FirstSkim_Sixth_InvQCD_noDYMTTSF
-#tag=08May2020_SecondProd_FirstSkim_Seventh_InvQCD_specialMerging
-tag=Legacy2017_15June2020_pt_Dep_SF
+tag=2017_17Nov2020_plots
 
 log=(--log)
 
@@ -23,18 +13,7 @@ lumi=41.529
 
 reg=SR  # A:SR , B:SStight , C:OSinviso, D:SSinviso, B': SSrlx
 
-baseline=baseline
-#baseline=s1b1jresolved
-#baseline=s2b0jresolved
-#baseline=sboostedLL
-#baseline=VBFloose
-#baseline=baseline_MTT
-#baseline=baseline40to70
-#baseline=baseline70
-#baseline=baseline_both0
-#baseline=baseline_both1
-#baseline=baseline_both10
-#baseline=baseline_both11
+baseline=sboostedLLMcut  # baseline, baselineMcut, s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, VBFloose, baseline_noQCD, baseline_MTT, VBFclass
 
 others=""
 
@@ -44,47 +23,46 @@ mkdir plots_$channel
 mkdir plots_$channel/$tag
 mkdir plots_$channel/$tag/$baseline\_$reg
 
-#VARS: dau1_pt, dau2_pt, dau1_eta, dau2_eta, bjet1_pt, bjet2_pt, tauH_mass, tauH_SVFIT_mass, ditau_deltaR, tauH_pt, bH_pt, bH_mass
-
 #for i in `seq 0 1`; # 1:noLog  - 0:Log
 for i in `seq 1`;
 do
   #
   ## Hbb
   #
-    python scripts/$plotter --dir analysis_$channel\_$tag --var bjet1_pt               --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(b_{1}) [GeV]" $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var bjet2_pt               --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(b_{2}) [GeV]" $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var bjet1_bID_deepFlavor   --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "bjet1_deepFlavor"   $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var bjet2_bID_deepFlavor   --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "bjet2_deepFlavor"   $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var bH_pt                  --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T} [GeV]"        $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var bH_mass                --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "m_{bb} [GeV]"       $sigDrawer $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var bjet1_eta              --reg $reg --sel $baseline --channel $channel --name $baseline --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "#eta_{b_{1}}"       $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var bjet2_eta              --reg $reg --sel $baseline --channel $channel --name $baseline --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "#eta_{b_{2}}"       $others --quit
+
+    python scripts/$plotter --dir analysis_$channel\_$tag --var bjet1_pt               --reg $reg --sel $baseline --channel $channel --name $baseline --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(b_{1}) [GeV]" $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var bjet2_pt               --reg $reg --sel $baseline --channel $channel --name $baseline --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(b_{2}) [GeV]" $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var bjet1_bID_deepFlavor   --reg $reg --sel $baseline --channel $channel --name $baseline --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "b_{1} DeepFlavor"   $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var bjet2_bID_deepFlavor   --reg $reg --sel $baseline --channel $channel --name $baseline --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "b_{2} DeepFlavor"   $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var bH_mass                --reg $reg --sel $baseline --channel $channel --name $baseline --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "m_{bb} [GeV]"       $others --quit
 
   #
   ## Htautau
   #
-    python scripts/$plotter --dir analysis_$channel\_$tag --var dau1_pt         --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(#tau_{1}) [GeV]" $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var dau2_pt         --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(#tau_{2}) [GeV]" $sigDrawer $others --quit
-
-    python scripts/$plotter --dir analysis_$channel\_$tag --var dau1_eta        --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "#eta_{#tau1}"          $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var dau2_eta        --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "#eta_{#tau2}"          $sigDrawer $others --quit
-
-    python scripts/$plotter --dir analysis_$channel\_$tag --var tauH_SVFIT_mass --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "m_{#tau#tau}^{SVfit} [GeV]" $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var tauH_mass       --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "m_{#tau#tau}^{vis} [GeV]"  $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var tauH_pt         --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T#tau#tau}^{vis} [GeV]" $sigDrawer $others --quit
-
-    python scripts/$plotter --dir analysis_$channel\_$tag --var ditau_deltaR    --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "#DeltaR_{#tau#tau}"          $sigDrawer $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var dau1_pt         --reg $reg --sel $baseline --channel $channel --name $baseline --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "p_{T}(#tau_{1}) [GeV]"      $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var dau1_eta        --reg $reg --sel $baseline --channel $channel --name $baseline --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "#eta_{#tau1}"               $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var tauH_SVFIT_mass --reg $reg --sel $baseline --channel $channel --name $baseline --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "m_{#tau#tau}^{SVfit} [GeV]" $others --quit
 
   #
-  ## HH
+  ## DNN scores
   #
-    python scripts/$plotter --dir analysis_$channel\_$tag --var HH_mass_raw  --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag  --label "m_{bb#tau#tau} [GeV]" $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var HH_pt        --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag  --label "p_{T}(bb#tau#tau) [GeV]" $sigDrawer $others --quit
-
-  #
-  ## BDT OUTS 
-  #
-  
-    python scripts/$plotter --dir analysis_$channel\_$tag --var BDToutSM_kl_1 --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "BDT score (#tau#tau, k_{#lambda}=1)" $sigDrawer $others --quit
-    python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[i]} --ratio  --tag $tag --label "BDT score (#tau#tau, k_{#lambda}=1)" $sigDrawer $others --quit
+    python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi ${log[0]} --ratio --tag $tag --label "DNN score" $others --blind-range 0.6 1.0 --quit
 
 done
+
+
+### scores
+##
+#mkdir plots_$channel/$tag/scores_$reg
+##
+##
+### VBF score
+### GGFclass, VBFclass, ttHclass, TTlepclass, TThadclass, DYclass
+#python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel GGFclass   --channel $channel --name GGFclass   --lymin 0.7 --lumi $lumi ${log[0]} --ratio --tag $tag --label "DNN score" $others --blind-range 0.6 1.0 --quit
+#python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel VBFclass   --channel $channel --name VBFclass   --lymin 0.7 --lumi $lumi ${log[0]} --ratio --tag $tag --label "DNN score" $others --blind-range 0.6 1.0 --quit
+#python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel ttHclass   --channel $channel --name ttHclass   --lymin 0.7 --lumi $lumi ${log[0]} --ratio --tag $tag --label "DNN score" $others --blind-range 0.6 1.0 --quit
+#python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel TTlepclass --channel $channel --name TTlepclass --lymin 0.7 --lumi $lumi ${log[0]} --ratio --tag $tag --label "DNN score" $others --blind-range 0.6 1.0 --quit
+#python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel TThadclass --channel $channel --name TThadclass --lymin 0.7 --lumi $lumi ${log[0]} --ratio --tag $tag --label "DNN score" $others --blind-range 0.6 1.0 --quit
+#python scripts/$plotter --dir analysis_$channel\_$tag --var DNNoutSM_kl_1 --reg $reg --sel DYclass    --channel $channel --name DYclass    --lymin 0.7 --lumi $lumi ${log[0]} --ratio --tag $tag --label "DNN score" $others --blind-range 0.6 1.0 --quit

--- a/scripts/modules/OutputManager.py
+++ b/scripts/modules/OutputManager.py
@@ -255,9 +255,9 @@ class OutputManager:
 
                     # if var == 'MT2' and sel == 'defaultBtagLLNoIsoBBTTCut' : print ">> -- bkg - SHAPE: " , hname, hQCD.Integral()
     ## FIXME: how to treat systematics properly ? Do we need to do ann alternative QCD histo for every syst?
-    def makeQCD (self, SR, yieldSB, shapeSB, SBtoSRfactor, regionC, regionD, doFitIf='False', fitFunc='[0] + [1]*x', computeSBtoSR = True,QCDname='QCD', removeNegBins = True):
+    def makeQCD (self, SR, yieldSB, shapeSB, SBtoSRfactor, regionC, regionD, doFitIf='False', fitFunc='[0] + [1]*x', computeSBtoSR = True,QCDname='QCD', removeNegBins = True, doUpDown = False):
         
-        print "... building QCD w/ name:", QCDname, ". SR:" , SR, " yieldSB:", yieldSB, " shapeSB:", shapeSB, " SBtoSRfactor:", SBtoSRfactor
+        print "... building QCD w/ name:", QCDname, ". SR:" , SR, " yieldSB:", yieldSB, " shapeSB:", shapeSB, " SBtoSRfactor:", SBtoSRfactor, " doUpDown:", doUpDown
         print "    >> recompute SBtoSR dynamically? "
         if computeSBtoSR: 
             print "    >>  yes"
@@ -352,10 +352,22 @@ class OutputManager:
                     normaliz = hQCD.Integral()
                     hQCDCorr.Multiply(fFitFunc) # NOTE: multiplication is done in the function range, so it's important to set this properly before. Errors are propagated.
                     hQCDCorr.Scale(normaliz/hQCDCorr.Integral())
-                    self.histos[hQCDCorr.GetName()] = hQCDCorr
+                    if doUpDown:
+                        hQCDCorrup   = hQCD.Clone(hQCDCorr.GetName()+"_Up")
+                        hQCDCorrdown = hQCD.Clone(hQCDCorr.GetName()+"_Down")
+                        self.histos[hQCDCorr.GetName()+"_Up"]   = hQCDCorrup
+                        self.histos[hQCDCorr.GetName()+"_Down"] = hQCDCorrdown
+                    else:
+                        self.histos[hQCDCorr.GetName()] = hQCDCorr
 
                 ## store hQCD - is either 'QCD' if no fit was done or uncorrQCD if fit was done, in any case is the final one to plot
-                self.histos[hQCD.GetName()] = hQCD
+                if doUpDown:
+                    hQCDup   = hQCD.Clone(hQCD.GetName()+"_Up")
+                    hQCDdown = hQCD.Clone(hQCD.GetName()+"_Down")
+                    self.histos[hQCD.GetName()+"_Up"]   = hQCDup
+                    self.histos[hQCD.GetName()+"_Down"] = hQCDdown
+                else:
+                    self.histos[hQCD.GetName()] = hQCD
             
 
         ### FIXME: now do 2D histos

--- a/test/skimNtuple2017_HHbtag.cpp
+++ b/test/skimNtuple2017_HHbtag.cpp
@@ -4686,7 +4686,7 @@ int main (int argc, char** argv)
           // In our framework case 1. is the default: in the VBF trigger phase space (case 2.) the branch m_trigSF is overwritten
           // with the VBF_SF, because "trigSF" is the actual weight used later in the analysis
           if (isMC && pairType == 2 && theSmallTree.m_VBFjj_mass > 800 && theSmallTree.m_VBFjet1_pt > 140 && theSmallTree.m_VBFjet2_pt > 60 &&
-              theSmallTree.m_dau1_pt > 25 && theSmallTree.m_dau2_pt > 25 && theSmallTree.m_dau1_pt <= 40 && theSmallTree.m_dau2_pt <= 40)
+              theSmallTree.m_dau1_pt > 25 && theSmallTree.m_dau2_pt > 25 && (theSmallTree.m_dau1_pt <= 40 || theSmallTree.m_dau2_pt <= 40) )
           {
             // Jet legs SF
             double jetSF    = getContentHisto3D(VBFjets_SF, std::get<0>(*(VBFcand_Mjj.rbegin())), VBFjet1.Pt(), VBFjet2.Pt(), 0); // 0: central value

--- a/test/skimNtuple2018_HHbtag.cpp
+++ b/test/skimNtuple2018_HHbtag.cpp
@@ -4598,7 +4598,7 @@ int main (int argc, char** argv)
               // In our framework case 1. is the default: in the VBF trigger phase space (case 2.) the branch m_trigSF is overwritten
               // with the VBF_SF, because "trigSF" is the actual weight used later in the analysis
               if (isMC && pairType == 2 && theSmallTree.m_VBFjj_mass > 800 && theSmallTree.m_VBFjet1_pt > 140 && theSmallTree.m_VBFjet2_pt > 60 &&
-                  theSmallTree.m_dau1_pt > 25 && theSmallTree.m_dau2_pt > 25 && theSmallTree.m_dau1_pt <= 40 && theSmallTree.m_dau2_pt <= 40)
+                  theSmallTree.m_dau1_pt > 25 && theSmallTree.m_dau2_pt > 25 && (theSmallTree.m_dau1_pt <= 40 || theSmallTree.m_dau2_pt <= 40) )
               {
                 // Jet legs SF
                 double jetSF    = getContentHisto3D(VBFjets_SF, std::get<0>(*(VBFcand_Mjj.rbegin())), VBFjet1.Pt(), VBFjet2.Pt(), 0); // 0: central value


### PR DESCRIPTION
Updated `combineFillerOutputs.py` to include:
- QCD shifted: it is built using the "old" method (shape from B and correction factor from C/D), up and down variations are the same.
- New bTagReshape SFs need a rinormalization factor: since it's always the same for all events it can be factorized and applied on the final histogram. Different factors for each different bTagReshape systematic should be used, but until we compute all of them I will use the central value.

Configs
- Updated all `main` and `selection` configs to include 
   - the bTagReshape weights
   - VBF trigger jets legs ucnertainties in tautau 2017 and 2018
- For the moment uncertainties on the bTagReshape SFs are commented out