### PR TITLE
Switch from deepTauVsJet VVLoose WP to VVVLooseWP for QCD estimation

### DIFF
--- a/config/mainCfg_ETau_Legacy2016_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2016_limits.cfg
@@ -104,7 +104,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.053
+classSBtoSR  = 0.037
 
 
 [bTagRfactor]

--- a/config/mainCfg_ETau_Legacy2017_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2017_limits.cfg
@@ -104,7 +104,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.100
+classSBtoSR  = 0.053
 
 
 [bTagRfactor]

--- a/config/mainCfg_ETau_Legacy2018_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2018_limits.cfg
@@ -102,7 +102,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.121
+classSBtoSR  = 0.070
 
 
 [bTagRfactor]

--- a/config/mainCfg_MuTau_Legacy2016_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2016_limits.cfg
@@ -103,7 +103,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.142
+classSBtoSR  = 0.066
 
 
 [bTagRfactor]

--- a/config/mainCfg_MuTau_Legacy2017_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2017_limits.cfg
@@ -104,7 +104,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.115
+classSBtoSR  = 0.059
 
 
 [bTagRfactor]

--- a/config/mainCfg_MuTau_Legacy2018_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2018_limits.cfg
@@ -104,7 +104,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.214
+classSBtoSR  = 0.099
 
 
 [bTagRfactor]

--- a/config/mainCfg_TauTau_Legacy2016_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2016_limits.cfg
@@ -103,8 +103,8 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-boostSBtoSR  = 0.042
-classSBtoSR  = 0.148
+boostSBtoSR  = 0.019
+classSBtoSR  = 0.089
 
 
 [bTagRfactor]

--- a/config/mainCfg_TauTau_Legacy2017_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2017_limits.cfg
@@ -104,8 +104,8 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-boostSBtoSR  = 0.275
-classSBtoSR  = 0.121
+boostSBtoSR  = 0.164
+classSBtoSR  = 0.070
 
 
 [bTagRfactor]

--- a/config/mainCfg_TauTau_Legacy2018_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2018_limits.cfg
@@ -104,8 +104,8 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-boostSBtoSR  = 0.083
-classSBtoSR  = 0.144
+boostSBtoSR  = 0.049
+classSBtoSR  = 0.083
 
 
 [bTagRfactor]

