### PR TITLE
2017 Jet cleaning

### DIFF
--- a/interface/PuJetIdSF.h
+++ b/interface/PuJetIdSF.h
@@ -44,7 +44,7 @@ class PuJetIdSF {
     float getSF     (bool isReal, float pt, float eta);
     float getSFError(bool isReal, float pt, float eta);
 
-    std::vector<float> getEvtWeight (bigTree &theBigTree, TLorentzVector tau1, TLorentzVector tau2);
+    std::vector<float> getEvtWeight (bigTree &theBigTree, TLorentzVector tau1, TLorentzVector tau2, bool cleanJets=false);
 
   private:
     TH2F* h_eff_;

--- a/src/PuJetIdSF.cc
+++ b/src/PuJetIdSF.cc
@@ -197,7 +197,7 @@ float PuJetIdSF::getSFError(bool isReal, float pt, float eta)
 }
 
 //getEvtWeight - Returns a vector with {central SF, SF_up, SF_down}
-std::vector<float> PuJetIdSF::getEvtWeight(bigTree &theBigTree, TLorentzVector tau1, TLorentzVector tau2)
+std::vector<float> PuJetIdSF::getEvtWeight(bigTree &theBigTree, TLorentzVector tau1, TLorentzVector tau2, bool cleanJets)
 {
   // Weight for each event
   std::vector<float> eventWeight(3);
@@ -224,6 +224,10 @@ std::vector<float> PuJetIdSF::getEvtWeight(bigTree &theBigTree, TLorentzVector t
     if (TMath::Abs(tlv_jet.Eta()) > 4.7) continue;
     if (tlv_jet.DeltaR(tau1) < 0.5) continue;
     if (tlv_jet.DeltaR(tau2) < 0.5) continue;
+
+    // Apply further cleaning for 2017 noisy jets, as suggested by HTT group: https://twiki.cern.ch/twiki/bin/view/CMS/HiggsToTauTauWorkingLegacyRun2#Jets
+    // The noisy jets to be removed are defined as: 20 < pt < 50 && abs(eta) > 2.65 && abs(eta) < 3.139
+    if (cleanJets && TMath::Abs(tlv_jet.Eta()) > 2.65 && TMath::Abs(tlv_jet.Eta()) < 3.139) continue;
 
     // Build genJet and check if it is matched
     bool isRealJet = false;

--- a/test/skimNtuple2017_HHbtag.cpp
+++ b/test/skimNtuple2017_HHbtag.cpp
@@ -3650,7 +3650,7 @@ int main (int argc, char** argv)
 
             // Apply further cleaning for 2017 noisy jets, as suggested by HTT group: https://twiki.cern.ch/twiki/bin/view/CMS/HiggsToTauTauWorkingLegacyRun2#Jets
             // The noisy jets to be removed are defined as: 20 < pt < 50 && abs(eta) > 2.65 && abs(eta) < 3.139
-            //if ( ijet.Pt()<50. && fabs(ijet.Eta())>2.65 && fabs(ijet.Eta()<3.139) ) continue; //Commented during March20 sync
+            if ( ijet.Pt()<50. && fabs(ijet.Eta())>2.65 && fabs(ijet.Eta())<3.139 ) continue;
 
             for (unsigned int kJet = iJet+1 ;   (kJet < theBigTree.jets_px->size ()) && (theSmallTree.m_njets < maxNjetsSaved) ;  ++kJet)
             {
@@ -3683,7 +3683,7 @@ int main (int argc, char** argv)
 
               // Apply further cleaning for 2017 noisy jets, as suggested by HTT group: https://twiki.cern.ch/twiki/bin/view/CMS/HiggsToTauTauWorkingLegacyRun2#Jets
               // The noisy jets to be removed are defined as: 20 < pt < 50 && abs(eta) > 2.65 && abs(eta) < 3.139
-              //if ( kjet.Pt()<50. && fabs(kjet.Eta())>2.65 && fabs(kjet.Eta()<3.139) ) continue; //Commented during March20 sync
+              if ( kjet.Pt()<50. && fabs(kjet.Eta())>2.65 && fabs(kjet.Eta())<3.139 ) continue;
 
               TLorentzVector jetPair = ijet+kjet;
               VBFcand_Mjj.push_back(make_tuple(jetPair.M(),iJet,kJet));
@@ -4054,7 +4054,7 @@ int main (int argc, char** argv)
 
           // Apply further cleaning for 2017 noisy jets, as suggested by HTT group: https://twiki.cern.ch/twiki/bin/view/CMS/HiggsToTauTauWorkingLegacyRun2#Jets
           // The noisy jets to be removed are defined as: 20 < pt < 50 && abs(eta) > 2.65 && abs(eta) < 3.139
-          //if ( tlv_jet.Pt()<50. && fabs(tlv_jet.Eta())>2.65 && fabs(tlv_jet.Eta()<3.139) ) continue; //Commented during March20 sync
+          if ( tlv_jet.Pt()<50. && fabs(tlv_jet.Eta())>2.65 && fabs(tlv_jet.Eta())<3.139 ) continue;
 
           // use these jets for HT
           if (tlv_jet.Pt () > 20)
@@ -4772,7 +4772,7 @@ int main (int argc, char** argv)
 
           // Apply further cleaning for 2017 noisy jets, as suggested by HTT group: https://twiki.cern.ch/twiki/bin/view/CMS/HiggsToTauTauWorkingLegacyRun2#Jets
           // The noisy jets to be removed are defined as: 20 < pt < 50 && abs(eta) > 2.65 && abs(eta) < 3.139
-          //if ( tlv_dummyJet.Pt()<50. && fabs(tlv_dummyJet.Eta())>2.65 && fabs(tlv_dummyJet.Eta()<3.139) ) continue; //Commented during March20 sync
+          if ( tlv_dummyJet.Pt()>20. && tlv_dummyJet.Pt()<50. && fabs(tlv_dummyJet.Eta())>2.65 && fabs(tlv_dummyJet.Eta())<3.139 ) continue;
 
           // remove jets that overlap with the tau selected in the leg 1 and 2
           if (tlv_firstLepton.DeltaR(tlv_dummyJet) < lepCleaningCone){
@@ -4852,7 +4852,7 @@ int main (int argc, char** argv)
       // PUjetIDSFprovider
       if (isMC)
       {
-        std::vector<float> PUjetID_SF_values = PUjetIDSFprovider.getEvtWeight(theBigTree, tlv_firstLepton, tlv_secondLepton);
+        std::vector<float> PUjetID_SF_values = PUjetIDSFprovider.getEvtWeight(theBigTree, tlv_firstLepton, tlv_secondLepton, true);
         theSmallTree.m_PUjetID_SF      = PUjetID_SF_values.at(0);
         theSmallTree.m_PUjetID_SF_up   = PUjetID_SF_values.at(1);
         theSmallTree.m_PUjetID_SF_down = PUjetID_SF_values.at(2);
@@ -4982,6 +4982,7 @@ int main (int argc, char** argv)
 
         // Kinematic selections + lepton cleaning
         if (tlv_additionalJet.Pt() < 20.) continue ;
+
         if (tlv_additionalJet.DeltaR(tlv_firstLepton)  < lepCleaningCone) continue ;
         if (tlv_additionalJet.DeltaR(tlv_secondLepton) < lepCleaningCone) continue ;
 
@@ -4990,6 +4991,10 @@ int main (int argc, char** argv)
         {
           if ( !(CheckBit(theBigTree.jets_PUJetIDupdated_WP->at(iJet), PUjetID_WP)) && tlv_additionalJet.Pt()<50.) continue;
         }
+
+        // Apply further cleaning for 2017 noisy jets, as suggested by HTT group: https://twiki.cern.ch/twiki/bin/view/CMS/HiggsToTauTauWorkingLegacyRun2#Jets
+        // The noisy jets to be removed are defined as: 20 < pt < 50 && abs(eta) > 2.65 && abs(eta) < 3.139
+        if ( tlv_additionalJet.Pt()<50. && fabs(tlv_additionalJet.Eta())>2.65 && fabs(tlv_additionalJet.Eta())<3.139 ) continue;
 
         // get up/down uncertainty for this additional jet
         pair <vector <double>, vector<double>> unc_additionalJet_updown = getJetUpDown(iJet, theBigTree);
@@ -5243,6 +5248,10 @@ int main (int argc, char** argv)
         // remove jets that overlap with the tau selected in the leg 1 and 2
         if (tlv_firstLepton.DeltaR(tlv_dummyJet)  < lepCleaningCone) continue;
         if (tlv_secondLepton.DeltaR(tlv_dummyJet) < lepCleaningCone) continue;
+
+        // Apply further cleaning for 2017 noisy jets, as suggested by HTT group: https://twiki.cern.ch/twiki/bin/view/CMS/HiggsToTauTauWorkingLegacyRun2#Jets
+        // The noisy jets to be removed are defined as: 20 < pt < 50 && abs(eta) > 2.65 && abs(eta) < 3.139
+        if ( tlv_dummyJet.Pt()>20. && tlv_dummyJet.Pt()<50. && fabs(tlv_dummyJet.Eta())>2.65 && fabs(tlv_dummyJet.Eta())<3.139 ) continue;
 
         if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end())
         {

--- a/test/skimOutputter_HHbtag.cpp
+++ b/test/skimOutputter_HHbtag.cpp
@@ -197,7 +197,7 @@ int main (int argc, char** argv)
 
   "MC_weight","PUReweight","PUjetID_SF*","L1pref_weight*",             // Weights and SFs
   "prescaleWeight","trigSF*","VBFtrigSF","customTauIdSF*",
-  "DYscale_MTT*","DYscale_MH","bTagweightM*","bTagweightL*",
+  "DYscale_MTT*","DYscale_MH","bTagweight*",
   "IdAndIsoAndFakeSF_deep","IdAndIsoAndFakeSF_deep_pt",
   "TTtopPtreweight*","idAndIsoAndFakeSF_tauid*",
   "idAndIsoAndFakeSF_mutauFR*","idAndIsoAndFakeSF_etauFR*",


### PR DESCRIPTION
Restored jet cleaning at high eta (~3) following JetMET and HTT recommendations:
`In 2017, the noisy jets should be removed. The noisy jets are defined as: 20 < pt < 50 && abs(eta) > 2.65 && abs(eta) < 3.139. Nothing should be removed in 2016 nor 2018.`
https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsToTauTauWorkingLegacyRun2#Jets