### PR TITLE
Fixing submission script when some input files are missing

### DIFF
--- a/scripts/systNtuple.py
+++ b/scripts/systNtuple.py
@@ -5,7 +5,7 @@ import optparse
 import fileinput
 import commands
 import time
-
+from os.path import basename
 
 if __name__ == "__main__":
 

--- a/scripts/systNtuple.py
+++ b/scripts/systNtuple.py
@@ -54,19 +54,7 @@ if __name__ == "__main__":
     if opt.nI > opt.nF:
         print 'Initial file is n', opt.nI, 'while final file is n', opt.nF, ': can not create proper range, exiting'
         sys.exit (1)
-
-    # Input/output folder already contains systematics files
-    if opt.nI < 0:
-        if os.path.isfile(opt.workdir + "/syst_output_0.root"):
-            print 'A file named', opt.workdir+'/syst_output_0.root', 'is already present in the directory, exiting'
-            sys.exit(1)
-    else:
-        if os.path.isfile(opt.workdir + "/syst_output_"+str(opt.nI)+".root"):
-            print "A file named", opt.workdir+"/syst_output_"+str(opt.nI)+".root", "is already present in the directory, exiting"
-            sys.exit(1)
-
-
-
+    
     # Input/Output setup
     # ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
     # List all files in the working dir
@@ -78,16 +66,25 @@ if __name__ == "__main__":
 
     # Create ordered list of output_*.root files
     inputfiles = []
-    for x in range(0,len(rootfiles)):
-        inputfiles.append('output_'+str(x)+'.root')
+    inputnumbers = [int(f[7:-5]) for f in rootfiles]
+   
+    # Input/output folder already contains systematics files
+    for inputnumber in inputnumbers:
+	if opt.nI >= 0 and (inputnumber < opt.nI or inputnumber > opt.nF):
+	    continue
+	filename = opt.workdir + "/syst_output_" + str(inputnumber) + ".root"
+	if os.path.isfile(filename):
+ 	    print 'A file named ' + filename + ' is already present in the directory, exiting'
+	    sys.exit(1) 
 
     # If running on a user-define range select only the requested input files
-    if opt.nI >= 0:
-        userfiles = []
-        for jobIdx in range(opt.nI,opt.nF+1):
-            userfiles.append('output_'+str(jobIdx)+'.root')
-
-        inputfiles = [f for f in inputfiles if f in userfiles]
+    for x in range(0, max(inputnumbers) + 1):
+	if opt.nI >= 0:
+	    if x < opt.nI or x > opt.nF:
+	        continue
+	filename = 'output_'+str(x)+'.root'
+	if filename in rootfiles:
+	    inputfiles.append(filename)
 
     # Append full path
     inputfiles = [os.path.join(opt.workdir, f) for f in inputfiles]
@@ -102,12 +99,9 @@ if __name__ == "__main__":
     if os.path.exists (jobsDir) : os.system ('rm -f ' + jobsDir + '/*')
     else                        : os.system ('mkdir -p ' + jobsDir)
 
-    n = int (0)
-    if opt.nI >=0:
-        n = int (opt.nI)
     commandFile = open (jobsDir + '/submit.sh', 'w')
     for inputfile in inputfiles : 
-
+	n = int(inputfile.split('/')[-1][7:-5])
         scriptFile = open ('%s/systJob_%d.sh'% (jobsDir,n), 'w')
         scriptFile.write ('#!/bin/bash\n')
         scriptFile.write ('export X509_USER_PROXY=~/.t3/proxy.cert\n')
@@ -131,7 +125,6 @@ if __name__ == "__main__":
         if opt.sleep : time.sleep (0.1)
         os.system (command)
         commandFile.write (command + '\n')
-        n = n + 1
     commandFile.close ()
 
 

--- a/scripts/systNtuple.py
+++ b/scripts/systNtuple.py
@@ -5,11 +5,6 @@ import optparse
 import fileinput
 import commands
 import time
-import glob
-import subprocess
-from os.path import basename
-import ROOT
-
 
 
 if __name__ == "__main__":
@@ -101,7 +96,7 @@ if __name__ == "__main__":
 
     commandFile = open (jobsDir + '/submit.sh', 'w')
     for inputfile in inputfiles : 
-	n = int(inputfile.split('/')[-1][7:-5])
+        n = int(inputfile.split('/')[-1][7:-5])
         scriptFile = open ('%s/systJob_%d.sh'% (jobsDir,n), 'w')
         scriptFile.write ('#!/bin/bash\n')
         scriptFile.write ('export X509_USER_PROXY=~/.t3/proxy.cert\n')

--- a/scripts/systNtuple_mib.py
+++ b/scripts/systNtuple_mib.py
@@ -5,7 +5,7 @@ import optparse
 import fileinput
 import commands
 import time
-
+from os.path import basename
 
 if __name__ == "__main__":
 

--- a/scripts/systNtuple_mib.py
+++ b/scripts/systNtuple_mib.py
@@ -5,11 +5,6 @@ import optparse
 import fileinput
 import commands
 import time
-import glob
-import subprocess
-from os.path import basename
-# import ROOT
-
 
 
 if __name__ == "__main__":
@@ -101,7 +96,7 @@ if __name__ == "__main__":
 
     commandFile = open (jobsDir + "/submit.sh", 'w')
     for inputfile in inputfiles : 
-	n = int(inputfile.split('/')[-1][7:-5])
+        n = int(inputfile.split('/')[-1][7:-5])
         scriptFile = open ('%s/systJob_%d.sh'% (jobsDir,n), 'w')
         scriptFile.write ('#!/bin/bash\n')
         scriptFile.write ('echo $HOSTNAME\n')

--- a/scripts/systNtuple_mib.py
+++ b/scripts/systNtuple_mib.py
@@ -8,7 +8,7 @@ import time
 import glob
 import subprocess
 from os.path import basename
-import ROOT
+# import ROOT
 
 
 
@@ -54,16 +54,6 @@ if __name__ == "__main__":
         print 'Initial file is n', opt.nI, 'while final file is n', opt.nF, ': can not create proper range, exiting'
         sys.exit (1)
 
-    # Input/output folder already contains systematics files
-    if opt.nI < 0:
-        if os.path.isfile(opt.workdir + "/syst_output_0.root"):
-            print 'A file named', opt.workdir+'/syst_output_0.root', 'is already present in the directory, exiting'
-            sys.exit(1)
-    else:
-        if os.path.isfile(opt.workdir + "/syst_output_"+str(opt.nI)+".root"):
-            print "A file named", opt.workdir+"/syst_output_"+str(opt.nI)+".root", "is already present in the directory, exiting"
-            sys.exit(1)
-
 
     # Input/Output setup
     # ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
@@ -76,16 +66,25 @@ if __name__ == "__main__":
 
     # Create ordered list of output_*.root files
     inputfiles = []
-    for x in range(0,len(rootfiles)):
-        inputfiles.append('output_'+str(x)+'.root')
+    inputnumbers = [int(f[7:-5]) for f in rootfiles]
+   
+    # Input/output folder already contains systematics files
+    for inputnumber in inputnumbers:
+	if opt.nI >= 0 and (inputnumber < opt.nI or inputnumber > opt.nF):
+	    continue
+	filename = opt.workdir + "/syst_output_" + str(inputnumber) + ".root"
+	if os.path.isfile(filename):
+ 	    print 'A file named ' + filename + ' is already present in the directory, exiting'
+	    sys.exit(1) 
 
     # If running on a user-define range select only the requested input files
-    if opt.nI >= 0:
-        userfiles = []
-        for jobIdx in range(opt.nI,opt.nF+1):
-            userfiles.append('output_'+str(jobIdx)+'.root')
-
-        inputfiles = [f for f in inputfiles if f in userfiles]
+    for x in range(0, max(inputnumbers) + 1):
+	if opt.nI >= 0:
+	    if x < opt.nI or x > opt.nF:
+	        continue
+	filename = 'output_'+str(x)+'.root'
+	if filename in rootfiles:
+	    inputfiles.append(filename)
 
     # Append full path
     inputfiles = [os.path.join(opt.workdir, f) for f in inputfiles]
@@ -100,12 +99,9 @@ if __name__ == "__main__":
     if os.path.exists (jobsDir) : os.system ('rm -f ' + jobsDir + '/*')
     else                        : os.system ('mkdir -p ' + jobsDir)
 
-    n = int (0)
-    if opt.nI >=0:
-        n = int (opt.nI)
-    commandFile = open (jobsDir + '/submit.sh', 'w')
+    commandFile = open (jobsDir + "/submit.sh", 'w')
     for inputfile in inputfiles : 
-
+	n = int(inputfile.split('/')[-1][7:-5])
         scriptFile = open ('%s/systJob_%d.sh'% (jobsDir,n), 'w')
         scriptFile.write ('#!/bin/bash\n')
         scriptFile.write ('echo $HOSTNAME\n')
@@ -139,7 +135,6 @@ if __name__ == "__main__":
         if opt.sleep : time.sleep (0.1)
         os.system (command)
         commandFile.write (command + '\n')
-        n = n + 1
     commandFile.close ()
 
 


### PR DESCRIPTION
Some fixes regarding the systematics submission script:
- If you had N input files, the script assumed you had from output_0.root to output_99.root. However, if some input files were missing (e.g. you had from 0 to 79 and from 100 to 119), it will still run from 0 to 99, causing an error from 80 to 99 and not running from 100 to 119. Now those errors don't happen.
- To check that the files haven't been already produced, the script checked that the syst_output_0.root (if -i wasn't set) or the syst_output_nI.root (if -i was set) existed. However, you may have run the first one already and want to run the rest without setting -i and -f). The script now checks that none of the files that want to be produced exist already.
- Both the syst_output and the skimJob files started at 0 or nI (if this one was set). This worked fine when you had all the files in the folder, but if not, you may have syst_output files with a different number that their corresponding output files. That is now fixed.