### PR TITLE
antiEle tauID SF bug-fix

### DIFF
--- a/test/skimNtuple2016_HHbtag.cpp
+++ b/test/skimNtuple2016_HHbtag.cpp
@@ -2011,6 +2011,9 @@ int main (int argc, char** argv)
       // ----------------------------------------------------------
       // pair selection is now complete, compute oher quantitites
 
+      // Temporary fix: only skim ETau events
+      if (pairType != 1) continue;
+
       // First create a map to associate <jetIdx, smearFactor> that will be
       // used to smear the jets always in the same way in the event.
       // Since the smearing is by definition a random process the smearing factors of

--- a/test/skimNtuple2016_HHbtag.cpp
+++ b/test/skimNtuple2016_HHbtag.cpp
@@ -594,7 +594,7 @@ int main (int argc, char** argv)
   TauIDSFTool * Deep_antiJet_medium_pt  = new TauIDSFTool("2016Legacy","DeepTau2017v2p1VSjet","Medium");   // for DeepTauv2p1 vs jets Medium
   TauIDSFTool * Deep_antiEle_vvloose    = new TauIDSFTool("2016Legacy","DeepTau2017v2p1VSe"  ,"VVLoose");  // for DeepTauv2p1 vs ele VVLoose
   TauIDSFTool * Deep_antiEle_vloose     = new TauIDSFTool("2016Legacy","DeepTau2017v2p1VSe"  ,"VLoose");   // for DeepTauv2p1 vs ele VLoose
-  TauIDSFTool * Deep_antiEle_tight      = new TauIDSFTool("2016Legacy","DeepTau2017v2p1VSe"  ,"Tight");    // for DeepTauv2p1 vs ele Tight
+  //TauIDSFTool * Deep_antiEle_tight      = new TauIDSFTool("2016Legacy","DeepTau2017v2p1VSe"  ,"Tight");    // for DeepTauv2p1 vs ele Tight
   TauIDSFTool * Deep_antiMu_vloose      = new TauIDSFTool("2016Legacy","DeepTau2017v2p1VSmu" ,"VLoose");   // for DeepTauv2p1 vs mu VLoose
   TauIDSFTool * Deep_antiMu_tight       = new TauIDSFTool("2016Legacy","DeepTau2017v2p1VSmu" ,"Tight");    // for DeepTauv2p1 vs mu Tight
 
@@ -2544,7 +2544,7 @@ int main (int argc, char** argv)
 
         idAndIsoSF_leg2_deep_vsJet    = Deep_antiJet_medium    ->getSFvsDM (tau2pt,  tau2DM, tau2Genmatch);
         idAndIsoSF_leg2_deep_vsJet_pt = Deep_antiJet_medium_pt ->getSFvsPT (tau2pt,  tau2Genmatch);
-        idAndIsoSF_leg2_deep_vsEle    = Deep_antiEle_tight     ->getSFvsEta(tau2eta, tau2Genmatch);
+        idAndIsoSF_leg2_deep_vsEle    = Deep_antiEle_vloose     ->getSFvsEta(tau2eta, tau2Genmatch);
         idAndIsoSF_leg2_deep_vsMu     = Deep_antiMu_tight      ->getSFvsEta(tau2eta, tau2Genmatch);
 
         vector<float> idAndIsoSF_leg2_deep_vsJet_pt_up (5, idAndIsoSF_leg2_deep_vsJet_pt); // in bins of pt: 20, 25, 30, 35, 40, infty
@@ -2577,8 +2577,8 @@ int main (int argc, char** argv)
         {
           if (isthisSDet_IDbin_second[bin])
           {
-            idAndIsoSF_leg2_deep_vsEle_up[bin]   = Deep_antiEle_tight ->getSFvsEta(tau2eta, tau2Genmatch,   "Up");
-            idAndIsoSF_leg2_deep_vsEle_down[bin] = Deep_antiEle_tight ->getSFvsEta(tau2eta, tau2Genmatch, "Down");
+            idAndIsoSF_leg2_deep_vsEle_up[bin]   = Deep_antiEle_vloose ->getSFvsEta(tau2eta, tau2Genmatch,   "Up");
+            idAndIsoSF_leg2_deep_vsEle_down[bin] = Deep_antiEle_vloose ->getSFvsEta(tau2eta, tau2Genmatch, "Down");
           }
         }
 

--- a/test/skimNtuple2017_HHbtag.cpp
+++ b/test/skimNtuple2017_HHbtag.cpp
@@ -601,7 +601,7 @@ int main (int argc, char** argv)
   TauIDSFTool * Deep_antiJet_medium_pt = new TauIDSFTool("2017ReReco","DeepTau2017v2p1VSjet","Medium");   // for DeepTauv2p1 vs jets Medium
   TauIDSFTool * Deep_antiEle_vvloose   = new TauIDSFTool("2017ReReco","DeepTau2017v2p1VSe"  ,"VVLoose");  // for DeepTauv2p1 vs ele VVLoose
   TauIDSFTool * Deep_antiEle_vloose    = new TauIDSFTool("2017ReReco","DeepTau2017v2p1VSe"  ,"VLoose");   // for DeepTauv2p1 vs ele VLoose
-  TauIDSFTool * Deep_antiEle_tight     = new TauIDSFTool("2017ReReco","DeepTau2017v2p1VSe"  ,"Tight");    // for DeepTauv2p1 vs ele Tight
+  //TauIDSFTool * Deep_antiEle_tight     = new TauIDSFTool("2017ReReco","DeepTau2017v2p1VSe"  ,"Tight");    // for DeepTauv2p1 vs ele Tight
   TauIDSFTool * Deep_antiMu_vloose     = new TauIDSFTool("2017ReReco","DeepTau2017v2p1VSmu" ,"VLoose");   // for DeepTauv2p1 vs mu VLoose
   TauIDSFTool * Deep_antiMu_tight      = new TauIDSFTool("2017ReReco","DeepTau2017v2p1VSmu" ,"Tight");    // for DeepTauv2p1 vs mu Tight
 
@@ -2605,7 +2605,7 @@ int main (int argc, char** argv)
 
         idAndIsoSF_leg2_deep_vsJet    = Deep_antiJet_medium    ->getSFvsDM (tau2pt,  tau2DM, tau2Genmatch);
         idAndIsoSF_leg2_deep_vsJet_pt = Deep_antiJet_medium_pt ->getSFvsPT (tau2pt,  tau2Genmatch);
-        idAndIsoSF_leg2_deep_vsEle    = Deep_antiEle_tight     ->getSFvsEta(tau2eta, tau2Genmatch);
+        idAndIsoSF_leg2_deep_vsEle    = Deep_antiEle_vloose     ->getSFvsEta(tau2eta, tau2Genmatch);
         idAndIsoSF_leg2_deep_vsMu     = Deep_antiMu_tight      ->getSFvsEta(tau2eta, tau2Genmatch);
 
         vector<float> idAndIsoSF_leg2_deep_vsJet_pt_up (5, idAndIsoSF_leg2_deep_vsJet_pt); // in bins of pt: 20, 25, 30, 35, 40, infty
@@ -2638,8 +2638,8 @@ int main (int argc, char** argv)
         {
           if (isthisSDet_IDbin_second[bin])
           {
-            idAndIsoSF_leg2_deep_vsEle_up[bin]   = Deep_antiEle_tight ->getSFvsEta(tau2eta, tau2Genmatch,   "Up");
-            idAndIsoSF_leg2_deep_vsEle_down[bin] = Deep_antiEle_tight ->getSFvsEta(tau2eta, tau2Genmatch, "Down");
+            idAndIsoSF_leg2_deep_vsEle_up[bin]   = Deep_antiEle_vloose ->getSFvsEta(tau2eta, tau2Genmatch,   "Up");
+            idAndIsoSF_leg2_deep_vsEle_down[bin] = Deep_antiEle_vloose ->getSFvsEta(tau2eta, tau2Genmatch, "Down");
           }
         }
 

--- a/test/skimNtuple2017_HHbtag.cpp
+++ b/test/skimNtuple2017_HHbtag.cpp
@@ -2060,6 +2060,9 @@ int main (int argc, char** argv)
       // ----------------------------------------------------------
       // pair selection is now complete, compute oher quantitites
 
+      // Temporary fix: only skim ETau events
+      if (pairType != 1) continue;
+
       // First create a map to associate <jetIdx, smearFactor> that will be
       // used to smear the jets always in the same way in the event.
       // Since the smearing is by definition a random process the smearing factors of

--- a/test/skimNtuple2018_HHbtag.cpp
+++ b/test/skimNtuple2018_HHbtag.cpp
@@ -2098,6 +2098,9 @@ int main (int argc, char** argv)
       // ----------------------------------------------------------
       // pair selection is now complete, compute oher quantitites
 
+      // Temporary fix: only skim ETau events
+      if (pairType != 1) continue;
+
       // First create a map to associate <jetIdx, smearFactor> that will be
       // used to smear the jets always in the same way in the event.
       // Since the smearing is by definition a random process the smearing factors of

--- a/test/skimNtuple2018_HHbtag.cpp
+++ b/test/skimNtuple2018_HHbtag.cpp
@@ -603,7 +603,7 @@ int main (int argc, char** argv)
   TauIDSFTool * Deep_antiJet_medium_pt = new TauIDSFTool("2018ReReco","DeepTau2017v2p1VSjet","Medium");   // for DeepTauv2p1 vs jets Medium
   TauIDSFTool * Deep_antiEle_vvloose   = new TauIDSFTool("2018ReReco","DeepTau2017v2p1VSe"  ,"VVLoose");  // for DeepTauv2p1 vs ele VVLoose
   TauIDSFTool * Deep_antiEle_vloose    = new TauIDSFTool("2018ReReco","DeepTau2017v2p1VSe"  ,"VLoose");   // for DeepTauv2p1 vs ele VLoose
-  TauIDSFTool * Deep_antiEle_tight     = new TauIDSFTool("2018ReReco","DeepTau2017v2p1VSe"  ,"Tight");    // for DeepTauv2p1 vs ele Tight
+  //TauIDSFTool * Deep_antiEle_tight     = new TauIDSFTool("2018ReReco","DeepTau2017v2p1VSe"  ,"Tight");    // for DeepTauv2p1 vs ele Tight
   TauIDSFTool * Deep_antiMu_vloose     = new TauIDSFTool("2018ReReco","DeepTau2017v2p1VSmu" ,"VLoose");   // for DeepTauv2p1 vs mu VLoose
   TauIDSFTool * Deep_antiMu_tight      = new TauIDSFTool("2018ReReco","DeepTau2017v2p1VSmu" ,"Tight");    // for DeepTauv2p1 vs mu Tight
 
@@ -2635,7 +2635,7 @@ int main (int argc, char** argv)
 
           idAndIsoSF_leg2_deep_vsJet    = Deep_antiJet_medium    ->getSFvsDM (tau2pt,  tau2DM, tau2Genmatch);
           idAndIsoSF_leg2_deep_vsJet_pt = Deep_antiJet_medium_pt ->getSFvsPT (tau2pt,  tau2Genmatch);
-          idAndIsoSF_leg2_deep_vsEle    = Deep_antiEle_tight     ->getSFvsEta(tau2eta, tau2Genmatch);
+          idAndIsoSF_leg2_deep_vsEle    = Deep_antiEle_vloose     ->getSFvsEta(tau2eta, tau2Genmatch);
           idAndIsoSF_leg2_deep_vsMu     = Deep_antiMu_tight      ->getSFvsEta(tau2eta, tau2Genmatch);
 
           vector<float> idAndIsoSF_leg2_deep_vsJet_pt_up (5, idAndIsoSF_leg2_deep_vsJet_pt); // in bins of pt: 20, 25, 30, 35, 40, infty
@@ -2668,8 +2668,8 @@ int main (int argc, char** argv)
           {
             if (isthisSDet_IDbin_second[bin])
             {
-              idAndIsoSF_leg2_deep_vsEle_up[bin]   = Deep_antiEle_tight ->getSFvsEta(tau2eta, tau2Genmatch,   "Up");
-              idAndIsoSF_leg2_deep_vsEle_down[bin] = Deep_antiEle_tight ->getSFvsEta(tau2eta, tau2Genmatch, "Down");
+              idAndIsoSF_leg2_deep_vsEle_up[bin]   = Deep_antiEle_vloose ->getSFvsEta(tau2eta, tau2Genmatch,   "Up");
+              idAndIsoSF_leg2_deep_vsEle_down[bin] = Deep_antiEle_vloose ->getSFvsEta(tau2eta, tau2Genmatch, "Down");
             }
           }
 


### PR DESCRIPTION
Fixed the tauID SF for the antiEle discriminator in ETau channel.
Also a temporary fix is added to 2016/2017/2018 skimmers to only re-skim ETau events (**this fix should be removed after the skimming is done**).