--- a/config/selectionCfg_ETau_Legacy2016.cfg
+++ b/config/selectionCfg_ETau_Legacy2016.cfg
@@ -37,10 +37,10 @@ ellypsMassCut2 = ((tauH_SVFIT_mass-129.)*(tauH_SVFIT_mass-129.))/(53.*53.) + ((b
 # ABCD regions used in the analysis - DeepTau
 SR           = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 5                          # signal region: opposite sign, isolated taus
 SStight      = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 5                          # B region
-OSrlx        = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2
-SSrlx        = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2                          # B' region
-OSinviso     = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # C region
-SSinviso     = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # D region
+OSrlx        = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 1
+SSrlx        = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 1                          # B' region
+OSinviso     = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5 # C region
+SSinviso     = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5 # D region
 
 # final categories without masscut
 s2b0jresolved = baseline , btagMM, isBoosted != 1, !(isVBF == 1 && VBFjj_mass > 500 && VBFjj_deltaEta > 3 && ((bjet1_bID_deepFlavor > 0.3093) || (bjet2_bID_deepFlavor > 0.3093)))

--- a/config/selectionCfg_ETau_Legacy2017.cfg
+++ b/config/selectionCfg_ETau_Legacy2017.cfg
@@ -44,10 +44,10 @@ ellypsMassCut2 = ((tauH_SVFIT_mass-129.)*(tauH_SVFIT_mass-129.))/(53.*53.) + ((b
 # ABCD regions used in the analysis - DeepTau
 SR           = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 5                          # signal region: opposite sign, isolated taus
 SStight      = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 5                          # B region
-OSrlx        = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2
-SSrlx        = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2                          # B' region
-OSinviso     = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # C region
-SSinviso     = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # D region
+OSrlx        = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 1
+SSrlx        = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 1                          # B' region
+OSinviso     = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5 # C region
+SSinviso     = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5 # D region
 
 # final categories without masscut
 s2b0jresolved = baseline , btagMM, isBoosted != 1, !(isVBF == 1 && VBFjj_mass > 500 && VBFjj_deltaEta > 3 && (bjet1_bID_deepFlavor > 0.3033 || bjet2_bID_deepFlavor > 0.3033) )

--- a/config/selectionCfg_ETau_Legacy2018.cfg
+++ b/config/selectionCfg_ETau_Legacy2018.cfg
@@ -35,10 +35,10 @@ ellypsMassCut2 = ((tauH_SVFIT_mass-129.)*(tauH_SVFIT_mass-129.))/(53.*53.) + ((b
 # ABCD regions used in the analysis - DeepTau
 SR           = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 5                          # signal region: opposite sign, isolated taus
 SStight      = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 5                          # B region
-OSrlx        = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2
-SSrlx        = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2                          # B' region
-OSinviso     = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # C region
-SSinviso     = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # D region
+OSrlx        = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 1
+SSrlx        = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 1                          # B' region
+OSinviso     = isOS != 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5 # C region
+SSinviso     = isOS == 0 && dau1_eleMVAiso == 1 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5 # D region
 
 # final categories without masscut
 s2b0jresolved = baseline , btagMM, isBoosted != 1, !(isVBF == 1 && VBFjj_mass > 500 && VBFjj_deltaEta > 3 && (bjet1_bID_deepFlavor > 0.2770 || bjet2_bID_deepFlavor > 0.2770) )

--- a/config/selectionCfg_MuTau_Legacy2016.cfg
+++ b/config/selectionCfg_MuTau_Legacy2016.cfg
@@ -39,10 +39,10 @@ ellypsMassCut2 = ((tauH_SVFIT_mass-129.)*(tauH_SVFIT_mass-129.))/(53.*53.) + ((b
 # ABCD regions used in the analysis - DeepTau
 SR           = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 5                            # signal region: opposite sign, isolated taus
 SStight      = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 5                            # B region
-OSrlx        = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 2
-SSrlx        = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 2                            # B' region
-OSinviso     = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5   # C region
-SSinviso     = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5   # D region
+OSrlx        = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 1
+SSrlx        = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 1                            # B' region
+OSinviso     = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5   # C region
+SSinviso     = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5   # D region
 
 # final categories without masscut
 s2b0jresolved = baseline , btagMM, isBoosted != 1, !(isVBF == 1 && VBFjj_mass > 500 && VBFjj_deltaEta > 3 && ((bjet1_bID_deepFlavor > 0.3093) || (bjet2_bID_deepFlavor > 0.3093)))

--- a/config/selectionCfg_MuTau_Legacy2017.cfg
+++ b/config/selectionCfg_MuTau_Legacy2017.cfg
@@ -44,10 +44,10 @@ ellypsMassCut2 = ((tauH_SVFIT_mass-129.)*(tauH_SVFIT_mass-129.))/(53.*53.) + ((b
 # ABCD regions used in the analysis - DeepTau
 SR           = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 5                          # signal region: opposite sign, isolated taus
 SStight      = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 5                          # B region
-OSrlx        = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 2
-SSrlx        = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 2                          # B' region
-OSinviso     = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # C region
-SSinviso     = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # D region
+OSrlx        = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 1
+SSrlx        = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 1                          # B' region
+OSinviso     = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5 # C region
+SSinviso     = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5 # D region
 
 # final categories without masscut
 s2b0jresolved = baseline , btagMM, isBoosted != 1, !(isVBF == 1 && VBFjj_mass > 500 && VBFjj_deltaEta > 3 && (bjet1_bID_deepFlavor > 0.3033 || bjet2_bID_deepFlavor > 0.3033) )

--- a/config/selectionCfg_MuTau_Legacy2018.cfg
+++ b/config/selectionCfg_MuTau_Legacy2018.cfg
@@ -40,10 +40,10 @@ ellypsMassCut2 = ((tauH_SVFIT_mass-129.)*(tauH_SVFIT_mass-129.))/(53.*53.) + ((b
 # ABCD regions used in the analysis - DeepTau
 SR           = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 5                            # signal region: opposite sign, isolated taus
 SStight      = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 5                            # B region
-OSrlx        = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 2
-SSrlx        = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 2                            # B' region
-OSinviso     = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5   # C region
-SSinviso     = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5   # D region
+OSrlx        = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 1
+SSrlx        = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 1                            # B' region
+OSinviso     = isOS != 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5   # C region
+SSinviso     = isOS == 0 && dau1_iso < 0.15 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5   # D region
 
 # final categories without masscut
 s2b0jresolved = baseline , btagMM, isBoosted != 1, !(isVBF == 1 && VBFjj_mass > 500 && VBFjj_deltaEta > 3 && (bjet1_bID_deepFlavor > 0.2770 || bjet2_bID_deepFlavor > 0.2770) )

--- a/config/selectionCfg_TauTau_Legacy2016.cfg
+++ b/config/selectionCfg_TauTau_Legacy2016.cfg
@@ -32,10 +32,10 @@ ellypsMassCut2 = ((tauH_SVFIT_mass-129.)*(tauH_SVFIT_mass-129.))/(53.*53.) + ((b
 # ABCD regions used in the analysis - DeepTau
 SR           = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 5                           # signal region: opposite sign, isolated taus
 SStight      = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 5                           # B region
-OSrlx        = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 2
-SSrlx        = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 2                           # B' region
-OSinviso     = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5  # C region
-SSinviso     = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5  # D region
+OSrlx        = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 1
+SSrlx        = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 1                           # B' region
+OSinviso     = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5  # C region
+SSinviso     = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5  # D region
 
 # final categories without masscut
 s2b0jresolved = baseline , btagMM, isBoosted != 1, !(isVBF == 1 && VBFjj_mass > 500 && VBFjj_deltaEta > 3 && ((bjet1_bID_deepFlavor > 0.3093) || (bjet2_bID_deepFlavor > 0.3093)))

--- a/config/selectionCfg_TauTau_Legacy2017.cfg
+++ b/config/selectionCfg_TauTau_Legacy2017.cfg
@@ -37,10 +37,10 @@ ellypsMassCut2 = ((tauH_SVFIT_mass-129.)*(tauH_SVFIT_mass-129.))/(53.*53.) + ((b
 # ABCD regions used in the analysis - DeepTau
 SR           = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 5                          # signal region: opposite sign, isolated taus
 SStight      = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 5                          # B region
-OSrlx        = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 2
-SSrlx        = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 2                          # B' region
-OSinviso     = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # C region
-SSinviso     = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5 # D region
+OSrlx        = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 1
+SSrlx        = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 1                          # B' region
+OSinviso     = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5 # C region
+SSinviso     = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5 # D region
 
 # final categories without masscut
 s2b0jresolved = baseline , btagMM, isBoosted != 1, !(isVBF == 1 && VBFjj_mass > 500 && VBFjj_deltaEta > 3 && (bjet1_bID_deepFlavor > 0.3033 || bjet2_bID_deepFlavor > 0.3033) )

--- a/config/selectionCfg_TauTau_Legacy2018.cfg
+++ b/config/selectionCfg_TauTau_Legacy2018.cfg
@@ -34,10 +34,10 @@ ellypsMassCut2 = ((tauH_SVFIT_mass-129.)*(tauH_SVFIT_mass-129.))/(53.*53.) + ((b
 # ABCD regions used in the analysis - DeepTau
 SR           = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 5                           # signal region: opposite sign, isolated taus
 SStight      = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 5                           # B region
-OSrlx        = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 2
-SSrlx        = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 2                           # B' region
-OSinviso     = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5  # C region
-SSinviso     = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 2 && dau2_deepTauVsJet < 5  # D region
+OSrlx        = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 1
+SSrlx        = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 1                           # B' region
+OSinviso     = isOS != 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5  # C region
+SSinviso     = isOS == 0 && dau1_deepTauVsJet >= 5 && dau2_deepTauVsJet >= 1 && dau2_deepTauVsJet < 5  # D region
 
 # final categories without masscut
 s2b0jresolved = baseline , btagMM, isBoosted != 1, !(isVBF == 1 && VBFjj_mass > 500 && VBFjj_deltaEta > 3 && (bjet1_bID_deepFlavor > 0.2770 || bjet2_bID_deepFlavor > 0.2770) )

--- a/config/systematics_QCD2016.cfg
+++ b/config/systematics_QCD2016.cfg
@@ -23,7 +23,7 @@ unc1 = CMS_bbtautau_2016_QCDratio:1.076
 #############
 ### res2b ###
 #############
-[ETau_res2b] # No uncertainty, just here for correct parsing
+[ETau_res2b]
 unc1 = CMS_bbtautau_2016_QCDratio:1.728
 unc2 = CMS_bbtautau_2016_QCDadditional:5.089
 

--- a/config/systematics_QCD2016.cfg
+++ b/config/systematics_QCD2016.cfg
@@ -11,26 +11,27 @@
 ### res1b ###
 #############
 [ETau_res1b]
-unc1 = CMS_bbtautau_2016_QCDratio:1.219
+unc1 = CMS_bbtautau_2016_QCDratio:1.214
 
 [MuTau_res1b]
-unc1 = CMS_bbtautau_2016_QCDratio:1.070
+unc1 = CMS_bbtautau_2016_QCDratio:1.068
 
 [TauTau_res1b]
-unc1 = CMS_bbtautau_2016_QCDratio:1.077
-unc2 = CMS_bbtautau_2016_QCDadditional:1.026
+unc1 = CMS_bbtautau_2016_QCDratio:1.076
 
 
 #############
 ### res2b ###
 #############
 [ETau_res2b] # No uncertainty, just here for correct parsing
+unc1 = CMS_bbtautau_2016_QCDratio:1.728
+unc2 = CMS_bbtautau_2016_QCDadditional:5.089
 
 [MuTau_res2b]
-unc1 = CMS_bbtautau_2016_QCDratio:1.167
+unc1 = CMS_bbtautau_2016_QCDratio:1.161
 
 [TauTau_res2b]
-unc1 = CMS_bbtautau_2016_QCDratio:2.029
+unc1 = CMS_bbtautau_2016_QCDratio:2.027
 
 
 ###############
@@ -41,70 +42,67 @@ unc1 = CMS_bbtautau_2016_QCDratio:2.029
 [MuTau_boosted] # No uncertainty, just here for correct parsing
 
 [TauTau_boosted]
-unc1 = CMS_bbtautau_2016_QCDratio:2.713
+unc1 = CMS_bbtautau_2016_QCDratio:2.705
 
 
 ################
 ### classGGF ###
 ################
-[ETau_classGGF]
+[ETau_classGGF] # No uncertainty, just here for correct parsing
 
 [MuTau_classGGF]
-unc1 = CMS_bbtautau_2016_QCDratio:1.214
+unc1 = CMS_bbtautau_2016_QCDratio:1.204
 
 [TauTau_classGGF]
-unc1 = CMS_bbtautau_2016_QCDratio:1.275
+unc1 = CMS_bbtautau_2016_QCDratio:1.269
 
 
 ################
 ### classVBF ###
 ################
 [ETau_classVBF]
-unc1 = CMS_bbtautau_2016_QCDratio:1.924
-unc2 = CMS_bbtautau_2016_QCDadditional:1.790
+unc1 = CMS_bbtautau_2016_QCDratio:1.922
 
 [MuTau_classVBF]
-unc1 = CMS_bbtautau_2016_QCDratio:1.214
+unc1 = CMS_bbtautau_2016_QCDratio:1.204
 
 [TauTau_classVBF]
-unc1 = CMS_bbtautau_2016_QCDratio:1.275
+unc1 = CMS_bbtautau_2016_QCDratio:1.269
 
 
 ################
 ### classttH ###
 ################
-[ETau_classttH]
-unc1 = CMS_bbtautau_2016_QCDratio:1.924
-#unc2 = CMS_bbtautau_2016_QCDadditional:54.694  # FIXME: temporary disabled
+[ETau_classttH] # No uncertainty, just here for correct parsing
 
 [MuTau_classttH]
-unc1 = CMS_bbtautau_2016_QCDratio:1.214
+unc1 = CMS_bbtautau_2016_QCDratio:1.204
 
-[TauTau_classttH] # No uncertainty, just here for correct parsing
+[TauTau_classttH] # No uncertainty, just here for correct parsing 
 
 
 ###############
 ### classDY ###
 ###############
 [ETau_classDY]
-unc1 = CMS_bbtautau_2016_QCDratio:1.924
-#unc2 = CMS_bbtautau_2016_QCDadditional:8.273  # FIXME: temporary disabled
+unc1 = CMS_bbtautau_2016_QCDratio:1.922
+unc2 = CMS_bbtautau_2016_QCDadditional:2.638 
 
 [MuTau_classDY]
-unc1 = CMS_bbtautau_2016_QCDratio:1.214
+unc1 = CMS_bbtautau_2016_QCDratio:1.204
 
 [TauTau_classDY]
-unc1 = CMS_bbtautau_2016_QCDratio:1.275
+unc1 = CMS_bbtautau_2016_QCDratio:1.269
 
 
 ###############
 ### classTT ###
 ###############
 [ETau_classTT]
-unc1 = CMS_bbtautau_2016_QCDratio:1.924
+unc1 = CMS_bbtautau_2016_QCDratio:1.922
 
 [MuTau_classTT]
-unc1 = CMS_bbtautau_2016_QCDratio:1.214
+unc1 = CMS_bbtautau_2016_QCDratio:1.204
 
 [TauTau_classTT]
-unc1 = CMS_bbtautau_2016_QCDratio:1.275
+unc1 = CMS_bbtautau_2016_QCDratio:1.269

--- a/config/systematics_QCD2017.cfg
+++ b/config/systematics_QCD2017.cfg
@@ -11,13 +11,13 @@
 ### res1b ###
 #############
 [ETau_res1b]
-unc1 = CMS_bbtautau_2017_QCDratio:1.147
+unc1 = CMS_bbtautau_2017_QCDratio:1.137
 
 [MuTau_res1b]
-unc1 = CMS_bbtautau_2017_QCDratio:1.058
+unc1 = CMS_bbtautau_2017_QCDratio:1.057
 
 [TauTau_res1b]
-unc1 = CMS_bbtautau_2017_QCDratio:1.060
+unc1 = CMS_bbtautau_2017_QCDratio:1.059
 
 
 #############
@@ -29,7 +29,7 @@ unc1 = CMS_bbtautau_2017_QCDratio:1.060
 unc1 = CMS_bbtautau_2017_QCDratio:1.227
 
 [TauTau_res2b]
-unc1 = CMS_bbtautau_2017_QCDratio:1.219
+unc1 = CMS_bbtautau_2017_QCDratio:1.213
 
 
 ###############
@@ -40,70 +40,70 @@ unc1 = CMS_bbtautau_2017_QCDratio:1.219
 [MuTau_boosted] # No uncertainty, just here for correct parsing
 
 [TauTau_boosted]
-unc1 = CMS_bbtautau_2017_QCDratio:1.448
+unc1 = CMS_bbtautau_2017_QCDratio:1.430
 
 
 ################
 ### classGGF ###
 ################
 [ETau_classGGF]
-unc1 = CMS_bbtautau_2017_QCDratio:1.337
+unc1 = CMS_bbtautau_2017_QCDratio:1.331
 
 [MuTau_classGGF]
-unc1 = CMS_bbtautau_2017_QCDratio:1.154
+unc1 = CMS_bbtautau_2017_QCDratio:1.149
 
 [TauTau_classGGF]
-unc1 = CMS_bbtautau_2017_QCDratio:1.206
+unc1 = CMS_bbtautau_2017_QCDratio:1.202
 
 
 ################
 ### classVBF ###
 ################
 [ETau_classVBF]
-unc1 = CMS_bbtautau_2017_QCDratio:1.337
+unc1 = CMS_bbtautau_2017_QCDratio:1.331
 
 [MuTau_classVBF]
-unc1 = CMS_bbtautau_2017_QCDratio:1.154
+unc1 = CMS_bbtautau_2017_QCDratio:1.149
 
 [TauTau_classVBF]
-unc1 = CMS_bbtautau_2017_QCDratio:1.206
+unc1 = CMS_bbtautau_2017_QCDratio:1.202
 
 
 ################
 ### classttH ###
 ################
 [ETau_classttH]
-unc1 = CMS_bbtautau_2017_QCDratio:1.337
+unc1 = CMS_bbtautau_2017_QCDratio:1.331
 
 [MuTau_classttH]
-unc1 = CMS_bbtautau_2017_QCDratio:1.154
+unc1 = CMS_bbtautau_2017_QCDratio:1.149
 
 [TauTau_classttH]
-unc1 = CMS_bbtautau_2017_QCDratio:1.206
+unc1 = CMS_bbtautau_2017_QCDratio:1.202
 
 
 ###############
 ### classDY ###
 ###############
 [ETau_classDY]
-unc1 = CMS_bbtautau_2017_QCDratio:1.337
+unc1 = CMS_bbtautau_2017_QCDratio:1.331
+unc2 = CMS_bbtautau_2016_QCDadditional:1.396
 
 [MuTau_classDY]
-unc1 = CMS_bbtautau_2017_QCDratio:1.154
+unc1 = CMS_bbtautau_2017_QCDratio:1.149
 
 [TauTau_classDY]
-unc1 = CMS_bbtautau_2017_QCDratio:1.206
-unc2 = CMS_bbtautau_2017_QCDadditional:1.129
+unc1 = CMS_bbtautau_2017_QCDratio:1.202
 
 
 ###############
 ### classTT ###
 ###############
 [ETau_classTT]
-unc1 = CMS_bbtautau_2017_QCDratio:1.337
+unc1 = CMS_bbtautau_2017_QCDratio:1.331
 
 [MuTau_classTT]
-unc1 = CMS_bbtautau_2017_QCDratio:1.154
+unc1 = CMS_bbtautau_2017_QCDratio:1.149
 
 [TauTau_classTT]
-unc1 = CMS_bbtautau_2017_QCDratio:1.206
+unc1 = CMS_bbtautau_2017_QCDratio:1.202

--- a/config/systematics_QCD2018.cfg
+++ b/config/systematics_QCD2018.cfg
@@ -11,29 +11,26 @@
 ### res1b ###
 #############
 [ETau_res1b]
-unc1 = CMS_bbtautau_2018_QCDratio:1.145
+unc1 = CMS_bbtautau_2018_QCDratio:1.138
 
 [MuTau_res1b]
-unc1 = CMS_bbtautau_2018_QCDratio:1.155
+unc1 = CMS_bbtautau_2018_QCDratio:1.154
 
 [TauTau_res1b]
-unc1 = CMS_bbtautau_2018_QCDratio:1.047
-unc2 = CMS_bbtautau_2018_QCDadditional:1.023
+unc1 = CMS_bbtautau_2018_QCDratio:1.046
 
 
 #############
 ### res2b ###
 #############
 [ETau_res2b]
-unc1 = CMS_bbtautau_2018_QCDratio:1.315
+unc1 = CMS_bbtautau_2018_QCDratio:1.269
 
 [MuTau_res2b]
-unc1 = CMS_bbtautau_2018_QCDratio:1.133
-unc2 = CMS_bbtautau_2018_QCDadditional:1.046
+unc1 = CMS_bbtautau_2018_QCDratio:1.111
 
 [TauTau_res2b]
-unc1 = CMS_bbtautau_2018_QCDratio:1.217
-unc2 = CMS_bbtautau_2018_QCDadditional:1.055
+unc1 = CMS_bbtautau_2018_QCDratio:1.212
 
 
 ###############
@@ -44,20 +41,20 @@ unc2 = CMS_bbtautau_2018_QCDadditional:1.055
 [MuTau_boosted] # No uncertainty, just here for correct parsing
 
 [TauTau_boosted]
-unc1 = CMS_bbtautau_2018_QCDratio:1.655
+unc1 = CMS_bbtautau_2018_QCDratio:1.650
 
 
 ################
 ### classGGF ###
 ################
-[ETau_classGGF]
-unc1 = CMS_bbtautau_2018_QCDratio:1.303
+[ETau_classGGF]  # No uncertainty, just here for correct parsing
 
 [MuTau_classGGF]
-unc1 = CMS_bbtautau_2018_QCDratio:1.114
+unc1 = CMS_bbtautau_2018_QCDratio:1.100
+unc2 = CMS_bbtautau_2016_QCDadditional:2.537
 
 [TauTau_classGGF]
-unc1 = CMS_bbtautau_2018_QCDratio:1.142
+unc1 = CMS_bbtautau_2018_QCDratio:1.138
 
 
 ################
@@ -66,45 +63,47 @@ unc1 = CMS_bbtautau_2018_QCDratio:1.142
 [ETau_classVBF] # No uncertainty, just here for correct parsing
 
 [MuTau_classVBF]
-unc1 = CMS_bbtautau_2018_QCDratio:1.114
+unc1 = CMS_bbtautau_2018_QCDratio:1.100
 
 [TauTau_classVBF]
-unc1 = CMS_bbtautau_2018_QCDratio:1.142
+unc1 = CMS_bbtautau_2018_QCDratio:1.138
 
 
 ################
 ### classttH ###
 ################
 [ETau_classttH]
-unc1 = CMS_bbtautau_2018_QCDratio:1.303
+unc1 = CMS_bbtautau_2018_QCDratio:1.299
 
 [MuTau_classttH]
-unc1 = CMS_bbtautau_2018_QCDratio:1.114
+unc1 = CMS_bbtautau_2018_QCDratio:1.100
 
-[TauTau_classttH] # No uncertainty, just here for correct parsing
+[TauTau_classttH] 
+unc1 = CMS_bbtautau_2018_QCDratio:1.138
+unc2 = CMS_bbtautau_2016_QCDadditional:3.884
 
 
 ###############
 ### classDY ###
 ###############
 [ETau_classDY]
-unc1 = CMS_bbtautau_2018_QCDratio:1.303
+unc1 = CMS_bbtautau_2018_QCDratio:1.299
 
 [MuTau_classDY]
-unc1 = CMS_bbtautau_2018_QCDratio:1.114
+unc1 = CMS_bbtautau_2018_QCDratio:1.100
 
 [TauTau_classDY]
-unc1 = CMS_bbtautau_2018_QCDratio:1.142
+unc1 = CMS_bbtautau_2018_QCDratio:1.138
 
 
 ###############
 ### classTT ###
 ###############
 [ETau_classTT]
-unc1 = CMS_bbtautau_2018_QCDratio:1.303
+unc1 = CMS_bbtautau_2018_QCDratio:1.299
 
 [MuTau_classTT]
-unc1 = CMS_bbtautau_2018_QCDratio:1.114
+unc1 = CMS_bbtautau_2018_QCDratio:1.100
 
 [TauTau_classTT]
-unc1 = CMS_bbtautau_2018_QCDratio:1.142
+unc1 = CMS_bbtautau_2018_QCDratio:1.138


### PR DESCRIPTION
For the time being I only modified selectionCfg_*.cfg.
selectionCfg_*_syst.cfg do not need any change because they contain only the signal region.
@francescobrivio @camendola should I change also the ttCR and tauIDSF config files? Do we want to change WP also for this cases? If not I would leave the files as they are!