### PR TITLE
Reverting temporary fix +  minor updates

### DIFF
--- a/config/mainCfg_ETau_Legacy2016_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2016_limits.cfg
@@ -104,7 +104,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.037
+classSBtoSR  = 0.033
 
 
 [bTagRfactor]

--- a/config/mainCfg_ETau_Legacy2016_template.cfg
+++ b/config/mainCfg_ETau_Legacy2016_template.cfg
@@ -62,7 +62,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.037
+classSBtoSR  = 0.033
 
 [bTagRfactor]
 central = 0.9996

--- a/config/mainCfg_ETau_Legacy2016_template.cfg
+++ b/config/mainCfg_ETau_Legacy2016_template.cfg
@@ -19,7 +19,7 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 [configs]
 
-sampleCfg = config/sampleCfg_Legacy2016.cfg
+sampleCfg = config/sampleCfg_Legacy2016_ETau.cfg
 cutCfg    = ZZZZ
 pattern   = goodsystfiles  # use this only when running on systematics files
 
@@ -65,4 +65,4 @@ doUnc        = True
 classSBtoSR  = 0.037
 
 [bTagRfactor]
-central = 1.0068
+central = 0.9996

--- a/config/mainCfg_ETau_Legacy2016_template.cfg
+++ b/config/mainCfg_ETau_Legacy2016_template.cfg
@@ -19,9 +19,9 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 [configs]
 
-sampleCfg = config/sampleCfg_Legacy2016_ETau.cfg
+sampleCfg = config/sampleCfg_Legacy2016_ETauWWWW.cfg
 cutCfg    = ZZZZ
-pattern   = goodsystfiles  # use this only when running on systematics files
+pattern   = PPPP  # use this only when running on systematics files
 
 
 [merge]

--- a/config/mainCfg_ETau_Legacy2017_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2017_limits.cfg
@@ -104,7 +104,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.053
+classSBtoSR  = 0.039
 
 
 [bTagRfactor]

--- a/config/mainCfg_ETau_Legacy2017_template.cfg
+++ b/config/mainCfg_ETau_Legacy2017_template.cfg
@@ -19,9 +19,9 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 
 [configs]
-sampleCfg = config/sampleCfg_Legacy2017_ETau.cfg
+sampleCfg = config/sampleCfg_Legacy2017_ETauWWWW.cfg
 cutCfg    = ZZZZ
-pattern   = goodsystfiles
+pattern   = PPPP
 
 
 [merge]

--- a/config/mainCfg_ETau_Legacy2017_template.cfg
+++ b/config/mainCfg_ETau_Legacy2017_template.cfg
@@ -19,7 +19,7 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 
 [configs]
-sampleCfg = config/sampleCfg_Legacy2017.cfg
+sampleCfg = config/sampleCfg_Legacy2017_ETau.cfg
 cutCfg    = ZZZZ
 pattern   = goodsystfiles
 
@@ -65,4 +65,4 @@ doUnc        = True
 classSBtoSR  = 0.053
 
 [bTagRfactor]
-central = 0.9949
+central = 0.9858

--- a/config/mainCfg_ETau_Legacy2017_template.cfg
+++ b/config/mainCfg_ETau_Legacy2017_template.cfg
@@ -62,7 +62,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.053
+classSBtoSR  = 0.039
 
 [bTagRfactor]
 central = 0.9858

--- a/config/mainCfg_ETau_Legacy2018_limits.cfg
+++ b/config/mainCfg_ETau_Legacy2018_limits.cfg
@@ -102,7 +102,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.070
+classSBtoSR  = 0.074
 
 
 [bTagRfactor]

--- a/config/mainCfg_ETau_Legacy2018_template.cfg
+++ b/config/mainCfg_ETau_Legacy2018_template.cfg
@@ -19,9 +19,9 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 
 [configs]
-sampleCfg = config/sampleCfg_Legacy2018_mib.cfg
+sampleCfg = config/sampleCfg_Legacy2018_mib_ETauWWWW.cfg
 cutCfg    = ZZZZ
-pattern   = goodsystfiles
+pattern   = PPPP
 
 
 [merge]

--- a/config/mainCfg_ETau_Legacy2018_template.cfg
+++ b/config/mainCfg_ETau_Legacy2018_template.cfg
@@ -66,4 +66,4 @@ classSBtoSR  = 0.070
 
 
 [bTagRfactor]
-central = 1.0004
+central = 0.9831

--- a/config/mainCfg_ETau_Legacy2018_template.cfg
+++ b/config/mainCfg_ETau_Legacy2018_template.cfg
@@ -62,7 +62,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.070
+classSBtoSR  = 0.074
 
 
 [bTagRfactor]

--- a/config/mainCfg_ETau_ttCR_Legacy2016.cfg
+++ b/config/mainCfg_ETau_ttCR_Legacy2016.cfg
@@ -5,7 +5,7 @@ lumi = 35922 # pb^-1
 # approximate to only one decimal digit
 lumi_fb = 35.9 # fb^-1
 
-outputFolder = /home/llr/cms/motta/CMSSW_11_1_0_pre6/src/KLUBAnalysis/MY_ttCRlimits_2016inclusive/ETau/
+outputFolder = ttCRlimits_2016inclusive_23Feb2021/ETau/
 
 data = DsingleEleB, DsingleEleC, DsingleEleD, DsingleEleE, DsingleEleF, DsingleEleG, DsingleEleH
 
@@ -20,7 +20,7 @@ selections = ttCR_invMcut
 regions    = SR, SStight, OSinviso, SSinviso
 
 [configs]
-sampleCfg = config/sampleCfg_Legacy2016.cfg
+sampleCfg = config/sampleCfg_Legacy2016_ETau.cfg
 cutCfg    = config/selectionCfg_ETau_ttCR_Legacy2016.cfg
 # pattern   = goodsystfiles 
 
@@ -84,4 +84,4 @@ r0 = DNNoutSM_kl_1, ttCR_invMcut, 0, 1
 ############################################################################################
 
 [bTagRfactor]
-central                         = 1.0068
+central = 0.9994

--- a/config/mainCfg_ETau_ttCR_Legacy2017.cfg
+++ b/config/mainCfg_ETau_ttCR_Legacy2017.cfg
@@ -5,7 +5,7 @@ lumi = 41529 # pb^-1
 # approximate to only one decimal digit
 lumi_fb = 41.5 # fb^-1
 
-outputFolder = /home/llr/cms/motta/CMSSW_11_1_0_pre6/src/KLUBAnalysis/MY_ttCRlimits_2017inclusive/ETau/
+outputFolder = ttCRlimits_2017inclusive_23Feb2021/ETau/
 
 data = DsingleEleB, DsingleEleC, DsingleEleD, DsingleEleE, DsingleEleF
 
@@ -20,7 +20,7 @@ selections = ttCR_invMcut
 regions    = SR, SStight, OSinviso, SSinviso
 
 [configs]
-sampleCfg = config/sampleCfg_Legacy2017.cfg
+sampleCfg = config/sampleCfg_Legacy2017_ETau.cfg
 cutCfg    = config/selectionCfg_ETau_ttCR_Legacy2017.cfg
 # pattern   = goodsystfiles 
 
@@ -85,4 +85,4 @@ r0 = DNNoutSM_kl_1, ttCR_invMcut, 0, 1
 ############################################################################################
 
 [bTagRfactor]
-central                         = 0.9949
+central = 0.9858

--- a/config/mainCfg_ETau_ttCR_Legacy2018.cfg
+++ b/config/mainCfg_ETau_ttCR_Legacy2018.cfg
@@ -5,7 +5,7 @@ lumi = 59741 # pb^-1
 # approximate to only one decimal digit
 lumi_fb = 59.7 # fb^-1
 
-outputFolder = /home/llr/cms/motta/CMSSW_11_1_0_pre6/src/KLUBAnalysis/MY_ttCRlimits_2018inclusive/ETau/
+outputFolder = ttCRlimits_2018inclusive_23Feb2021/ETau/
 
 data = DsingleEleA, DsingleEleB, DsingleEleC, DsingleEleD
 
@@ -20,7 +20,7 @@ selections = ttCR_invMcut
 regions    = SR, SStight, OSinviso, SSinviso
 
 [configs]
-sampleCfg = config/sampleCfg_Legacy2018.cfg
+sampleCfg = config/sampleCfg_Legacy2018_mib_ETau.cfg
 cutCfg    = config/selectionCfg_ETau_ttCR_Legacy2018.cfg
 # pattern   = goodsystfiles 
 
@@ -84,4 +84,4 @@ r0 = DNNoutSM_kl_1, ttCR_invMcut, 0, 1
 ############################################################################################
 
 [bTagRfactor]
-central                         = 1.0004
+central = 0.9831

--- a/config/mainCfg_MuTau_Legacy2016_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2016_limits.cfg
@@ -103,7 +103,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.066
+classSBtoSR  = 0.050
 
 
 [bTagRfactor]

--- a/config/mainCfg_MuTau_Legacy2016_template.cfg
+++ b/config/mainCfg_MuTau_Legacy2016_template.cfg
@@ -62,7 +62,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.066
+classSBtoSR  = 0.050
 
 
 [bTagRfactor]

--- a/config/mainCfg_MuTau_Legacy2016_template.cfg
+++ b/config/mainCfg_MuTau_Legacy2016_template.cfg
@@ -19,9 +19,9 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 [configs]
 
-sampleCfg = config/sampleCfg_Legacy2016.cfg
+sampleCfg = config/sampleCfg_Legacy2016WWWW.cfg
 cutCfg    = ZZZZ
-pattern   = goodsystfiles  # use this only when running on systematics files
+pattern   = PPPP  # use this only when running on systematics files
 
 
 [merge]

--- a/config/mainCfg_MuTau_Legacy2016_template.cfg
+++ b/config/mainCfg_MuTau_Legacy2016_template.cfg
@@ -66,4 +66,4 @@ classSBtoSR  = 0.066
 
 
 [bTagRfactor]
-central = 1.0081
+central = 1.0031

--- a/config/mainCfg_MuTau_Legacy2017_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2017_limits.cfg
@@ -104,7 +104,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.059
+classSBtoSR  = 0.062
 
 
 [bTagRfactor]

--- a/config/mainCfg_MuTau_Legacy2017_template.cfg
+++ b/config/mainCfg_MuTau_Legacy2017_template.cfg
@@ -19,9 +19,9 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 
 [configs]
-sampleCfg = config/sampleCfg_Legacy2017.cfg
+sampleCfg = config/sampleCfg_Legacy2017WWWW.cfg
 cutCfg    = ZZZZ
-pattern   = goodsystfiles
+pattern   = PPPP
 
 
 [merge]

--- a/config/mainCfg_MuTau_Legacy2017_template.cfg
+++ b/config/mainCfg_MuTau_Legacy2017_template.cfg
@@ -62,7 +62,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.059
+classSBtoSR  = 0.062
 
 [bTagRfactor]
 central = 0.9876

--- a/config/mainCfg_MuTau_Legacy2017_template.cfg
+++ b/config/mainCfg_MuTau_Legacy2017_template.cfg
@@ -65,4 +65,4 @@ doUnc        = True
 classSBtoSR  = 0.059
 
 [bTagRfactor]
-central = 0.9993
+central = 0.9876

--- a/config/mainCfg_MuTau_Legacy2018_limits.cfg
+++ b/config/mainCfg_MuTau_Legacy2018_limits.cfg
@@ -104,7 +104,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.099
+classSBtoSR  = 0.111
 
 
 [bTagRfactor]

--- a/config/mainCfg_MuTau_Legacy2018_template.cfg
+++ b/config/mainCfg_MuTau_Legacy2018_template.cfg
@@ -62,7 +62,7 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-classSBtoSR  = 0.099
+classSBtoSR  = 0.111
 
 [bTagRfactor]
 central = 0.9890

--- a/config/mainCfg_MuTau_Legacy2018_template.cfg
+++ b/config/mainCfg_MuTau_Legacy2018_template.cfg
@@ -19,9 +19,9 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 
 [configs]
-sampleCfg = config/sampleCfg_Legacy2018_mib.cfg
+sampleCfg = config/sampleCfg_Legacy2018_mibWWWW.cfg
 cutCfg    = ZZZZ
-pattern   = goodsystfiles
+pattern   = PPPP
 
 
 [merge]

--- a/config/mainCfg_MuTau_Legacy2018_template.cfg
+++ b/config/mainCfg_MuTau_Legacy2018_template.cfg
@@ -65,4 +65,4 @@ doUnc        = True
 classSBtoSR  = 0.099
 
 [bTagRfactor]
-central = 1.0039
+central = 0.9890

--- a/config/mainCfg_MuTau_ttCR_Legacy2016.cfg
+++ b/config/mainCfg_MuTau_ttCR_Legacy2016.cfg
@@ -5,7 +5,7 @@ lumi = 35922 # pb^-1
 # approximate to only one decimal digit
 lumi_fb = 35.9 # fb^-1
 
-outputFolder = /home/llr/cms/motta/CMSSW_11_1_0_pre6/src/KLUBAnalysis/MY_ttCRlimits_2016inclusive/MuTau/
+outputFolder = ttCRlimits_2016inclusive_23Feb2021/MuTau/
 
 data = DsingleMuB, DsingleMuC, DsingleMuD, DsingleMuE, DsingleMuF, DsingleMuG, DsingleMuH
 
@@ -84,4 +84,4 @@ r0 = DNNoutSM_kl_1, ttCR_invMcut, 0, 1
 ############################################################################################
 
 [bTagRfactor]
-central                         = 1.0081
+central = 1.0031

--- a/config/mainCfg_MuTau_ttCR_Legacy2017.cfg
+++ b/config/mainCfg_MuTau_ttCR_Legacy2017.cfg
@@ -5,7 +5,7 @@ lumi = 41529 # pb^-1
 # approximate to only one decimal digit
 lumi_fb = 41.5 # fb^-1
 
-outputFolder = /home/llr/cms/motta/CMSSW_11_1_0_pre6/src/KLUBAnalysis/MY_ttCRlimits_2017inclusive/MuTau/
+outputFolder = ttCRlimits_2017inclusive_23Feb2021/MuTau/
 
 data = DsingleMuB, DsingleMuC, DsingleMuD, DsingleMuE, DsingleMuF
 
@@ -85,4 +85,4 @@ r0 = DNNoutSM_kl_1, ttCR_invMcut, 0, 1
 ############################################################################################
 
 [bTagRfactor]
-central                         = 0.9993
+central = 0.9876

--- a/config/mainCfg_MuTau_ttCR_Legacy2018.cfg
+++ b/config/mainCfg_MuTau_ttCR_Legacy2018.cfg
@@ -5,7 +5,7 @@ lumi = 59741 # pb^-1
 # approximate to only one decimal digit
 lumi_fb = 59.7 # fb^-1
 
-outputFolder = /home/llr/cms/motta/CMSSW_11_1_0_pre6/src/KLUBAnalysis/MY_ttCRlimits_2018inclusive/MuTau/
+outputFolder = ttCRlimits_2018inclusive_23Feb2021/MuTau/
 
 data = DsingleMuA, DsingleMuB, DsingleMuC, DsingleMuD
 
@@ -20,7 +20,7 @@ selections = ttCR_invMcut
 regions    = SR, SStight, OSinviso, SSinviso
 
 [configs]
-sampleCfg = config/sampleCfg_Legacy2018.cfg
+sampleCfg = config/sampleCfg_Legacy2018_mib.cfg
 cutCfg    = config/selectionCfg_MuTau_ttCR_Legacy2018.cfg
 # pattern   = goodsystfiles
 
@@ -84,4 +84,4 @@ r0 = DNNoutSM_kl_1, ttCR_invMcut, 0, 1
 ############################################################################################
 
 [bTagRfactor]
-central                          = 1.0039
+central = 0.9890

--- a/config/mainCfg_TauTau_Legacy2016_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2016_limits.cfg
@@ -103,8 +103,8 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-boostSBtoSR  = 0.019
-classSBtoSR  = 0.089
+boostSBtoSR  = 0.016
+classSBtoSR  = 0.090
 
 
 [bTagRfactor]

--- a/config/mainCfg_TauTau_Legacy2016_template.cfg
+++ b/config/mainCfg_TauTau_Legacy2016_template.cfg
@@ -62,8 +62,8 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-boostSBtoSR  = 0.019
-classSBtoSR  = 0.089
+boostSBtoSR  = 0.016
+classSBtoSR  = 0.090
 
 
 [bTagRfactor]

--- a/config/mainCfg_TauTau_Legacy2016_template.cfg
+++ b/config/mainCfg_TauTau_Legacy2016_template.cfg
@@ -67,4 +67,4 @@ classSBtoSR  = 0.089
 
 
 [bTagRfactor]
-central = 1.0103
+central = 1.0002

--- a/config/mainCfg_TauTau_Legacy2016_template.cfg
+++ b/config/mainCfg_TauTau_Legacy2016_template.cfg
@@ -19,9 +19,9 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 [configs]
 
-sampleCfg = config/sampleCfg_Legacy2016.cfg
+sampleCfg = config/sampleCfg_Legacy2016WWWW.cfg
 cutCfg    = ZZZZ
-pattern   = goodsystfiles  # use this only when running on systematics files
+pattern   = PPPP  # use this only when running on systematics files
 
 
 [merge]

--- a/config/mainCfg_TauTau_Legacy2017_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2017_limits.cfg
@@ -104,8 +104,8 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-boostSBtoSR  = 0.164
-classSBtoSR  = 0.070
+boostSBtoSR  = 0.168
+classSBtoSR  = 0.066
 
 
 [bTagRfactor]

--- a/config/mainCfg_TauTau_Legacy2017_template.cfg
+++ b/config/mainCfg_TauTau_Legacy2017_template.cfg
@@ -19,9 +19,9 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 
 [configs]
-sampleCfg = config/sampleCfg_Legacy2017.cfg
+sampleCfg = config/sampleCfg_Legacy2017WWWW.cfg
 cutCfg    = ZZZZ
-pattern   = goodsystfiles
+pattern   = PPPP
 
 
 [merge]

--- a/config/mainCfg_TauTau_Legacy2017_template.cfg
+++ b/config/mainCfg_TauTau_Legacy2017_template.cfg
@@ -62,8 +62,8 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-boostSBtoSR  = 0.164
-classSBtoSR  = 0.070
+boostSBtoSR  = 0.168
+classSBtoSR  = 0.066
 
 
 [bTagRfactor]

--- a/config/mainCfg_TauTau_Legacy2017_template.cfg
+++ b/config/mainCfg_TauTau_Legacy2017_template.cfg
@@ -67,4 +67,4 @@ classSBtoSR  = 0.070
 
 
 [bTagRfactor]
-central                          = 0.9547
+central = 0.9894

--- a/config/mainCfg_TauTau_Legacy2018_limits.cfg
+++ b/config/mainCfg_TauTau_Legacy2018_limits.cfg
@@ -104,8 +104,8 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-boostSBtoSR  = 0.049
-classSBtoSR  = 0.083
+boostSBtoSR  = 0.053
+classSBtoSR  = 0.082
 
 
 [bTagRfactor]

--- a/config/mainCfg_TauTau_Legacy2018_template.cfg
+++ b/config/mainCfg_TauTau_Legacy2018_template.cfg
@@ -19,9 +19,9 @@ regions    = SR, SStight, OSinviso, SSinviso
 
 
 [configs]
-sampleCfg = config/sampleCfg_Legacy2018_mib.cfg
+sampleCfg = config/sampleCfg_Legacy2018_mibWWWW.cfg
 cutCfg    = ZZZZ
-pattern   = goodsystfiles
+pattern   = PPPP
 
 
 [merge]

--- a/config/mainCfg_TauTau_Legacy2018_template.cfg
+++ b/config/mainCfg_TauTau_Legacy2018_template.cfg
@@ -62,8 +62,8 @@ fitFunc      = [0] + [1]*x
 regionC      = SStight
 regionD      = SSinviso
 doUnc        = True
-boostSBtoSR  = 0.049
-classSBtoSR  = 0.083
+boostSBtoSR  = 0.053
+classSBtoSR  = 0.082
 
 
 [bTagRfactor]

--- a/config/mainCfg_TauTau_Legacy2018_template.cfg
+++ b/config/mainCfg_TauTau_Legacy2018_template.cfg
@@ -67,4 +67,4 @@ classSBtoSR  = 0.083
 
 
 [bTagRfactor]
-central = 0.9795
+central = 1.0038

--- a/config/mainCfg_TauTau_ttCR_Legacy2016.cfg
+++ b/config/mainCfg_TauTau_ttCR_Legacy2016.cfg
@@ -5,7 +5,7 @@ lumi = 35922 # pb^-1
 # approximate to only one decimal digit
 lumi_fb = 35.9 # fb^-1
 
-outputFolder = /home/llr/cms/motta/CMSSW_11_1_0_pre6/src/KLUBAnalysis/MY_ttCRlimits_2016inclusive/TauTau/
+outputFolder = ttCRlimits_2016inclusive_23Feb2021/TauTau/
 
 data = DTauB, DTauC, DTauD, DTauE, DTauF, DTauG, DTauH
 
@@ -85,4 +85,4 @@ r0 = DNNoutSM_kl_1, ttCR_invMcut, 0, 1
 ############################################################################################
 
 [bTagRfactor]
-central                         = 1.0103
+central = 1.0002

--- a/config/mainCfg_TauTau_ttCR_Legacy2017.cfg
+++ b/config/mainCfg_TauTau_ttCR_Legacy2017.cfg
@@ -5,7 +5,7 @@ lumi = 41529 # pb^-1 full 2017
 # approximate to only one decimal digit
 lumi_fb = 41.5 # fb^-1 full 2017
 
-outputFolder = /home/llr/cms/motta/CMSSW_11_1_0_pre6/src/KLUBAnalysis/MY_ttCRlimits_2017inclusive/TauTau/
+outputFolder = ttCRlimits_2017inclusive_23Feb2021/TauTau/
 
 data = DTauB, DTauC, DTauD, DTauE, DTauF
 
@@ -85,4 +85,4 @@ r0 = DNNoutSM_kl_1, ttCR_invMcut, 0, 1
 ############################################################################################
 
 [bTagRfactor]
-central                         = 0.9547
+central = 0.9894

--- a/config/mainCfg_TauTau_ttCR_Legacy2018.cfg
+++ b/config/mainCfg_TauTau_ttCR_Legacy2018.cfg
@@ -5,7 +5,7 @@ lumi = 59741 # pb^-1
 # approximate to only one decimal digit
 lumi_fb = 59.7 # fb^-1
 
-outputFolder = /home/llr/cms/motta/CMSSW_11_1_0_pre6/src/KLUBAnalysis/MY_ttCRlimits_2018inclusive/TauTau/
+outputFolder = ttCRlimits_2018inclusive_23Feb2021/TauTau/
 
 data = DTauA, DTauB, DTauC, DTauD
 
@@ -20,7 +20,7 @@ selections = ttCR_invMcut
 regions    = SR, SStight, OSinviso, SSinviso
 
 [configs]
-sampleCfg = config/sampleCfg_Legacy2018.cfg
+sampleCfg = config/sampleCfg_Legacy2018_mib.cfg
 cutCfg    = config/selectionCfg_TauTau_ttCR_Legacy2018.cfg
 # pattern   = goodsystfiles
 
@@ -84,4 +84,4 @@ r0 = DNNoutSM_kl_1, ttCR_invMcut, 0, 1
 ############################################################################################
 
 [bTagRfactor]
-central                          = 0.9795
+central = 1.0038

--- a/config/sampleCfg_Legacy2016.cfg
+++ b/config/sampleCfg_Legacy2016.cfg
@@ -1,133 +1,133 @@
 [samples]
-DsingleMuB = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Mu_2016B
-DsingleMuC = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Mu_2016C
-DsingleMuD = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Mu_2016D
-DsingleMuE = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Mu_2016E
-DsingleMuF = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Mu_2016F
-DsingleMuG = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Mu_2016G
-DsingleMuH = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Mu_2016H
+DsingleMuB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016B
+DsingleMuC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016C
+DsingleMuD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016D
+DsingleMuE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016E
+DsingleMuF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016F
+DsingleMuG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016G
+DsingleMuH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016H
 
-DsingleEleB = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Ele_2016B
-DsingleEleC = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Ele_2016C
-DsingleEleD = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Ele_2016D
-DsingleEleE = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Ele_2016E
-DsingleEleF = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Ele_2016F
-DsingleEleG = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Ele_2016G
-DsingleEleH = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Ele_2016H
+DsingleEleB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016B
+DsingleEleC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016C
+DsingleEleD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016D
+DsingleEleE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016E
+DsingleEleF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016F
+DsingleEleG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016G
+DsingleEleH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016H
 
-DTauB = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Tau_2016B
-DTauC = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Tau_2016C
-DTauD = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Tau_2016D
-DTauE = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Tau_2016E
-DTauF = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Tau_2016F
-DTauG = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Tau_2016G
-DTauH = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_Tau_2016H
+DTauB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016B
+DTauC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016C
+DTauD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016D
+DTauE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016E
+DTauF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016F
+DTauG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016G
+DTauH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016H
 
 ########
 
-TTfullyHad = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_TT_fullyHad
-TTfullyLep = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_TT_fullyLep
-TTsemiLep  = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_TT_semiLep
+TTfullyHad = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_TT_semiLep
 
-DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY
-DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_Low_Mass
+DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY
+DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_Low_Mass
 
-DY0b   = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_updown_allLHEjets_0b
-DY1b   = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_updown_allLHEjets_1b
-DY2b   = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_updown_allLHEjets_2b
+DY0b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_updown_allLHEjets_0b
+DY1b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_updown_allLHEjets_1b
+DY2b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_updown_allLHEjets_2b
 
-DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_0b_0JPt
-DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_0b_10JPt
-DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_0b_50JPt
-DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_0b_80JPt
-DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_0b_110JPt
-DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_0b_190JPt
-DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_1b_0JPt
-DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_1b_10JPt
-DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_1b_50JPt
-DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_1b_80JPt
-DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_1b_110JPt
-DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_1b_190JPt
-DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_2b_0JPt
-DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_2b_10JPt
-DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_2b_50JPt
-DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_2b_80JPt
-DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_2b_110JPt
-DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_DY_2b_190JPt
+DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_0b_50JPt
+DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_0b_80JPt
+DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_0b_110JPt
+DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_0b_190JPt
+DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_1b_50JPt
+DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_1b_80JPt
+DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_1b_110JPt
+DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_1b_190JPt
+DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_2b_50JPt
+DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_2b_80JPt
+DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_2b_110JPt
+DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_DY_2b_190JPt
 
-WJets_HT_0_70       = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WJets_HT_0_70
-WJets_HT_70_100     = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WJets_HT_70_100
-WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WJets_HT_100_200
-WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WJets_HT_200_400
-WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WJets_HT_400_600
-WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WJets_HT_600_800
-WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WJets_HT_800_1200
-WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WJets_HT_1200_2500
-WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WJets_HT_2500_Inf
+WJets_HT_0_70       = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WJets_HT_0_70
+WJets_HT_70_100     = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WJets_HT_70_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WJets_HT_2500_Inf
 
-TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ST_tW_top
-TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ST_tW_antitop
-singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ST_t_channel_top
-singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ST_t_channel_antitop
+TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ST_t_channel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ST_t_channel_antitop
 
-EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_EWKWMinus2Jets_WToLNu
-EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_EWKWPlus2Jets_WToLNu
-EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_EWKZ2Jets_ZToLL
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_EWKZ2Jets_ZToLL
 
-WWTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WWTo2L2Nu
-WWTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WWTo4Q
-WWToLNuQQ              = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WWToLNuQQ
-WZTo1L1Nu2Q            = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WZTo1L1Nu2Q
-WZTo1L3Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WZTo1L3Nu
-WZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WZTo2L2Q
-WZTo3LNu               = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WZTo3LNu
-ZZTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ZZTo2L2Nu
-ZZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ZZTo2L2Q
-ZZTo2Q2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ZZTo2Q2Nu
-ZZTo4L                 = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ZZTo4L
-ZZTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ZZTo4Q
+WWTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WWTo2L2Nu
+WWTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WWTo4Q
+WWToLNuQQ              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WWToLNuQQ
+WZTo1L1Nu2Q            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WZTo1L3Nu
+WZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WZTo2L2Q
+WZTo3LNu               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WZTo3LNu
+ZZTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ZZTo2L2Nu
+ZZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ZZTo2Q2Nu
+ZZTo4L                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ZZTo4L
+ZZTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ZZTo4Q
 
-ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ZH_HBB_ZQQ
-ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ZH_HBB_ZLL
-ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ZH_HTauTau
-ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ggHTauTau
-VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_VBFHTauTau
-WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WplusHTauTau
-WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WminusHTauTau
-ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ttHJetTononBB
-ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ttHJetToBB
+ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ZH_HBB_ZQQ
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ZH_HTauTau
+ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ttHJetToBB
 
-WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WWW
-WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WWZ
-WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_WZZ
-ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_ZZZ
+WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_WZZ
+ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_ZZZ
 
-TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_TTWJetsToLNu
-TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_TTWJetsToQQ
-TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_TTZToLLNuNu
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_TTZToLLNuNu
 
-TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_TTWW
-TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_TTWZ
-TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_TTZZ
+TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_TTZZ
 
 #########
 
-#GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_GGHHSM
-GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_HHRew_SM
-VBFHHSM = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+#GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_GGHHSM
+GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_HHRew_SM
+VBFHHSM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
 
-GGHH_NLO_cHHH1_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_GGHH_NLO_cHHH1_xs
-GGHH_NLO_cHHH0_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_GGHH_NLO_cHHH0_xs
-GGHH_NLO_cHHH2p45_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_GGHH_NLO_cHHH2p45_xs
-GGHH_NLO_cHHH5_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_GGHH_NLO_cHHH5_xs
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_GGHH_NLO_cHHH5_xs
 
-VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
-VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1
-VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1
-VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0
-VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2
-VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1
-VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_9Dec2020/SKIM_VBFHHTo2B2Tau_CV_1_C2V_0_C3_1
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_VBFHHTo2B2Tau_CV_1_C2V_0_C3_1
 
 #########
 

--- a/config/sampleCfg_Legacy2016_ETau.cfg
+++ b/config/sampleCfg_Legacy2016_ETau.cfg
@@ -1,0 +1,209 @@
+[samples]
+DsingleMuB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Mu_2016B
+DsingleMuC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Mu_2016C
+DsingleMuD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Mu_2016D
+DsingleMuE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Mu_2016E
+DsingleMuF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Mu_2016F
+DsingleMuG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Mu_2016G
+DsingleMuH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Mu_2016H
+
+DsingleEleB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016B
+DsingleEleC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016C
+DsingleEleD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016D
+DsingleEleE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016E
+DsingleEleF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016F
+DsingleEleG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016G
+DsingleEleH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016H
+
+DTauB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Tau_2016B
+DTauC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Tau_2016C
+DTauD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Tau_2016D
+DTauE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Tau_2016E
+DTauF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Tau_2016F
+DTauG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Tau_2016G
+DTauH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Tau_2016H
+
+########
+
+TTfullyHad = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_TT_semiLep
+
+DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY
+DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_Low_Mass
+
+DY0b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_updown_allLHEjets_0b
+DY1b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_updown_allLHEjets_1b
+DY2b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_updown_allLHEjets_2b
+
+DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_0b_50JPt
+DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_0b_80JPt
+DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_0b_110JPt
+DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_0b_190JPt
+DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_1b_50JPt
+DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_1b_80JPt
+DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_1b_110JPt
+DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_1b_190JPt
+DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_2b_50JPt
+DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_2b_80JPt
+DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_2b_110JPt
+DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_DY_2b_190JPt
+
+WJets_HT_0_70       = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WJets_HT_0_70
+WJets_HT_70_100     = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WJets_HT_70_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WJets_HT_2500_Inf
+
+TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ST_t_channel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ST_t_channel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_EWKZ2Jets_ZToLL
+
+WWTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WWTo2L2Nu
+WWTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WWTo4Q
+WWToLNuQQ              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WWToLNuQQ
+WZTo1L1Nu2Q            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WZTo1L3Nu
+WZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WZTo2L2Q
+WZTo3LNu               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WZTo3LNu
+ZZTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ZZTo2L2Nu
+ZZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ZZTo2Q2Nu
+ZZTo4L                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ZZTo4L
+ZZTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ZZTo4Q
+
+ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ZH_HBB_ZQQ
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ZH_HTauTau
+ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ttHJetToBB
+
+WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_WZZ
+ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_ZZZ
+
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_TTZToLLNuNu
+
+TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_TTZZ
+
+#########
+
+#GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_GGHHSM
+GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_HHRew_SM
+VBFHHSM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_VBFHHTo2B2Tau_CV_1_C2V_0_C3_1
+
+#########
+
+VBFRadion600  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-600
+VBFRadion650  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-650
+VBFRadion700  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-700
+VBFRadion750  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-750
+VBFRadion800  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-800
+VBFRadion850  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-850
+VBFRadion900  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-900
+VBFRadion1000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1000
+VBFRadion1250 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1250
+VBFRadion1500 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1500
+VBFRadion1750 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1750
+VBFRadion2000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-2000
+VBFRadion3000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-3000
+
+#########
+
+Radion250      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-250
+Radion270      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-270
+Radion280      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-280
+Radion300      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-300
+Radion350      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-350
+Radion400      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-400
+Radion450      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-450
+Radion500      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-500
+Radion550      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-550
+Radion600      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-600
+Radion650      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-650
+Radion750      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-750
+Radion900      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-900
+
+#########
+
+Graviton250 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-250
+Graviton260 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-260
+Graviton270 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-270
+Graviton280 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-280
+Graviton300 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-300
+Graviton320 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-320
+Graviton340 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-340
+Graviton350 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-350
+Graviton400 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-400
+Graviton450 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-450
+Graviton500 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-500
+Graviton550 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-550
+Graviton600 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-600
+Graviton650 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-650
+Graviton750 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-750
+Graviton800 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-800
+
+GravitonRS300 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-300
+GravitonRS650 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-650
+GravitonRS900 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-900
+
+#########
+benchmark1  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_1
+benchmark2  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_2
+benchmark3  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_3
+benchmark4  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_4
+benchmark5  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_5
+benchmark6  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_6
+benchmark7  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_7
+benchmark8  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_8
+benchmark9  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_9
+benchmark10 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_10
+benchmark11 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_11
+benchmark12 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_12
+
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/sampleCfg_Legacy2016_ETau.cfg
+++ b/config/sampleCfg_Legacy2016_ETau.cfg
@@ -1,12 +1,4 @@
 [samples]
-DsingleMuB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Mu_2016B
-DsingleMuC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Mu_2016C
-DsingleMuD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Mu_2016D
-DsingleMuE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Mu_2016E
-DsingleMuF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Mu_2016F
-DsingleMuG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Mu_2016G
-DsingleMuH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Mu_2016H
-
 DsingleEleB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016B
 DsingleEleC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016C
 DsingleEleD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016D
@@ -14,14 +6,6 @@ DsingleEleE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_201
 DsingleEleF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016F
 DsingleEleG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016G
 DsingleEleH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016H
-
-DTauB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Tau_2016B
-DTauC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Tau_2016C
-DTauD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Tau_2016D
-DTauE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Tau_2016E
-DTauF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Tau_2016F
-DTauG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Tau_2016G
-DTauH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Tau_2016H
 
 ########
 

--- a/config/sampleCfg_Legacy2016_ETau_JERdown.cfg
+++ b/config/sampleCfg_Legacy2016_ETau_JERdown.cfg
@@ -1,0 +1,193 @@
+[samples]
+DsingleEleB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016B
+DsingleEleC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016C
+DsingleEleD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016D
+DsingleEleE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016E
+DsingleEleF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016F
+DsingleEleG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016G
+DsingleEleH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016H
+
+########
+
+TTfullyHad = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TT_semiLep
+
+DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY
+DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_Low_Mass
+
+DY0b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_updown_allLHEjets_0b
+DY1b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_updown_allLHEjets_1b
+DY2b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_updown_allLHEjets_2b
+
+DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_0b_50JPt
+DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_0b_80JPt
+DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_0b_110JPt
+DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_0b_190JPt
+DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_1b_50JPt
+DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_1b_80JPt
+DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_1b_110JPt
+DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_1b_190JPt
+DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_2b_50JPt
+DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_2b_80JPt
+DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_2b_110JPt
+DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_2b_190JPt
+
+WJets_HT_0_70       = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_0_70
+WJets_HT_70_100     = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_70_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_2500_Inf
+
+TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ST_t_channel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ST_t_channel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_EWKZ2Jets_ZToLL
+
+WWTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WWTo2L2Nu
+WWTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WWTo4Q
+WWToLNuQQ              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WWToLNuQQ
+WZTo1L1Nu2Q            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WZTo1L3Nu
+WZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WZTo2L2Q
+WZTo3LNu               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WZTo3LNu
+ZZTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZZTo2L2Nu
+ZZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZZTo2Q2Nu
+ZZTo4L                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZZTo4L
+ZZTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZZTo4Q
+
+ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZH_HBB_ZQQ
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZH_HTauTau
+ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ttHJetToBB
+
+WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WZZ
+ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZZZ
+
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TTZToLLNuNu
+
+TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TTZZ
+
+#########
+
+#GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_GGHHSM
+GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_HHRew_SM
+VBFHHSM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_1_C2V_0_C3_1
+
+#########
+
+VBFRadion600  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-600
+VBFRadion650  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-650
+VBFRadion700  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-700
+VBFRadion750  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-750
+VBFRadion800  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-800
+VBFRadion850  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-850
+VBFRadion900  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-900
+VBFRadion1000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1000
+VBFRadion1250 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1250
+VBFRadion1500 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1500
+VBFRadion1750 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1750
+VBFRadion2000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-2000
+VBFRadion3000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-3000
+
+#########
+
+Radion250      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-250
+Radion270      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-270
+Radion280      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-280
+Radion300      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-300
+Radion350      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-350
+Radion400      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-400
+Radion450      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-450
+Radion500      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-500
+Radion550      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-550
+Radion600      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-600
+Radion650      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-650
+Radion750      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-750
+Radion900      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-900
+
+#########
+
+Graviton250 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-250
+Graviton260 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-260
+Graviton270 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-270
+Graviton280 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-280
+Graviton300 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-300
+Graviton320 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-320
+Graviton340 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-340
+Graviton350 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-350
+Graviton400 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-400
+Graviton450 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-450
+Graviton500 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-500
+Graviton550 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-550
+Graviton600 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-600
+Graviton650 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-650
+Graviton750 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-750
+Graviton800 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-800
+
+GravitonRS300 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-300
+GravitonRS650 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-650
+GravitonRS900 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-900
+
+#########
+benchmark1  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_1
+benchmark2  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_2
+benchmark3  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_3
+benchmark4  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_4
+benchmark5  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_5
+benchmark6  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_6
+benchmark7  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_7
+benchmark8  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_8
+benchmark9  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_9
+benchmark10 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_10
+benchmark11 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_11
+benchmark12 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_12
+
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/sampleCfg_Legacy2016_ETau_JERup.cfg
+++ b/config/sampleCfg_Legacy2016_ETau_JERup.cfg
@@ -9,109 +9,109 @@ DsingleEleH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_201
 
 ########
 
-TTfullyHad = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TT_fullyHad
-TTfullyLep = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TT_fullyLep
-TTsemiLep  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TT_semiLep
+TTfullyHad = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TT_semiLep
 
-DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY
-DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_Low_Mass
+DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY
+DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_Low_Mass
 
-DY0b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_updown_allLHEjets_0b
-DY1b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_updown_allLHEjets_1b
-DY2b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_updown_allLHEjets_2b
+DY0b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_updown_allLHEjets_0b
+DY1b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_updown_allLHEjets_1b
+DY2b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_updown_allLHEjets_2b
 
-DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_0b_0JPt
-DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_0b_10JPt
-DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_0b_50JPt
-DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_0b_80JPt
-DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_0b_110JPt
-DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_0b_190JPt
-DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_1b_0JPt
-DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_1b_10JPt
-DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_1b_50JPt
-DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_1b_80JPt
-DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_1b_110JPt
-DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_1b_190JPt
-DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_2b_0JPt
-DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_2b_10JPt
-DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_2b_50JPt
-DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_2b_80JPt
-DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_2b_110JPt
-DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_2b_190JPt
+DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_0b_50JPt
+DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_0b_80JPt
+DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_0b_110JPt
+DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_0b_190JPt
+DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_1b_50JPt
+DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_1b_80JPt
+DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_1b_110JPt
+DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_1b_190JPt
+DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_2b_50JPt
+DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_2b_80JPt
+DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_2b_110JPt
+DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_2b_190JPt
 
-WJets_HT_0_70       = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_0_70
-WJets_HT_70_100     = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_70_100
-WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_100_200
-WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_200_400
-WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_400_600
-WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_600_800
-WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_800_1200
-WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_1200_2500
-WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_2500_Inf
+WJets_HT_0_70       = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_0_70
+WJets_HT_70_100     = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_70_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_2500_Inf
 
-TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ST_tW_top
-TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ST_tW_antitop
-singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ST_t_channel_top
-singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ST_t_channel_antitop
+TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ST_t_channel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ST_t_channel_antitop
 
-EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_EWKWMinus2Jets_WToLNu
-EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_EWKWPlus2Jets_WToLNu
-EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_EWKZ2Jets_ZToLL
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_EWKZ2Jets_ZToLL
 
-WWTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WWTo2L2Nu
-WWTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WWTo4Q
-WWToLNuQQ              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WWToLNuQQ
-WZTo1L1Nu2Q            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WZTo1L1Nu2Q
-WZTo1L3Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WZTo1L3Nu
-WZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WZTo2L2Q
-WZTo3LNu               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WZTo3LNu
-ZZTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZZTo2L2Nu
-ZZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZZTo2L2Q
-ZZTo2Q2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZZTo2Q2Nu
-ZZTo4L                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZZTo4L
-ZZTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZZTo4Q
+WWTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WWTo2L2Nu
+WWTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WWTo4Q
+WWToLNuQQ              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WWToLNuQQ
+WZTo1L1Nu2Q            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WZTo1L3Nu
+WZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WZTo2L2Q
+WZTo3LNu               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WZTo3LNu
+ZZTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZZTo2L2Nu
+ZZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZZTo2Q2Nu
+ZZTo4L                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZZTo4L
+ZZTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZZTo4Q
 
-ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZH_HBB_ZQQ
-ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZH_HBB_ZLL
-ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZH_HTauTau
-ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ggHTauTau
-VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHTauTau
-WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WplusHTauTau
-WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WminusHTauTau
-ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ttHJetTononBB
-ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ttHJetToBB
+ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZH_HBB_ZQQ
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZH_HTauTau
+ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ttHJetToBB
 
-WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WWW
-WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WWZ
-WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WZZ
-ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZZZ
+WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WZZ
+ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZZZ
 
-TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TTWJetsToLNu
-TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TTWJetsToQQ
-TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TTZToLLNuNu
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TTZToLLNuNu
 
-TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TTWW
-TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TTWZ
-TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TTZZ
+TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TTZZ
 
 #########
 
-#GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_GGHHSM
-GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_HHRew_SM
-VBFHHSM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+#GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_GGHHSM
+GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_HHRew_SM
+VBFHHSM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
 
-GGHH_NLO_cHHH1_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_GGHH_NLO_cHHH1_xs
-GGHH_NLO_cHHH0_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_GGHH_NLO_cHHH0_xs
-GGHH_NLO_cHHH2p45_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_GGHH_NLO_cHHH2p45_xs
-GGHH_NLO_cHHH5_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_GGHH_NLO_cHHH5_xs
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH5_xs
 
-VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
-VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1
-VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1
-VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0
-VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2
-VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1
-VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_1_C2V_0_C3_1
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_1_C2V_0_C3_1
 
 #########
 

--- a/config/sampleCfg_Legacy2016_ETau_JERup.cfg
+++ b/config/sampleCfg_Legacy2016_ETau_JERup.cfg
@@ -1,0 +1,193 @@
+[samples]
+DsingleEleB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016B
+DsingleEleC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016C
+DsingleEleD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016D
+DsingleEleE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016E
+DsingleEleF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016F
+DsingleEleG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016G
+DsingleEleH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_ETau/SKIM_Ele_2016H
+
+########
+
+TTfullyHad = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TT_semiLep
+
+DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY
+DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_Low_Mass
+
+DY0b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_updown_allLHEjets_0b
+DY1b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_updown_allLHEjets_1b
+DY2b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_updown_allLHEjets_2b
+
+DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_0b_50JPt
+DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_0b_80JPt
+DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_0b_110JPt
+DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_0b_190JPt
+DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_1b_50JPt
+DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_1b_80JPt
+DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_1b_110JPt
+DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_1b_190JPt
+DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_2b_50JPt
+DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_2b_80JPt
+DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_2b_110JPt
+DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_DY_2b_190JPt
+
+WJets_HT_0_70       = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_0_70
+WJets_HT_70_100     = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_70_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WJets_HT_2500_Inf
+
+TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ST_t_channel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ST_t_channel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_EWKZ2Jets_ZToLL
+
+WWTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WWTo2L2Nu
+WWTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WWTo4Q
+WWToLNuQQ              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WWToLNuQQ
+WZTo1L1Nu2Q            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WZTo1L3Nu
+WZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WZTo2L2Q
+WZTo3LNu               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WZTo3LNu
+ZZTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZZTo2L2Nu
+ZZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZZTo2L2Q
+ZZTo2Q2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZZTo2Q2Nu
+ZZTo4L                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZZTo4L
+ZZTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZZTo4Q
+
+ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZH_HBB_ZQQ
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZH_HTauTau
+ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ttHJetToBB
+
+WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_WZZ
+ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_ZZZ
+
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TTZToLLNuNu
+
+TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_TTZZ
+
+#########
+
+#GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_GGHHSM
+GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_HHRew_SM
+VBFHHSM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup//SKIM_VBFHHTo2B2Tau_CV_1_C2V_0_C3_1
+
+#########
+
+VBFRadion600  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-600
+VBFRadion650  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-650
+VBFRadion700  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-700
+VBFRadion750  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-750
+VBFRadion800  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-800
+VBFRadion850  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-850
+VBFRadion900  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-900
+VBFRadion1000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1000
+VBFRadion1250 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1250
+VBFRadion1500 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1500
+VBFRadion1750 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1750
+VBFRadion2000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-2000
+VBFRadion3000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-3000
+
+#########
+
+Radion250      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-250
+Radion270      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-270
+Radion280      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-280
+Radion300      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-300
+Radion350      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-350
+Radion400      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-400
+Radion450      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-450
+Radion500      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-500
+Radion550      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-550
+Radion600      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-600
+Radion650      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-650
+Radion750      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-750
+Radion900      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-900
+
+#########
+
+Graviton250 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-250
+Graviton260 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-260
+Graviton270 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-270
+Graviton280 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-280
+Graviton300 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-300
+Graviton320 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-320
+Graviton340 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-340
+Graviton350 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-350
+Graviton400 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-400
+Graviton450 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-450
+Graviton500 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-500
+Graviton550 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-550
+Graviton600 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-600
+Graviton650 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-650
+Graviton750 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-750
+Graviton800 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-800
+
+GravitonRS300 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-300
+GravitonRS650 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-650
+GravitonRS900 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-900
+
+#########
+benchmark1  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_1
+benchmark2  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_2
+benchmark3  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_3
+benchmark4  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_4
+benchmark5  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_5
+benchmark6  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_6
+benchmark7  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_7
+benchmark8  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_8
+benchmark9  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_9
+benchmark10 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_10
+benchmark11 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_11
+benchmark12 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_12
+
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/sampleCfg_Legacy2016_JERdown.cfg
+++ b/config/sampleCfg_Legacy2016_JERdown.cfg
@@ -1,0 +1,209 @@
+[samples]
+DsingleMuB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016B
+DsingleMuC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016C
+DsingleMuD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016D
+DsingleMuE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016E
+DsingleMuF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016F
+DsingleMuG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016G
+DsingleMuH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016H
+
+DsingleEleB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016B
+DsingleEleC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016C
+DsingleEleD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016D
+DsingleEleE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016E
+DsingleEleF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016F
+DsingleEleG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016G
+DsingleEleH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016H
+
+DTauB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016B
+DTauC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016C
+DTauD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016D
+DTauE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016E
+DTauF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016F
+DTauG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016G
+DTauH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016H
+
+########
+
+TTfullyHad = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TT_semiLep
+
+DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY
+DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_Low_Mass
+
+DY0b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_updown_allLHEjets_0b
+DY1b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_updown_allLHEjets_1b
+DY2b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_updown_allLHEjets_2b
+
+DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_0b_50JPt
+DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_0b_80JPt
+DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_0b_110JPt
+DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_0b_190JPt
+DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_1b_50JPt
+DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_1b_80JPt
+DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_1b_110JPt
+DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_1b_190JPt
+DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_2b_50JPt
+DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_2b_80JPt
+DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_2b_110JPt
+DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_DY_2b_190JPt
+
+WJets_HT_0_70       = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_0_70
+WJets_HT_70_100     = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_70_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WJets_HT_2500_Inf
+
+TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ST_t_channel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ST_t_channel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_EWKZ2Jets_ZToLL
+
+WWTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WWTo2L2Nu
+WWTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WWTo4Q
+WWToLNuQQ              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WWToLNuQQ
+WZTo1L1Nu2Q            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WZTo1L3Nu
+WZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WZTo2L2Q
+WZTo3LNu               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WZTo3LNu
+ZZTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZZTo2L2Nu
+ZZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZZTo2Q2Nu
+ZZTo4L                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZZTo4L
+ZZTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZZTo4Q
+
+ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZH_HBB_ZQQ
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZH_HTauTau
+ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ttHJetToBB
+
+WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_WZZ
+ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_ZZZ
+
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TTZToLLNuNu
+
+TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_TTZZ
+
+#########
+
+#GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_GGHHSM
+GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_HHRew_SM
+VBFHHSM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERdown/SKIM_VBFHHTo2B2Tau_CV_1_C2V_0_C3_1
+
+#########
+
+VBFRadion600  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-600
+VBFRadion650  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-650
+VBFRadion700  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-700
+VBFRadion750  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-750
+VBFRadion800  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-800
+VBFRadion850  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-850
+VBFRadion900  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-900
+VBFRadion1000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1000
+VBFRadion1250 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1250
+VBFRadion1500 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1500
+VBFRadion1750 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1750
+VBFRadion2000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-2000
+VBFRadion3000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-3000
+
+#########
+
+Radion250      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-250
+Radion270      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-270
+Radion280      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-280
+Radion300      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-300
+Radion350      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-350
+Radion400      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-400
+Radion450      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-450
+Radion500      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-500
+Radion550      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-550
+Radion600      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-600
+Radion650      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-650
+Radion750      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-750
+Radion900      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-900
+
+#########
+
+Graviton250 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-250
+Graviton260 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-260
+Graviton270 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-270
+Graviton280 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-280
+Graviton300 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-300
+Graviton320 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-320
+Graviton340 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-340
+Graviton350 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-350
+Graviton400 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-400
+Graviton450 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-450
+Graviton500 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-500
+Graviton550 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-550
+Graviton600 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-600
+Graviton650 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-650
+Graviton750 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-750
+Graviton800 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-800
+
+GravitonRS300 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-300
+GravitonRS650 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-650
+GravitonRS900 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-900
+
+#########
+benchmark1  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_1
+benchmark2  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_2
+benchmark3  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_3
+benchmark4  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_4
+benchmark5  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_5
+benchmark6  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_6
+benchmark7  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_7
+benchmark8  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_8
+benchmark9  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_9
+benchmark10 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_10
+benchmark11 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_11
+benchmark12 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_12
+
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/sampleCfg_Legacy2016_JERup.cfg
+++ b/config/sampleCfg_Legacy2016_JERup.cfg
@@ -1,0 +1,209 @@
+[samples]
+DsingleMuB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016B
+DsingleMuC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016C
+DsingleMuD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016D
+DsingleMuE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016E
+DsingleMuF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016F
+DsingleMuG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016G
+DsingleMuH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Mu_2016H
+
+DsingleEleB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016B
+DsingleEleC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016C
+DsingleEleD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016D
+DsingleEleE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016E
+DsingleEleF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016F
+DsingleEleG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016G
+DsingleEleH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Ele_2016H
+
+DTauB = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016B
+DTauC = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016C
+DTauD = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016D
+DTauE = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016E
+DTauF = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016F
+DTauG = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016G
+DTauH = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021/SKIM_Tau_2016H
+
+########
+
+TTfullyHad = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TT_semiLep
+
+DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY
+DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_Low_Mass
+
+DY0b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_updown_allLHEjets_0b
+DY1b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_updown_allLHEjets_1b
+DY2b   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_updown_allLHEjets_2b
+
+DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_0b_50JPt
+DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_0b_80JPt
+DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_0b_110JPt
+DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_0b_190JPt
+DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_1b_50JPt
+DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_1b_80JPt
+DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_1b_110JPt
+DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_1b_190JPt
+DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_2b_50JPt
+DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_2b_80JPt
+DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_2b_110JPt
+DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_DY_2b_190JPt
+
+WJets_HT_0_70       = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_0_70
+WJets_HT_70_100     = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_70_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WJets_HT_2500_Inf
+
+TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ST_t_channel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ST_t_channel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_EWKZ2Jets_ZToLL
+
+WWTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WWTo2L2Nu
+WWTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WWTo4Q
+WWToLNuQQ              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WWToLNuQQ
+WZTo1L1Nu2Q            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WZTo1L3Nu
+WZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WZTo2L2Q
+WZTo3LNu               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WZTo3LNu
+ZZTo2L2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZZTo2L2Nu
+ZZTo2L2Q               = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZZTo2Q2Nu
+ZZTo4L                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZZTo4L
+ZZTo4Q                 = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZZTo4Q
+
+ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZH_HBB_ZQQ
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZH_HTauTau
+ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ttHJetToBB
+
+WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_WZZ
+ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_ZZZ
+
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TTZToLLNuNu
+
+TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_TTZZ
+
+#########
+
+#GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_GGHHSM
+GGHHSM  = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_HHRew_SM
+VBFHHSM = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_1
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_0_5_C2V_1_C3_1
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_1_5_C2V_1_C3_1
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_0
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_1_C2V_1_C3_2
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_1_C2V_2_C3_1
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2016_16Feb2021_JERup/SKIM_VBFHHTo2B2Tau_CV_1_C2V_0_C3_1
+
+#########
+
+VBFRadion600  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-600
+VBFRadion650  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-650
+VBFRadion700  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-700
+VBFRadion750  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-750
+VBFRadion800  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-800
+VBFRadion850  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-850
+VBFRadion900  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-900
+VBFRadion1000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1000
+VBFRadion1250 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1250
+VBFRadion1500 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1500
+VBFRadion1750 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-1750
+VBFRadion2000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-2000
+VBFRadion3000 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_VBFToRadionToHHTo2B2Tau_M-3000
+
+#########
+
+Radion250      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-250
+Radion270      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-270
+Radion280      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-280
+Radion300      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-300
+Radion350      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-350
+Radion400      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-400
+Radion450      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-450
+Radion500      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-500
+Radion550      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-550
+Radion600      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-600
+Radion650      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-650
+Radion750      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-750
+Radion900      = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRadionToHHTo2B2Tau_M-900
+
+#########
+
+Graviton250 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-250
+Graviton260 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-260
+Graviton270 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-270
+Graviton280 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-280
+Graviton300 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-300
+Graviton320 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-320
+Graviton340 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-340
+Graviton350 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-350
+Graviton400 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-400
+Graviton450 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-450
+Graviton500 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-500
+Graviton550 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-550
+Graviton600 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-600
+Graviton650 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-650
+Graviton750 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-750
+Graviton800 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToBulkGravitonToHHTo2B2Tau_M-800
+
+GravitonRS300 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-300
+GravitonRS650 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-650
+GravitonRS900 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_GluGluToRSGravitonToHHTo2B2Tau_M-900
+
+#########
+benchmark1  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_1
+benchmark2  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_2
+benchmark3  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_3
+benchmark4  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_4
+benchmark5  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_5
+benchmark6  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_6
+benchmark7  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_7
+benchmark8  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_8
+benchmark9  = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_9
+benchmark10 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_10
+benchmark11 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_11
+benchmark12 = /data_CMS/cms/amendola/HH2017Skim_Jan2019/SKIMS_28Aug2018_Run2017/SKIM_HH_benchmark_12
+
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/sampleCfg_Legacy2017.cfg
+++ b/config/sampleCfg_Legacy2017.cfg
@@ -1,138 +1,138 @@
 [samples]
-DsingleMuB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Mu_2017B
-DsingleMuC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Mu_2017C
-DsingleMuD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Mu_2017D
-DsingleMuE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Mu_2017E
-DsingleMuF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Mu_2017F
+DsingleMuB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017B
+DsingleMuC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017C
+DsingleMuD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017D
+DsingleMuE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017E
+DsingleMuF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017F
 
-DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Ele_2017B
-DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Ele_2017C
-DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Ele_2017D
-DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Ele_2017E
-DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Ele_2017F
+DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017B
+DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017C
+DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017D
+DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017E
+DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017F
 
-DTauB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Tau_2017B
-DTauC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Tau_2017C
-DTauD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Tau_2017D
-DTauE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Tau_2017E
-DTauF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_Tau_2017F
-
-########
-
-TTfullyHad = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_TT_fullyHad
-TTfullyLep = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_TT_fullyLep
-TTsemiLep  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_TT_semiLep
-
-DYJets_0j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_0j0b
-DYJets_1j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_1j0b
-DYJets_1j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_1j1b
-DYJets_2j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_2j0b
-DYJets_2j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_2j1b
-DYJets_2j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_2j2b
-DYJets_3j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_3j0b
-DYJets_3j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_3j1b
-DYJets_3j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_3j2b
-DYJets_3j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_3j3b
-DYJets_4j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_4j0b
-DYJets_4j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_4j1b
-DYJets_4j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_4j2b
-DYJets_4j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_4j3b
-DYJets_4j4b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_4j4b
-
-DY_HM                      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY
-DYJets_M_10_50_Not_PU_Safe = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_M_10_50_Not_PU_Safe
-DYJets_M_10_50_PU_Safe     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DYJets_M_10_50_PU_Safe
-
-DY_0b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_0b_0JPt
-DY_0b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_0b_10JPt
-DY_0b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_0b_30JPt
-DY_0b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_0b_50JPt
-DY_0b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_0b_100JPt
-DY_0b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_0b_200JPt
-DY_1b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_1b_0JPt
-DY_1b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_1b_10JPt
-DY_1b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_1b_30JPt
-DY_1b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_1b_50JPt
-DY_1b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_1b_100JPt
-DY_1b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_1b_200JPt
-DY_2b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_2b_0JPt
-DY_2b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_2b_10JPt
-DY_2b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_2b_30JPt
-DY_2b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_2b_50JPt
-DY_2b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_2b_100JPt
-DY_2b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_DY_2b_200JPt
-
-WJets_HT_0_70      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WJets_HT_0_70
-WJets_HT_70_100    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WJets_HT_70_100
-WJets_HT_100_200   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WJets_HT_100_200
-WJets_HT_200_400   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WJets_HT_200_400
-WJets_HT_400_600   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WJets_HT_400_600
-WJets_HT_600_800   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WJets_HT_600_800
-WJets_HT_800_1200  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WJets_HT_800_1200
-WJets_HT_1200_2500 = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WJets_HT_1200_2500
-WJets_HT_2500_Inf  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WJets_HT_2500_Inf
-
-TWtop             = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ST_tW_top
-TWantitop         = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ST_tW_antitop
-singleTop_top     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ST_tchannel_top
-singleTop_antitop = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ST_tchannel_antitop
-
-EWKWMinus2Jets_WToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_EWKWMinus2Jets_WToLNu
-EWKWPlus2Jets_WToLNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_EWKWPlus2Jets_WToLNu
-EWKZ2Jets_ZToLL        = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_EWKZ2Jets_ZToLL
-
-ZH_HBB_ZLL    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ZH_HBB_ZLL
-ZH_HBB_ZQQ    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ZH_HBB_ZQQ
-ZH_HTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ZH_HTauTau
-VBFHTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_VBFHTauTau
-ggHTauTau     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ggHTauTau
-WplusHTauTau  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WplusHTauTau
-WminusHTauTau = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WminusHTauTau
-
-ZZTo4L      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ZZTo4L
-ZZTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ZZTo2L2Nu
-ZZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ZZTo2L2Q
-ZZTo2Q2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ZZTo2Q2Nu
-WZTo3LNu    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WZTo3LNu
-WZTo1L1Nu2Q = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WZTo1L1Nu2Q
-WZTo1L3Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WZTo1L3Nu
-WZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WZTo2L2Q
-WWTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WWTo2L2Nu
-WWToLNuQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WWToLNuQQ
-WWTo4Q      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WWTo4Q
-ZZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ZZZ
-WZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WZZ
-WWW	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WWW
-WWZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_WWZ
-
-ttHJetToBB    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ttHJetToBB
-ttHJetTononBB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ttHJetTononBB
-ttHToTauTau   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_ttHToTauTau
-TTWJetsToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_TTWJetsToLNu
-TTWJetsToQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_TTWJetsToQQ
-TTZZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_TTZZ
-TTWW	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_TTWW
-TTWZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_TTWZ
-TTWH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_TTWH
-TTZH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_TTZH
-TTZToLLNuNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_TTZToLLNuNu
-TTZToQQ       = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_TTZToQQ
+DTauB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017B
+DTauC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017C
+DTauD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017D
+DTauE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017E
+DTauF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017F
 
 ########
 
-GGHH_NLO_cHHH0_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_GGHH_NLO_cHHH0_xs
-GGHH_NLO_cHHH1_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_GGHH_NLO_cHHH1_xs
-GGHH_NLO_cHHH2p45_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_GGHH_NLO_cHHH2p45_xs
-GGHH_NLO_cHHH5_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_GGHH_NLO_cHHH5_xs
+TTfullyHad = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_TT_semiLep
 
-VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
-VBFHH_CV_1_C2V_0_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_VBFHH_CV_1_C2V_0_C3_2_xs
-VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_VBFHH_CV_1p5_C2V_1_C3_1_xs
-VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
-VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
-VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
-VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_VBFHH_CV_0p5_C2V_1_C3_1_xs
-VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_24Nov2020_final/SKIM_VBFHH_CV_1_C2V_0_C3_1_xs
+DYJets_0j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_0j0b
+DYJets_1j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_1j0b
+DYJets_1j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_1j1b
+DYJets_2j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_2j0b
+DYJets_2j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_2j1b
+DYJets_2j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_2j2b
+DYJets_3j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_3j0b
+DYJets_3j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_3j1b
+DYJets_3j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_3j2b
+DYJets_3j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_3j3b
+DYJets_4j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_4j0b
+DYJets_4j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_4j1b
+DYJets_4j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_4j2b
+DYJets_4j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_4j3b
+DYJets_4j4b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_4j4b
+
+DY_HM                      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY
+DYJets_M_10_50_Not_PU_Safe = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_M_10_50_Not_PU_Safe
+DYJets_M_10_50_PU_Safe     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DYJets_M_10_50_PU_Safe
+
+DY_0b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_0b_30JPt
+DY_0b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_0b_50JPt
+DY_0b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_0b_100JPt
+DY_0b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_0b_200JPt
+DY_1b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_1b_30JPt
+DY_1b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_1b_50JPt
+DY_1b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_1b_100JPt
+DY_1b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_1b_200JPt
+DY_2b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_2b_30JPt
+DY_2b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_2b_50JPt
+DY_2b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_2b_100JPt
+DY_2b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_DY_2b_200JPt
+
+WJets_HT_0_70      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WJets_HT_0_70
+WJets_HT_70_100    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WJets_HT_70_100
+WJets_HT_100_200   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WJets_HT_100_200
+WJets_HT_200_400   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WJets_HT_200_400
+WJets_HT_400_600   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WJets_HT_400_600
+WJets_HT_600_800   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WJets_HT_600_800
+WJets_HT_800_1200  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500 = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WJets_HT_2500_Inf
+
+TWtop             = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ST_tW_top
+TWantitop         = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ST_tW_antitop
+singleTop_top     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ST_tchannel_top
+singleTop_antitop = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ST_tchannel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_EWKZ2Jets_ZToLL
+
+ZH_HBB_ZLL    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ZH_HBB_ZLL
+ZH_HBB_ZQQ    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ZH_HBB_ZQQ
+ZH_HTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ZH_HTauTau
+VBFHTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_VBFHTauTau
+ggHTauTau     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ggHTauTau
+WplusHTauTau  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WplusHTauTau
+WminusHTauTau = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WminusHTauTau
+
+ZZTo4L      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ZZTo4L
+ZZTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ZZTo2L2Nu
+ZZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ZZTo2Q2Nu
+WZTo3LNu    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WZTo3LNu
+WZTo1L1Nu2Q = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WZTo1L3Nu
+WZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WZTo2L2Q
+WWTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WWTo2L2Nu
+WWToLNuQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WWToLNuQQ
+WWTo4Q      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WWTo4Q
+ZZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ZZZ
+WZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WZZ
+WWW	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WWW
+WWZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_WWZ
+
+ttHJetToBB    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ttHJetToBB
+ttHJetTononBB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ttHJetTononBB
+ttHToTauTau   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_ttHToTauTau
+TTWJetsToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_TTWJetsToLNu
+TTWJetsToQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_TTWJetsToQQ
+TTZZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_TTZZ
+TTWW	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_TTWW
+TTWZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_TTWZ
+TTWH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_TTWH
+TTZH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_TTZH
+TTZToLLNuNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_TTZToLLNuNu
+TTZToQQ       = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_TTZToQQ
+
+########
+
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_VBFHH_CV_1_C2V_0_C3_2_xs
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_VBFHH_CV_1p5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_VBFHH_CV_0p5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_VBFHH_CV_1_C2V_0_C3_1_xs
 
 
 ## specify here if a sample should use a user-defined efficiency bin for the normalization

--- a/config/sampleCfg_Legacy2017_ETau.cfg
+++ b/config/sampleCfg_Legacy2017_ETau.cfg
@@ -1,0 +1,132 @@
+[samples]
+DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017B
+DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017C
+DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017D
+DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017E
+DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017F
+
+########
+
+TTfullyHad = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_TT_semiLep
+
+DYJets_0j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_0j0b
+DYJets_1j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_1j0b
+DYJets_1j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_1j1b
+DYJets_2j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_2j0b
+DYJets_2j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_2j1b
+DYJets_2j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_2j2b
+DYJets_3j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_3j0b
+DYJets_3j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_3j1b
+DYJets_3j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_3j2b
+DYJets_3j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_3j3b
+DYJets_4j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_4j0b
+DYJets_4j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_4j1b
+DYJets_4j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_4j2b
+DYJets_4j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_4j3b
+DYJets_4j4b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_4j4b
+
+DY_HM                      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY
+DYJets_M_10_50_Not_PU_Safe = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_M_10_50_Not_PU_Safe
+DYJets_M_10_50_PU_Safe     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DYJets_M_10_50_PU_Safe
+
+DY_0b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_0b_30JPt
+DY_0b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_0b_50JPt
+DY_0b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_0b_100JPt
+DY_0b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_0b_200JPt
+DY_1b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_1b_30JPt
+DY_1b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_1b_50JPt
+DY_1b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_1b_100JPt
+DY_1b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_1b_200JPt
+DY_2b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_2b_30JPt
+DY_2b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_2b_50JPt
+DY_2b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_2b_100JPt
+DY_2b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_DY_2b_200JPt
+
+WJets_HT_0_70      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WJets_HT_0_70
+WJets_HT_70_100    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WJets_HT_70_100
+WJets_HT_100_200   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WJets_HT_100_200
+WJets_HT_200_400   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WJets_HT_200_400
+WJets_HT_400_600   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WJets_HT_400_600
+WJets_HT_600_800   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WJets_HT_600_800
+WJets_HT_800_1200  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500 = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WJets_HT_2500_Inf
+
+TWtop             = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ST_tW_top
+TWantitop         = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ST_tW_antitop
+singleTop_top     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ST_tchannel_top
+singleTop_antitop = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ST_tchannel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_EWKZ2Jets_ZToLL
+
+ZH_HBB_ZLL    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ZH_HBB_ZLL
+ZH_HBB_ZQQ    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ZH_HBB_ZQQ
+ZH_HTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ZH_HTauTau
+VBFHTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_VBFHTauTau
+ggHTauTau     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ggHTauTau
+WplusHTauTau  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WplusHTauTau
+WminusHTauTau = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WminusHTauTau
+
+ZZTo4L      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ZZTo4L
+ZZTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ZZTo2L2Nu
+ZZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ZZTo2Q2Nu
+WZTo3LNu    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WZTo3LNu
+WZTo1L1Nu2Q = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WZTo1L3Nu
+WZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WZTo2L2Q
+WWTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WWTo2L2Nu
+WWToLNuQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WWToLNuQQ
+WWTo4Q      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WWTo4Q
+ZZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ZZZ
+WZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WZZ
+WWW	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WWW
+WWZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_WWZ
+
+ttHJetToBB    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ttHJetToBB
+ttHJetTononBB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ttHJetTononBB
+ttHToTauTau   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_ttHToTauTau
+TTWJetsToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_TTWJetsToLNu
+TTWJetsToQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_TTWJetsToQQ
+TTZZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_TTZZ
+TTWW	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_TTWW
+TTWZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_TTWZ
+TTWH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_TTWH
+TTZH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_TTZH
+TTZToLLNuNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_TTZToLLNuNu
+TTZToQQ       = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_TTZToQQ
+
+########
+
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_VBFHH_CV_1_C2V_0_C3_2_xs
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_VBFHH_CV_1p5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_VBFHH_CV_0p5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_VBFHH_CV_1_C2V_0_C3_1_xs
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/sampleCfg_Legacy2017_ETau_JERdown.cfg
+++ b/config/sampleCfg_Legacy2017_ETau_JERdown.cfg
@@ -1,9 +1,9 @@
 [samples]
-DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017B
-DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017C
-DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017D
-DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017E
-DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017F
+DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017B
+DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017C
+DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017D
+DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017E
+DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017F
 
 ########
 

--- a/config/sampleCfg_Legacy2017_ETau_JERdown.cfg
+++ b/config/sampleCfg_Legacy2017_ETau_JERdown.cfg
@@ -1,0 +1,132 @@
+[samples]
+DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017B
+DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017C
+DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017D
+DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017E
+DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017F
+
+########
+
+TTfullyHad = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TT_semiLep
+
+DYJets_0j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_0j0b
+DYJets_1j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_1j0b
+DYJets_1j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_1j1b
+DYJets_2j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_2j0b
+DYJets_2j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_2j1b
+DYJets_2j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_2j2b
+DYJets_3j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_3j0b
+DYJets_3j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_3j1b
+DYJets_3j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_3j2b
+DYJets_3j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_3j3b
+DYJets_4j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_4j0b
+DYJets_4j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_4j1b
+DYJets_4j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_4j2b
+DYJets_4j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_4j3b
+DYJets_4j4b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_4j4b
+
+DY_HM                      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY
+DYJets_M_10_50_Not_PU_Safe = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_M_10_50_Not_PU_Safe
+DYJets_M_10_50_PU_Safe     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_M_10_50_PU_Safe
+
+DY_0b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_0b_30JPt
+DY_0b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_0b_50JPt
+DY_0b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_0b_100JPt
+DY_0b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_0b_200JPt
+DY_1b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_1b_30JPt
+DY_1b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_1b_50JPt
+DY_1b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_1b_100JPt
+DY_1b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_1b_200JPt
+DY_2b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_2b_30JPt
+DY_2b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_2b_50JPt
+DY_2b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_2b_100JPt
+DY_2b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_2b_200JPt
+
+WJets_HT_0_70      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_0_70
+WJets_HT_70_100    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_70_100
+WJets_HT_100_200   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_100_200
+WJets_HT_200_400   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_200_400
+WJets_HT_400_600   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_400_600
+WJets_HT_600_800   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_600_800
+WJets_HT_800_1200  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500 = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_2500_Inf
+
+TWtop             = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ST_tW_top
+TWantitop         = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ST_tW_antitop
+singleTop_top     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ST_tchannel_top
+singleTop_antitop = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ST_tchannel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_EWKZ2Jets_ZToLL
+
+ZH_HBB_ZLL    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZH_HBB_ZLL
+ZH_HBB_ZQQ    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZH_HBB_ZQQ
+ZH_HTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZH_HTauTau
+VBFHTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHTauTau
+ggHTauTau     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ggHTauTau
+WplusHTauTau  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WplusHTauTau
+WminusHTauTau = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WminusHTauTau
+
+ZZTo4L      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZZTo4L
+ZZTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZZTo2L2Nu
+ZZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZZTo2Q2Nu
+WZTo3LNu    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WZTo3LNu
+WZTo1L1Nu2Q = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WZTo1L3Nu
+WZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WZTo2L2Q
+WWTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WWTo2L2Nu
+WWToLNuQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WWToLNuQQ
+WWTo4Q      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WWTo4Q
+ZZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZZZ
+WZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WZZ
+WWW	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WWW
+WWZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WWZ
+
+ttHJetToBB    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ttHJetToBB
+ttHJetTononBB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ttHJetTononBB
+ttHToTauTau   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ttHToTauTau
+TTWJetsToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTWJetsToLNu
+TTWJetsToQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTWJetsToQQ
+TTZZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTZZ
+TTWW	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTWW
+TTWZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTWZ
+TTWH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTWH
+TTZH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTZH
+TTZToLLNuNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTZToLLNuNu
+TTZToQQ       = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTZToQQ
+
+########
+
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_1_C2V_0_C3_2_xs
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_1p5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_0p5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_1_C2V_0_C3_1_xs
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/sampleCfg_Legacy2017_ETau_JERup.cfg
+++ b/config/sampleCfg_Legacy2017_ETau_JERup.cfg
@@ -1,0 +1,132 @@
+[samples]
+DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017B
+DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017C
+DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017D
+DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017E
+DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017F
+
+########
+
+TTfullyHad = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TT_semiLep
+
+DYJets_0j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_0j0b
+DYJets_1j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_1j0b
+DYJets_1j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_1j1b
+DYJets_2j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_2j0b
+DYJets_2j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_2j1b
+DYJets_2j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_2j2b
+DYJets_3j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_3j0b
+DYJets_3j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_3j1b
+DYJets_3j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_3j2b
+DYJets_3j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_3j3b
+DYJets_4j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_4j0b
+DYJets_4j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_4j1b
+DYJets_4j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_4j2b
+DYJets_4j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_4j3b
+DYJets_4j4b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_4j4b
+
+DY_HM                      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY
+DYJets_M_10_50_Not_PU_Safe = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_M_10_50_Not_PU_Safe
+DYJets_M_10_50_PU_Safe     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_M_10_50_PU_Safe
+
+DY_0b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_0b_30JPt
+DY_0b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_0b_50JPt
+DY_0b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_0b_100JPt
+DY_0b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_0b_200JPt
+DY_1b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_1b_30JPt
+DY_1b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_1b_50JPt
+DY_1b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_1b_100JPt
+DY_1b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_1b_200JPt
+DY_2b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_2b_30JPt
+DY_2b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_2b_50JPt
+DY_2b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_2b_100JPt
+DY_2b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_2b_200JPt
+
+WJets_HT_0_70      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_0_70
+WJets_HT_70_100    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_70_100
+WJets_HT_100_200   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_100_200
+WJets_HT_200_400   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_200_400
+WJets_HT_400_600   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_400_600
+WJets_HT_600_800   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_600_800
+WJets_HT_800_1200  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500 = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_2500_Inf
+
+TWtop             = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ST_tW_top
+TWantitop         = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ST_tW_antitop
+singleTop_top     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ST_tchannel_top
+singleTop_antitop = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ST_tchannel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_EWKZ2Jets_ZToLL
+
+ZH_HBB_ZLL    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZH_HBB_ZLL
+ZH_HBB_ZQQ    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZH_HBB_ZQQ
+ZH_HTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZH_HTauTau
+VBFHTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHTauTau
+ggHTauTau     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ggHTauTau
+WplusHTauTau  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WplusHTauTau
+WminusHTauTau = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WminusHTauTau
+
+ZZTo4L      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZZTo4L
+ZZTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZZTo2L2Nu
+ZZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZZTo2Q2Nu
+WZTo3LNu    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WZTo3LNu
+WZTo1L1Nu2Q = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WZTo1L3Nu
+WZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WZTo2L2Q
+WWTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WWTo2L2Nu
+WWToLNuQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WWToLNuQQ
+WWTo4Q      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WWTo4Q
+ZZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZZZ
+WZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WZZ
+WWW	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WWW
+WWZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WWZ
+
+ttHJetToBB    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ttHJetToBB
+ttHJetTononBB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ttHJetTononBB
+ttHToTauTau   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ttHToTauTau
+TTWJetsToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTWJetsToLNu
+TTWJetsToQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTWJetsToQQ
+TTZZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTZZ
+TTWW	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTWW
+TTWZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTWZ
+TTWH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTWH
+TTZH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTZH
+TTZToLLNuNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTZToLLNuNu
+TTZToQQ       = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTZToQQ
+
+########
+
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_1_C2V_0_C3_2_xs
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_1p5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_0p5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_1_C2V_0_C3_1_xs
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/sampleCfg_Legacy2017_ETau_JERup.cfg
+++ b/config/sampleCfg_Legacy2017_ETau_JERup.cfg
@@ -1,9 +1,9 @@
 [samples]
-DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017B
-DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017C
-DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017D
-DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017E
-DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017F
+DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017B
+DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017C
+DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017D
+DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017E
+DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_23Feb2021/SKIM_Ele_2017F
 
 ########
 

--- a/config/sampleCfg_Legacy2017_JERdown.cfg
+++ b/config/sampleCfg_Legacy2017_JERdown.cfg
@@ -1,0 +1,144 @@
+[samples]
+DsingleMuB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Mu_2017B
+DsingleMuC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Mu_2017C
+DsingleMuD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Mu_2017D
+DsingleMuE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Mu_2017E
+DsingleMuF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Mu_2017F
+
+DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017B
+DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017C
+DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017D
+DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017E
+DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017F
+
+DTauB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Tau_2017B
+DTauC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Tau_2017C
+DTauD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Tau_2017D
+DTauE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Tau_2017E
+DTauF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Tau_2017F
+
+########
+
+TTfullyHad = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TT_semiLep
+
+DYJets_0j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_0j0b
+DYJets_1j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_1j0b
+DYJets_1j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_1j1b
+DYJets_2j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_2j0b
+DYJets_2j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_2j1b
+DYJets_2j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_2j2b
+DYJets_3j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_3j0b
+DYJets_3j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_3j1b
+DYJets_3j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_3j2b
+DYJets_3j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_3j3b
+DYJets_4j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_4j0b
+DYJets_4j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_4j1b
+DYJets_4j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_4j2b
+DYJets_4j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_4j3b
+DYJets_4j4b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_4j4b
+
+DY_HM                      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY
+DYJets_M_10_50_Not_PU_Safe = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_M_10_50_Not_PU_Safe
+DYJets_M_10_50_PU_Safe     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DYJets_M_10_50_PU_Safe
+
+DY_0b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_0b_30JPt
+DY_0b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_0b_50JPt
+DY_0b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_0b_100JPt
+DY_0b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_0b_200JPt
+DY_1b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_1b_30JPt
+DY_1b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_1b_50JPt
+DY_1b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_1b_100JPt
+DY_1b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_1b_200JPt
+DY_2b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_2b_30JPt
+DY_2b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_2b_50JPt
+DY_2b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_2b_100JPt
+DY_2b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_DY_2b_200JPt
+
+WJets_HT_0_70      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_0_70
+WJets_HT_70_100    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_70_100
+WJets_HT_100_200   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_100_200
+WJets_HT_200_400   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_200_400
+WJets_HT_400_600   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_400_600
+WJets_HT_600_800   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_600_800
+WJets_HT_800_1200  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500 = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WJets_HT_2500_Inf
+
+TWtop             = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ST_tW_top
+TWantitop         = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ST_tW_antitop
+singleTop_top     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ST_tchannel_top
+singleTop_antitop = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ST_tchannel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_EWKZ2Jets_ZToLL
+
+ZH_HBB_ZLL    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZH_HBB_ZLL
+ZH_HBB_ZQQ    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZH_HBB_ZQQ
+ZH_HTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZH_HTauTau
+VBFHTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHTauTau
+ggHTauTau     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ggHTauTau
+WplusHTauTau  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WplusHTauTau
+WminusHTauTau = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WminusHTauTau
+
+ZZTo4L      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZZTo4L
+ZZTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZZTo2L2Nu
+ZZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZZTo2Q2Nu
+WZTo3LNu    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WZTo3LNu
+WZTo1L1Nu2Q = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WZTo1L3Nu
+WZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WZTo2L2Q
+WWTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WWTo2L2Nu
+WWToLNuQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WWToLNuQQ
+WWTo4Q      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WWTo4Q
+ZZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ZZZ
+WZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WZZ
+WWW	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WWW
+WWZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_WWZ
+
+ttHJetToBB    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ttHJetToBB
+ttHJetTononBB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ttHJetTononBB
+ttHToTauTau   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_ttHToTauTau
+TTWJetsToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTWJetsToLNu
+TTWJetsToQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTWJetsToQQ
+TTZZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTZZ
+TTWW	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTWW
+TTWZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTWZ
+TTWH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTWH
+TTZH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTZH
+TTZToLLNuNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTZToLLNuNu
+TTZToQQ       = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_TTZToQQ
+
+########
+
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_1_C2V_0_C3_2_xs
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_1p5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_0p5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_VBFHH_CV_1_C2V_0_C3_1_xs
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/sampleCfg_Legacy2017_JERdown.cfg
+++ b/config/sampleCfg_Legacy2017_JERdown.cfg
@@ -1,21 +1,21 @@
 [samples]
-DsingleMuB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Mu_2017B
-DsingleMuC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Mu_2017C
-DsingleMuD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Mu_2017D
-DsingleMuE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Mu_2017E
-DsingleMuF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Mu_2017F
+DsingleMuB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017B
+DsingleMuC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017C
+DsingleMuD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017D
+DsingleMuE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017E
+DsingleMuF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017F
 
-DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017B
-DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017C
-DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017D
-DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017E
-DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Ele_2017F
+DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017B
+DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017C
+DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017D
+DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017E
+DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017F
 
-DTauB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Tau_2017B
-DTauC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Tau_2017C
-DTauD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Tau_2017D
-DTauE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Tau_2017E
-DTauF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_1Mar2021_JERDown/SKIM_Tau_2017F
+DTauB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017B
+DTauC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017C
+DTauD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017D
+DTauE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017E
+DTauF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017F
 
 ########
 

--- a/config/sampleCfg_Legacy2017_JERup.cfg
+++ b/config/sampleCfg_Legacy2017_JERup.cfg
@@ -1,0 +1,144 @@
+[samples]
+DsingleMuB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Mu_2017B
+DsingleMuC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Mu_2017C
+DsingleMuD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Mu_2017D
+DsingleMuE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Mu_2017E
+DsingleMuF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Mu_2017F
+
+DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017B
+DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017C
+DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017D
+DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017E
+DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017F
+
+DTauB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Tau_2017B
+DTauC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Tau_2017C
+DTauD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Tau_2017D
+DTauE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Tau_2017E
+DTauF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Tau_2017F
+
+########
+
+TTfullyHad = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TT_fullyHad
+TTfullyLep = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TT_fullyLep
+TTsemiLep  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TT_semiLep
+
+DYJets_0j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_0j0b
+DYJets_1j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_1j0b
+DYJets_1j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_1j1b
+DYJets_2j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_2j0b
+DYJets_2j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_2j1b
+DYJets_2j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_2j2b
+DYJets_3j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_3j0b
+DYJets_3j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_3j1b
+DYJets_3j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_3j2b
+DYJets_3j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_3j3b
+DYJets_4j0b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_4j0b
+DYJets_4j1b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_4j1b
+DYJets_4j2b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_4j2b
+DYJets_4j3b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_4j3b
+DYJets_4j4b = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_4j4b
+
+DY_HM                      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY
+DYJets_M_10_50_Not_PU_Safe = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_M_10_50_Not_PU_Safe
+DYJets_M_10_50_PU_Safe     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DYJets_M_10_50_PU_Safe
+
+DY_0b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_0b_30JPt
+DY_0b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_0b_50JPt
+DY_0b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_0b_100JPt
+DY_0b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_0b_200JPt
+DY_1b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_1b_30JPt
+DY_1b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_1b_50JPt
+DY_1b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_1b_100JPt
+DY_1b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_1b_200JPt
+DY_2b_1Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_2b_30JPt
+DY_2b_4Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_2b_50JPt
+DY_2b_5Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_2b_100JPt
+DY_2b_6Pt = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_DY_2b_200JPt
+
+WJets_HT_0_70      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_0_70
+WJets_HT_70_100    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_70_100
+WJets_HT_100_200   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_100_200
+WJets_HT_200_400   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_200_400
+WJets_HT_400_600   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_400_600
+WJets_HT_600_800   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_600_800
+WJets_HT_800_1200  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500 = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WJets_HT_2500_Inf
+
+TWtop             = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ST_tW_top
+TWantitop         = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ST_tW_antitop
+singleTop_top     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ST_tchannel_top
+singleTop_antitop = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ST_tchannel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_EWKZ2Jets_ZToLL
+
+ZH_HBB_ZLL    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZH_HBB_ZLL
+ZH_HBB_ZQQ    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZH_HBB_ZQQ
+ZH_HTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZH_HTauTau
+VBFHTauTau    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHTauTau
+ggHTauTau     = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ggHTauTau
+WplusHTauTau  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WplusHTauTau
+WminusHTauTau = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WminusHTauTau
+
+ZZTo4L      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZZTo4L
+ZZTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZZTo2L2Nu
+ZZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZZTo2Q2Nu
+WZTo3LNu    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WZTo3LNu
+WZTo1L1Nu2Q = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WZTo1L3Nu
+WZTo2L2Q    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WZTo2L2Q
+WWTo2L2Nu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WWTo2L2Nu
+WWToLNuQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WWToLNuQQ
+WWTo4Q      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WWTo4Q
+ZZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ZZZ
+WZZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WZZ
+WWW	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WWW
+WWZ	    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_WWZ
+
+ttHJetToBB    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ttHJetToBB
+ttHJetTononBB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ttHJetTononBB
+ttHToTauTau   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_ttHToTauTau
+TTWJetsToLNu  = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTWJetsToLNu
+TTWJetsToQQ   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTWJetsToQQ
+TTZZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTZZ
+TTWW	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTWW
+TTWZ	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTWZ
+TTWH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTWH
+TTZH	      = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTZH
+TTZToLLNuNu   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTZToLLNuNu
+TTZToQQ       = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_TTZToQQ
+
+########
+
+GGHH_NLO_cHHH0_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH1_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH2p45_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs    = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_1_C2V_0_C3_2_xs
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_1p5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_0p5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_VBFHH_CV_1_C2V_0_C3_1_xs
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/sampleCfg_Legacy2017_JERup.cfg
+++ b/config/sampleCfg_Legacy2017_JERup.cfg
@@ -1,21 +1,21 @@
 [samples]
-DsingleMuB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Mu_2017B
-DsingleMuC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Mu_2017C
-DsingleMuD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Mu_2017D
-DsingleMuE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Mu_2017E
-DsingleMuF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Mu_2017F
+DsingleMuB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017B
+DsingleMuC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017C
+DsingleMuD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017D
+DsingleMuE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017E
+DsingleMuF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Mu_2017F
 
-DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017B
-DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017C
-DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017D
-DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017E
-DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Ele_2017F
+DsingleEleB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017B
+DsingleEleC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017C
+DsingleEleD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017D
+DsingleEleE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017E
+DsingleEleF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Ele_2017F
 
-DTauB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Tau_2017B
-DTauC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Tau_2017C
-DTauD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Tau_2017D
-DTauE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Tau_2017E
-DTauF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_27Feb2021_JERUp/SKIM_Tau_2017F
+DTauB = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017B
+DTauC = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017C
+DTauD = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017D
+DTauE = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017E
+DTauF = /gwteraz/users/dzuolo/HHbbtautauAnalysis/SKIMMED_Legacy2017_19Feb2021/SKIM_Tau_2017F
 
 ########
 

--- a/config/sampleCfg_Legacy2018_mib.cfg
+++ b/config/sampleCfg_Legacy2018_mib.cfg
@@ -1,126 +1,126 @@
 [samples]
-DsingleMuA   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_SingleMuon2018A
-DsingleMuB   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_SingleMuon2018B
-DsingleMuC   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_SingleMuon2018C
-DsingleMuD   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_SingleMuon2018D
+DsingleMuA   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleMuon2018A
+DsingleMuB   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleMuon2018B
+DsingleMuC   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleMuon2018C
+DsingleMuD   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleMuon2018D
 
-DsingleEleA  =/gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_SingleElectron2018A
-DsingleEleB  =/gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_SingleElectron2018B
-DsingleEleC  =/gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_SingleElectron2018C
-DsingleEleD  =/gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_SingleElectron2018D
+DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018A
+DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018B
+DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018C
+DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018D
 
-DTauA        = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_Tau2018A
-DTauB        = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_Tau2018B
-DTauC        = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_Tau2018C
-DTauD        = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_Tau2018D
+DTauA        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_Tau2018A
+DTauB        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_Tau2018B
+DTauC        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_Tau2018C
+DTauD        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_Tau2018D
 
 ########
 
-TTfullyHad     = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_TT_fullyHad
-TTfullyLep     = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_TT_fullyLep
-TTsemiLep      = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_TT_semiLep
+TTfullyHad     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_TT_fullyHad
+TTfullyLep     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_TT_fullyLep
+TTsemiLep      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_TT_semiLep
 
 
 #incl
 
-DY_HM = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY
-DY_LM = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_lowMass
+DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY
+DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_lowMass
 
-DY_0b_1Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_0b_0JPt
-DY_0b_2Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_0b_10JPt
-DY_0b_3Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_0b_30JPt
-DY_0b_4Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_0b_50JPt
-DY_0b_5Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_0b_100JPt
-DY_0b_6Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_0b_200JPt
-DY_1b_1Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_1b_0JPt
-DY_1b_2Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_1b_10JPt
-DY_1b_3Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_1b_30JPt
-DY_1b_4Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_1b_50JPt
-DY_1b_5Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_1b_100JPt
-DY_1b_6Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_1b_200JPt
-DY_2b_1Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_2b_0JPt
-DY_2b_2Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_2b_10JPt
-DY_2b_3Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_2b_30JPt
-DY_2b_4Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_2b_50JPt
-DY_2b_5Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_2b_100JPt
-DY_2b_6Pt = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_DY_2b_200JPt
+DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_0b_30JPt
+DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_0b_50JPt
+DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_0b_100JPt
+DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_0b_200JPt
+DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_1b_30JPt
+DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_1b_50JPt
+DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_1b_100JPt
+DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_1b_200JPt
+DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_2b_30JPt
+DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_2b_50JPt
+DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_2b_100JPt
+DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_DY_2b_200JPt
 
 
-WJets_HT_0_100      = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WJets_HT_0_100
-WJets_HT_100_200    = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WJets_HT_100_200
-WJets_HT_200_400    = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WJets_HT_200_400
-WJets_HT_400_600    = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WJets_HT_400_600
-WJets_HT_600_800    = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WJets_HT_600_800
-WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WJets_HT_800_1200
-WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WJets_HT_1200_2500
-WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WJets_HT_2500_Inf
+WJets_HT_0_100      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WJets_HT_0_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WJets_HT_2500_Inf
 
-TWtop                  = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ST_tW_top
-TWantitop              = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ST_tW_antitop
-singleTop_top          = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ST_tchannel_top
-singleTop_antitop      = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ST_tchannel_antitop
+TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ST_tchannel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ST_tchannel_antitop
 
-EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_EWKWMinus2Jets_WToLNu
-EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_EWKWPlus2Jets_WToLNu
-EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_EWKZ2Jets_ZToLL
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_EWKZ2Jets_ZToLL
 
-WWTo2L2Nu    = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WWTo2L2Nu
-WWTo4Q       = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WWTo4Q
-WWToLNuQQ    = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WWToLNuQQ
+WWTo2L2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WWTo2L2Nu
+WWTo4Q       = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WWTo4Q
+WWToLNuQQ    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WWToLNuQQ
 
-WZTo1L1Nu2Q  = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WZTo1L1Nu2Q
-WZTo1L3Nu    = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WZTo1L3Nu
-WZTo2L2Q     = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WZTo2L2Q
-WZTo3LNu     = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WZTo3LNu
+WZTo1L1Nu2Q  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WZTo1L3Nu
+WZTo2L2Q     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WZTo2L2Q
+WZTo3LNu     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WZTo3LNu
 
-ZZTo2L2Nu    = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ZZTo2L2Nu
-ZZTo2L2Q     = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ZZTo2L2Q
-ZZTo2Q2Nu    = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ZZTo2Q2Nu
-ZZTo4L       = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ZZTo4L
+ZZTo2L2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ZZTo2L2Nu
+ZZTo2L2Q     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ZZTo2Q2Nu
+ZZTo4L       = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ZZTo4L
 
-ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ZH_HBB_ZLL
-ZH_HTauTau             = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ZH_HTauTau
-ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ZH_HBB_ZQQ
-ggHTauTau              = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ggHTauTau
-VBFHTauTau             = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_VBFHTauTau
-WplusHTauTau           = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WplusHTauTau
-WminusHTauTau          = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WminusHTauTau
-ttHJetTononBB          = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ttHJetTononBB
-ttHJetToBB             = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ttHJetToBB
-ttHJetToTauTau         = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ttHJetToTauTau
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ZH_HTauTau
+ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ZH_HBB_ZQQ
+ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ttHJetToBB
+ttHJetToTauTau         = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ttHJetToTauTau
 
-ZZZ                    = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_ZZZ
-WWW                    = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WWW
-WWZ                    = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WWZ
-WZZ                    = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_WZZ
+ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_ZZZ
+WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_WZZ
 
-TTWJetsToLNu           = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_TTWJetsToLNu
-TTWJetsToQQ            = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_TTWJetsToQQ
-TTZToLLNuNu            = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_TTZToLLNuNu
-TTZToQQ                = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_TTZToQQ
-TTWW                   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_TTWW
-TTWZ                   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_TTWZ
-TTZZ                   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_TTZZ
-TTWH                   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_TTWH
-TTZH                   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_TTZH
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_TTZToLLNuNu
+TTZToQQ                = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_TTZToQQ
+TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_TTZZ
+TTWH                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_TTWH
+TTZH                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_TTZH
 
 #########
 
-VBFSM    = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_VBFHH_CV_1_C2V_1_C3_1
-GGHHSM   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_HHRew_SM
+VBFSM    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_VBFHH_CV_1_C2V_1_C3_1
+GGHHSM   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_HHRew_SM
 
-GGHH_NLO_cHHH1_xs      = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_GGHH_NLO_cHHH1_xs
-GGHH_NLO_cHHH0_xs      = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_GGHH_NLO_cHHH0_xs
-GGHH_NLO_cHHH2p45_xs   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_GGHH_NLO_cHHH2p45_xs
-GGHH_NLO_cHHH5_xs      = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_GGHH_NLO_cHHH5_xs
+GGHH_NLO_cHHH1_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH0_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_GGHH_NLO_cHHH5_xs
 
-VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
-VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_VBFHH_CV_0_5_C2V_1_C3_1_xs
-VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_VBFHH_CV_1_5_C2V_1_C3_1_xs
-VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
-VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
-VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
-VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMMED_Legacy2018_12Nov2020/SKIM_VBFHH_CV_1_C2V_0_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_VBFHH_CV_0_5_C2V_1_C3_1_xs
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_VBFHH_CV_1_5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_VBFHH_CV_1_C2V_0_C3_1_xs
 
 
 ## specify here if a sample should use a user-defined efficiency bin for the normalization

--- a/config/sampleCfg_Legacy2018_mib_ETau.cfg
+++ b/config/sampleCfg_Legacy2018_mib_ETau.cfg
@@ -1,0 +1,132 @@
+[samples]
+DsingleMuA   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleMuon2018A
+DsingleMuB   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleMuon2018B
+DsingleMuC   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleMuon2018C
+DsingleMuD   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleMuon2018D
+
+DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018A
+DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018B
+DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018C
+DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018D
+
+DTauA        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_Tau2018A
+DTauB        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_Tau2018B
+DTauC        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_Tau2018C
+DTauD        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_Tau2018D
+
+########
+
+TTfullyHad     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TT_fullyHad
+TTfullyLep     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TT_fullyLep
+TTsemiLep      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TT_semiLep
+
+
+#incl
+
+DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY
+DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_lowMass
+
+DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_0b_30JPt
+DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_0b_50JPt
+DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_0b_100JPt
+DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_0b_200JPt
+DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_1b_30JPt
+DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_1b_50JPt
+DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_1b_100JPt
+DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_1b_200JPt
+DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_2b_30JPt
+DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_2b_50JPt
+DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_2b_100JPt
+DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_2b_200JPt
+
+
+WJets_HT_0_100      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WJets_HT_0_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WJets_HT_2500_Inf
+
+TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ST_tchannel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ST_tchannel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_EWKZ2Jets_ZToLL
+
+WWTo2L2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WWTo2L2Nu
+WWTo4Q       = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WWTo4Q
+WWToLNuQQ    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WWToLNuQQ
+
+WZTo1L1Nu2Q  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WZTo1L3Nu
+WZTo2L2Q     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WZTo2L2Q
+WZTo3LNu     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WZTo3LNu
+
+ZZTo2L2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ZZTo2L2Nu
+ZZTo2L2Q     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ZZTo2Q2Nu
+ZZTo4L       = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ZZTo4L
+
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ZH_HTauTau
+ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ZH_HBB_ZQQ
+ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ttHJetToBB
+ttHJetToTauTau         = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ttHJetToTauTau
+
+ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_ZZZ
+WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_WZZ
+
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TTZToLLNuNu
+TTZToQQ                = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TTZToQQ
+TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TTZZ
+TTWH                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TTWH
+TTZH                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TTZH
+
+#########
+
+VBFSM    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_VBFHH_CV_1_C2V_1_C3_1
+GGHHSM   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_HHRew_SM
+
+GGHH_NLO_cHHH1_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH0_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_VBFHH_CV_0_5_C2V_1_C3_1_xs
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_VBFHH_CV_1_5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_VBFHH_CV_1_C2V_0_C3_1_xs
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/sampleCfg_Legacy2018_mib_ETau.cfg
+++ b/config/sampleCfg_Legacy2018_mib_ETau.cfg
@@ -1,18 +1,8 @@
 [samples]
-DsingleMuA   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleMuon2018A
-DsingleMuB   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleMuon2018B
-DsingleMuC   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleMuon2018C
-DsingleMuD   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleMuon2018D
-
-DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018A
-DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018B
-DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018C
-DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018D
-
-DTauA        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_Tau2018A
-DTauB        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_Tau2018B
-DTauC        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_Tau2018C
-DTauD        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_Tau2018D
+DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleElectron2018A
+DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleElectron2018B
+DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleElectron2018C
+DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleElectron2018D
 
 ########
 

--- a/config/sampleCfg_Legacy2018_mib_ETau.cfg
+++ b/config/sampleCfg_Legacy2018_mib_ETau.cfg
@@ -10,9 +10,6 @@ TTfullyHad     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TT_f
 TTfullyLep     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TT_fullyLep
 TTsemiLep      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_TT_semiLep
 
-
-#incl
-
 DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY
 DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_DY_lowMass
 

--- a/config/sampleCfg_Legacy2018_mib_ETau_JERdown.cfg
+++ b/config/sampleCfg_Legacy2018_mib_ETau_JERdown.cfg
@@ -1,8 +1,8 @@
 [samples]
-DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018A
-DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018B
-DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018C
-DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018D
+DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleElectron2018A
+DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleElectron2018B
+DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleElectron2018C
+DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleElectron2018D
 
 ########
 
@@ -10,8 +10,6 @@ TTfullyHad     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_T
 TTfullyLep     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TT_fullyLep
 TTsemiLep      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TT_semiLep
 
-
-#incl
 
 DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY
 DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_lowMass

--- a/config/sampleCfg_Legacy2018_mib_ETau_JERdown.cfg
+++ b/config/sampleCfg_Legacy2018_mib_ETau_JERdown.cfg
@@ -1,0 +1,122 @@
+[samples]
+DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018A
+DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018B
+DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018C
+DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018D
+
+########
+
+TTfullyHad     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TT_fullyHad
+TTfullyLep     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TT_fullyLep
+TTsemiLep      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TT_semiLep
+
+
+#incl
+
+DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY
+DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_lowMass
+
+DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_0b_30JPt
+DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_0b_50JPt
+DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_0b_100JPt
+DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_0b_200JPt
+DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_1b_30JPt
+DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_1b_50JPt
+DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_1b_100JPt
+DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_1b_200JPt
+DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_2b_30JPt
+DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_2b_50JPt
+DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_2b_100JPt
+DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_2b_200JPt
+
+
+WJets_HT_0_100      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_0_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_2500_Inf
+
+TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ST_tchannel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ST_tchannel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_EWKZ2Jets_ZToLL
+
+WWTo2L2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WWTo2L2Nu
+WWTo4Q       = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WWTo4Q
+WWToLNuQQ    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WWToLNuQQ
+
+WZTo1L1Nu2Q  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WZTo1L3Nu
+WZTo2L2Q     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WZTo2L2Q
+WZTo3LNu     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WZTo3LNu
+
+ZZTo2L2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZZTo2L2Nu
+ZZTo2L2Q     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZZTo2Q2Nu
+ZZTo4L       = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZZTo4L
+
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZH_HTauTau
+ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZH_HBB_ZQQ
+ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ttHJetToBB
+ttHJetToTauTau         = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ttHJetToTauTau
+
+ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZZZ
+WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WZZ
+
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTZToLLNuNu
+TTZToQQ                = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTZToQQ
+TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTZZ
+TTWH                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTWH
+TTZH                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTZH
+
+#########
+
+VBFSM    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_1_C2V_1_C3_1
+GGHHSM   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_HHRew_SM
+
+GGHH_NLO_cHHH1_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH0_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_0_5_C2V_1_C3_1_xs
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_1_5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_1_C2V_0_C3_1_xs
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/sampleCfg_Legacy2018_mib_ETau_JERup.cfg
+++ b/config/sampleCfg_Legacy2018_mib_ETau_JERup.cfg
@@ -1,17 +1,14 @@
 [samples]
-DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018A
-DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018B
-DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018C
-DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018D
+DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleElectron2018A
+DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleElectron2018B
+DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleElectron2018C
+DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_ETau/SKIM_SingleElectron2018D
 
 ########
 
 TTfullyHad     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TT_fullyHad
 TTfullyLep     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TT_fullyLep
 TTsemiLep      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TT_semiLep
-
-
-#incl
 
 DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY
 DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_lowMass

--- a/config/sampleCfg_Legacy2018_mib_ETau_JERup.cfg
+++ b/config/sampleCfg_Legacy2018_mib_ETau_JERup.cfg
@@ -1,0 +1,122 @@
+[samples]
+DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018A
+DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018B
+DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018C
+DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018D
+
+########
+
+TTfullyHad     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TT_fullyHad
+TTfullyLep     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TT_fullyLep
+TTsemiLep      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TT_semiLep
+
+
+#incl
+
+DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY
+DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_lowMass
+
+DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_0b_30JPt
+DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_0b_50JPt
+DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_0b_100JPt
+DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_0b_200JPt
+DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_1b_30JPt
+DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_1b_50JPt
+DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_1b_100JPt
+DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_1b_200JPt
+DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_2b_30JPt
+DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_2b_50JPt
+DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_2b_100JPt
+DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_2b_200JPt
+
+
+WJets_HT_0_100      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_0_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_2500_Inf
+
+TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ST_tchannel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ST_tchannel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_EWKZ2Jets_ZToLL
+
+WWTo2L2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WWTo2L2Nu
+WWTo4Q       = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WWTo4Q
+WWToLNuQQ    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WWToLNuQQ
+
+WZTo1L1Nu2Q  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WZTo1L3Nu
+WZTo2L2Q     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WZTo2L2Q
+WZTo3LNu     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WZTo3LNu
+
+ZZTo2L2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZZTo2L2Nu
+ZZTo2L2Q     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZZTo2Q2Nu
+ZZTo4L       = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZZTo4L
+
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZH_HTauTau
+ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZH_HBB_ZQQ
+ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ttHJetToBB
+ttHJetToTauTau         = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ttHJetToTauTau
+
+ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZZZ
+WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WZZ
+
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTZToLLNuNu
+TTZToQQ                = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTZToQQ
+TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTZZ
+TTWH                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTWH
+TTZH                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTZH
+
+#########
+
+VBFSM    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_1_C2V_1_C3_1
+GGHHSM   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_HHRew_SM
+
+GGHH_NLO_cHHH1_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH0_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_0_5_C2V_1_C3_1_xs
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_1_5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_1_C2V_0_C3_1_xs
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/sampleCfg_Legacy2018_mib_JERdown.cfg
+++ b/config/sampleCfg_Legacy2018_mib_JERdown.cfg
@@ -1,18 +1,18 @@
 [samples]
-DsingleMuA   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleMuon2018A
-DsingleMuB   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleMuon2018B
-DsingleMuC   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleMuon2018C
-DsingleMuD   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleMuon2018D
+DsingleMuA   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleMuon2018A
+DsingleMuB   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleMuon2018B
+DsingleMuC   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleMuon2018C
+DsingleMuD   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleMuon2018D
 
-DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018A
-DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018B
-DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018C
-DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018D
+DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018A
+DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018B
+DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018C
+DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018D
 
-DTauA        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_Tau2018A
-DTauB        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_Tau2018B
-DTauC        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_Tau2018C
-DTauD        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_Tau2018D
+DTauA        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_Tau2018A
+DTauB        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_Tau2018B
+DTauC        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_Tau2018C
+DTauD        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_Tau2018D
 
 ########
 

--- a/config/sampleCfg_Legacy2018_mib_JERdown.cfg
+++ b/config/sampleCfg_Legacy2018_mib_JERdown.cfg
@@ -1,0 +1,132 @@
+[samples]
+DsingleMuA   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleMuon2018A
+DsingleMuB   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleMuon2018B
+DsingleMuC   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleMuon2018C
+DsingleMuD   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleMuon2018D
+
+DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018A
+DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018B
+DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018C
+DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_SingleElectron2018D
+
+DTauA        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_Tau2018A
+DTauB        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_Tau2018B
+DTauC        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_Tau2018C
+DTauD        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_Tau2018D
+
+########
+
+TTfullyHad     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TT_fullyHad
+TTfullyLep     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TT_fullyLep
+TTsemiLep      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TT_semiLep
+
+
+#incl
+
+DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY
+DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_lowMass
+
+DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_0b_30JPt
+DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_0b_50JPt
+DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_0b_100JPt
+DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_0b_200JPt
+DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_1b_30JPt
+DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_1b_50JPt
+DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_1b_100JPt
+DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_1b_200JPt
+DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_2b_30JPt
+DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_2b_50JPt
+DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_2b_100JPt
+DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_DY_2b_200JPt
+
+
+WJets_HT_0_100      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_0_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WJets_HT_2500_Inf
+
+TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ST_tchannel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ST_tchannel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_EWKZ2Jets_ZToLL
+
+WWTo2L2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WWTo2L2Nu
+WWTo4Q       = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WWTo4Q
+WWToLNuQQ    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WWToLNuQQ
+
+WZTo1L1Nu2Q  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WZTo1L3Nu
+WZTo2L2Q     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WZTo2L2Q
+WZTo3LNu     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WZTo3LNu
+
+ZZTo2L2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZZTo2L2Nu
+ZZTo2L2Q     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZZTo2Q2Nu
+ZZTo4L       = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZZTo4L
+
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZH_HTauTau
+ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZH_HBB_ZQQ
+ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ttHJetToBB
+ttHJetToTauTau         = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ttHJetToTauTau
+
+ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_ZZZ
+WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_WZZ
+
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTZToLLNuNu
+TTZToQQ                = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTZToQQ
+TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTZZ
+TTWH                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTWH
+TTZH                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_TTZH
+
+#########
+
+VBFSM    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_1_C2V_1_C3_1
+GGHHSM   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_HHRew_SM
+
+GGHH_NLO_cHHH1_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH0_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_0_5_C2V_1_C3_1_xs
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_1_5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERdown/SKIM_VBFHH_CV_1_C2V_0_C3_1_xs
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/sampleCfg_Legacy2018_mib_JERup.cfg
+++ b/config/sampleCfg_Legacy2018_mib_JERup.cfg
@@ -1,18 +1,18 @@
 [samples]
-DsingleMuA   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleMuon2018A
-DsingleMuB   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleMuon2018B
-DsingleMuC   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleMuon2018C
-DsingleMuD   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleMuon2018D
+DsingleMuA   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleMuon2018A
+DsingleMuB   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleMuon2018B
+DsingleMuC   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleMuon2018C
+DsingleMuD   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleMuon2018D
 
-DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018A
-DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018B
-DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018C
-DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018D
+DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018A
+DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018B
+DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018C
+DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_SingleElectron2018D
 
-DTauA        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_Tau2018A
-DTauB        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_Tau2018B
-DTauC        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_Tau2018C
-DTauD        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_Tau2018D
+DTauA        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_Tau2018A
+DTauB        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_Tau2018B
+DTauC        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_Tau2018C
+DTauD        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021/SKIM_Tau2018D
 
 ########
 

--- a/config/sampleCfg_Legacy2018_mib_JERup.cfg
+++ b/config/sampleCfg_Legacy2018_mib_JERup.cfg
@@ -1,0 +1,132 @@
+[samples]
+DsingleMuA   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleMuon2018A
+DsingleMuB   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleMuon2018B
+DsingleMuC   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleMuon2018C
+DsingleMuD   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleMuon2018D
+
+DsingleEleA  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018A
+DsingleEleB  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018B
+DsingleEleC  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018C
+DsingleEleD  =/gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_SingleElectron2018D
+
+DTauA        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_Tau2018A
+DTauB        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_Tau2018B
+DTauC        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_Tau2018C
+DTauD        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_Tau2018D
+
+########
+
+TTfullyHad     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TT_fullyHad
+TTfullyLep     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TT_fullyLep
+TTsemiLep      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TT_semiLep
+
+
+#incl
+
+DY_HM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY
+DY_LM = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_lowMass
+
+DY_0b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_0b_0JPt
+DY_0b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_0b_10JPt
+DY_0b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_0b_30JPt
+DY_0b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_0b_50JPt
+DY_0b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_0b_100JPt
+DY_0b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_0b_200JPt
+DY_1b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_1b_0JPt
+DY_1b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_1b_10JPt
+DY_1b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_1b_30JPt
+DY_1b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_1b_50JPt
+DY_1b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_1b_100JPt
+DY_1b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_1b_200JPt
+DY_2b_1Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_2b_0JPt
+DY_2b_2Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_2b_10JPt
+DY_2b_3Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_2b_30JPt
+DY_2b_4Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_2b_50JPt
+DY_2b_5Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_2b_100JPt
+DY_2b_6Pt = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_DY_2b_200JPt
+
+
+WJets_HT_0_100      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_0_100
+WJets_HT_100_200    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_100_200
+WJets_HT_200_400    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_200_400
+WJets_HT_400_600    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_400_600
+WJets_HT_600_800    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_600_800
+WJets_HT_800_1200   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WJets_HT_2500_Inf
+
+TWtop                  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ST_tW_top
+TWantitop              = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ST_tW_antitop
+singleTop_top          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ST_tchannel_top
+singleTop_antitop      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ST_tchannel_antitop
+
+EWKWMinus2Jets_WToLNu  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL        = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_EWKZ2Jets_ZToLL
+
+WWTo2L2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WWTo2L2Nu
+WWTo4Q       = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WWTo4Q
+WWToLNuQQ    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WWToLNuQQ
+
+WZTo1L1Nu2Q  = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WZTo1L1Nu2Q
+WZTo1L3Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WZTo1L3Nu
+WZTo2L2Q     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WZTo2L2Q
+WZTo3LNu     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WZTo3LNu
+
+ZZTo2L2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZZTo2L2Nu
+ZZTo2L2Q     = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZZTo2L2Q
+ZZTo2Q2Nu    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZZTo2Q2Nu
+ZZTo4L       = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZZTo4L
+
+ZH_HBB_ZLL             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZH_HBB_ZLL
+ZH_HTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZH_HTauTau
+ZH_HBB_ZQQ             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZH_HBB_ZQQ
+ggHTauTau              = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ggHTauTau
+VBFHTauTau             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHTauTau
+WplusHTauTau           = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WplusHTauTau
+WminusHTauTau          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WminusHTauTau
+ttHJetTononBB          = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ttHJetTononBB
+ttHJetToBB             = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ttHJetToBB
+ttHJetToTauTau         = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ttHJetToTauTau
+
+ZZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_ZZZ
+WWW                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WWW
+WWZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WWZ
+WZZ                    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_WZZ
+
+TTWJetsToLNu           = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTWJetsToLNu
+TTWJetsToQQ            = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTWJetsToQQ
+TTZToLLNuNu            = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTZToLLNuNu
+TTZToQQ                = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTZToQQ
+TTWW                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTWW
+TTWZ                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTWZ
+TTZZ                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTZZ
+TTWH                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTWH
+TTZH                   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_TTZH
+
+#########
+
+VBFSM    = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_1_C2V_1_C3_1
+GGHHSM   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_HHRew_SM
+
+GGHH_NLO_cHHH1_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH1_xs
+GGHH_NLO_cHHH0_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH0_xs
+GGHH_NLO_cHHH2p45_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH2p45_xs
+GGHH_NLO_cHHH5_xs      = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_GGHH_NLO_cHHH5_xs
+
+VBFHH_CV_1_C2V_1_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_1_C2V_1_C3_1_xs
+VBFHH_CV_0p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_0_5_C2V_1_C3_1_xs
+VBFHH_CV_1p5_C2V_1_C3_1_xs = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_1_5_C2V_1_C3_1_xs
+VBFHH_CV_1_C2V_1_C3_0_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_1_C2V_1_C3_0_xs
+VBFHH_CV_1_C2V_1_C3_2_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_1_C2V_1_C3_2_xs
+VBFHH_CV_1_C2V_2_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_1_C2V_2_C3_1_xs
+VBFHH_CV_1_C2V_0_C3_1_xs   = /gwteraz/users/brivio/SKIMS_Legacy2018_16Feb2021_JERup/SKIM_VBFHH_CV_1_C2V_0_C3_1_xs
+
+
+## specify here if a sample should use a user-defined efficiency bin for the normalization
+## tipical case: HH reweight, every new point needs to be normalised to a different weight sum
+## if nothing is specified, default bin num. 1 is used
+## NOTE: empty sections are ok for this config parser
+
+[userEffBin]
+#HH = 1

--- a/config/selectionCfg_ETau_Legacy2016_syst.cfg
+++ b/config/selectionCfg_ETau_Legacy2016_syst.cfg
@@ -809,6 +809,45 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v5_jesDown_11
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
 baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_nominal      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM10 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM11 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesUp        = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesDown      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_jesUp_Tot    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_up
+baseline_jesDown_Tot  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_down
+baseline_jesUp_1      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup1
+baseline_jesUp_2      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup2
+baseline_jesUp_3      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup3
+baseline_jesUp_4      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup4
+baseline_jesUp_5      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup5
+baseline_jesUp_6      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup6
+baseline_jesUp_7      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup7
+baseline_jesUp_8      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup8
+baseline_jesUp_9      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup9
+baseline_jesUp_10     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup10
+baseline_jesUp_11     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup11
+baseline_jesDown_1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown1
+baseline_jesDown_2    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown2
+baseline_jesDown_3    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown3
+baseline_jesDown_4    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown4
+baseline_jesDown_5    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown5
+baseline_jesDown_6    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown6
+baseline_jesDown_7    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown7
+baseline_jesDown_8    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown8
+baseline_jesDown_9    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown9
+baseline_jesDown_10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown10
+baseline_jesDown_11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown11
 
 # remove DY weights, they are already taken into account in baseline weights
 #btagLL    = bTagweightL

--- a/config/selectionCfg_ETau_Legacy2017_syst.cfg
+++ b/config/selectionCfg_ETau_Legacy2017_syst.cfg
@@ -809,6 +809,45 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v5_jesDown_11
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
 baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_nominal      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM10 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM11 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesUp        = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesDown      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_jesUp_Tot    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_up
+baseline_jesDown_Tot  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_down
+baseline_jesUp_1      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup1
+baseline_jesUp_2      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup2
+baseline_jesUp_3      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup3
+baseline_jesUp_4      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup4
+baseline_jesUp_5      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup5
+baseline_jesUp_6      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup6
+baseline_jesUp_7      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup7
+baseline_jesUp_8      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup8
+baseline_jesUp_9      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup9
+baseline_jesUp_10     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup10
+baseline_jesUp_11     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup11
+baseline_jesDown_1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown1
+baseline_jesDown_2    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown2
+baseline_jesDown_3    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown3
+baseline_jesDown_4    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown4
+baseline_jesDown_5    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown5
+baseline_jesDown_6    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown6
+baseline_jesDown_7    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown7
+baseline_jesDown_8    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown8
+baseline_jesDown_9    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown9
+baseline_jesDown_10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown10
+baseline_jesDown_11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown11
 
 # remove DY weights, they are already taken into account in baseline weights
 #btagLL    = bTagweightL

--- a/config/selectionCfg_ETau_Legacy2018_syst.cfg
+++ b/config/selectionCfg_ETau_Legacy2018_syst.cfg
@@ -807,6 +807,45 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v5_jesDown_11
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
 baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_nominal      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM10 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM11 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesUp        = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesDown      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_jesUp_Tot    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_up
+baseline_jesDown_Tot  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_down
+baseline_jesUp_1      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup1
+baseline_jesUp_2      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup2
+baseline_jesUp_3      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup3
+baseline_jesUp_4      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup4
+baseline_jesUp_5      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup5
+baseline_jesUp_6      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup6
+baseline_jesUp_7      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup7
+baseline_jesUp_8      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup8
+baseline_jesUp_9      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup9
+baseline_jesUp_10     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup10
+baseline_jesUp_11     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup11
+baseline_jesDown_1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown1
+baseline_jesDown_2    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown2
+baseline_jesDown_3    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown3
+baseline_jesDown_4    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown4
+baseline_jesDown_5    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown5
+baseline_jesDown_6    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown6
+baseline_jesDown_7    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown7
+baseline_jesDown_8    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown8
+baseline_jesDown_9    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown9
+baseline_jesDown_10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown10
+baseline_jesDown_11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown11
 
 # remove DY weights, they are already taken into account in baseline weights
 #btagLL    = bTagweightL

--- a/config/selectionCfg_MuTau_Legacy2016_syst.cfg
+++ b/config/selectionCfg_MuTau_Legacy2016_syst.cfg
@@ -811,6 +811,45 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v5_jesDown_11
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
 baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_nominal      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM10 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM11 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesUp        = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesDown      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_jesUp_Tot    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_up
+baseline_jesDown_Tot  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_down
+baseline_jesUp_1      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup1
+baseline_jesUp_2      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup2
+baseline_jesUp_3      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup3
+baseline_jesUp_4      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup4
+baseline_jesUp_5      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup5
+baseline_jesUp_6      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup6
+baseline_jesUp_7      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup7
+baseline_jesUp_8      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup8
+baseline_jesUp_9      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup9
+baseline_jesUp_10     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup10
+baseline_jesUp_11     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup11
+baseline_jesDown_1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown1
+baseline_jesDown_2    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown2
+baseline_jesDown_3    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown3
+baseline_jesDown_4    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown4
+baseline_jesDown_5    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown5
+baseline_jesDown_6    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown6
+baseline_jesDown_7    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown7
+baseline_jesDown_8    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown8
+baseline_jesDown_9    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown9
+baseline_jesDown_10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown10
+baseline_jesDown_11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown11
 
 # remove DY weights, they are already taken into account in baseline weights
 #btagLL    = bTagweightL

--- a/config/selectionCfg_MuTau_Legacy2017_syst.cfg
+++ b/config/selectionCfg_MuTau_Legacy2017_syst.cfg
@@ -809,6 +809,45 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v5_jesDown_11
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
 baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_nominal      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM10 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM11 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesUp        = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesDown      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_jesUp_Tot    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_up
+baseline_jesDown_Tot  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_down
+baseline_jesUp_1      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup1
+baseline_jesUp_2      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup2
+baseline_jesUp_3      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup3
+baseline_jesUp_4      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup4
+baseline_jesUp_5      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup5
+baseline_jesUp_6      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup6
+baseline_jesUp_7      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup7
+baseline_jesUp_8      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup8
+baseline_jesUp_9      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup9
+baseline_jesUp_10     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup10
+baseline_jesUp_11     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup11
+baseline_jesDown_1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown1
+baseline_jesDown_2    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown2
+baseline_jesDown_3    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown3
+baseline_jesDown_4    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown4
+baseline_jesDown_5    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown5
+baseline_jesDown_6    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown6
+baseline_jesDown_7    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown7
+baseline_jesDown_8    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown8
+baseline_jesDown_9    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown9
+baseline_jesDown_10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown10
+baseline_jesDown_11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown11
 
 # remove DY weights, they are already taken into account in baseline weights
 #btagLL    = bTagweightL

--- a/config/selectionCfg_MuTau_Legacy2018_syst.cfg
+++ b/config/selectionCfg_MuTau_Legacy2018_syst.cfg
@@ -807,6 +807,45 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v5_jesDown_11
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
 baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_nominal      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM10 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM11 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesUp        = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesDown      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_jesUp_Tot    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_up
+baseline_jesDown_Tot  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_down
+baseline_jesUp_1      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup1
+baseline_jesUp_2      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup2
+baseline_jesUp_3      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup3
+baseline_jesUp_4      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup4
+baseline_jesUp_5      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup5
+baseline_jesUp_6      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup6
+baseline_jesUp_7      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup7
+baseline_jesUp_8      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup8
+baseline_jesUp_9      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup9
+baseline_jesUp_10     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup10
+baseline_jesUp_11     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup11
+baseline_jesDown_1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown1
+baseline_jesDown_2    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown2
+baseline_jesDown_3    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown3
+baseline_jesDown_4    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown4
+baseline_jesDown_5    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown5
+baseline_jesDown_6    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown6
+baseline_jesDown_7    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown7
+baseline_jesDown_8    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown8
+baseline_jesDown_9    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown9
+baseline_jesDown_10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown10
+baseline_jesDown_11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown11
 
 # remove DY weights, they are already taken into account in baseline weights
 #btagLL    = bTagweightL

--- a/config/selectionCfg_TauTau_Legacy2016_syst.cfg
+++ b/config/selectionCfg_TauTau_Legacy2016_syst.cfg
@@ -809,6 +809,45 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v5_jesDown_11
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
 baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_nominal      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM10 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM11 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesUp        = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesDown      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_jesUp_Tot    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_up
+baseline_jesDown_Tot  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_down
+baseline_jesUp_1      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup1
+baseline_jesUp_2      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup2
+baseline_jesUp_3      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup3
+baseline_jesUp_4      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup4
+baseline_jesUp_5      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup5
+baseline_jesUp_6      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup6
+baseline_jesUp_7      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup7
+baseline_jesUp_8      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup8
+baseline_jesUp_9      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup9
+baseline_jesUp_10     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup10
+baseline_jesUp_11     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup11
+baseline_jesDown_1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown1
+baseline_jesDown_2    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown2
+baseline_jesDown_3    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown3
+baseline_jesDown_4    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown4
+baseline_jesDown_5    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown5
+baseline_jesDown_6    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown6
+baseline_jesDown_7    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown7
+baseline_jesDown_8    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown8
+baseline_jesDown_9    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown9
+baseline_jesDown_10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown10
+baseline_jesDown_11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown11
 
 # remove DY weights, they are already taken into account in baseline weights
 #btagLL    = bTagweightL

--- a/config/selectionCfg_TauTau_Legacy2017_syst.cfg
+++ b/config/selectionCfg_TauTau_Legacy2017_syst.cfg
@@ -810,6 +810,45 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v5_jesDown_11
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
 baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_nominal      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_tesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_tesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_tesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_tesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_tesUp_DM10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_tesDown_DM10 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_tesUp_DM11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_tesDown_DM11 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_eesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_eesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_eesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_eesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_mesUp        = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_mesDown      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape
+baseline_jesUp_Tot    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jes_up
+baseline_jesDown_Tot  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jes_down
+baseline_jesUp_1      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetup1
+baseline_jesUp_2      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetup2
+baseline_jesUp_3      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetup3
+baseline_jesUp_4      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetup4
+baseline_jesUp_5      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetup5
+baseline_jesUp_6      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetup6
+baseline_jesUp_7      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetup7
+baseline_jesUp_8      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetup8
+baseline_jesUp_9      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetup9
+baseline_jesUp_10     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetup10
+baseline_jesUp_11     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetup11
+baseline_jesDown_1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetdown1
+baseline_jesDown_2    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetdown2
+baseline_jesDown_3    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetdown3
+baseline_jesDown_4    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetdown4
+baseline_jesDown_5    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetdown5
+baseline_jesDown_6    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetdown6
+baseline_jesDown_7    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetdown7
+baseline_jesDown_8    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetdown8
+baseline_jesDown_9    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetdown9
+baseline_jesDown_10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetdown10
+baseline_jesDown_11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, customTauIdSF, bTagweightReshape_jetdown11
 
 # remove DY weights, they are already taken into account in baseline weights
 #btagLL    = bTagweightL

--- a/config/selectionCfg_TauTau_Legacy2018_syst.cfg
+++ b/config/selectionCfg_TauTau_Legacy2018_syst.cfg
@@ -807,6 +807,45 @@ DYclass_jesDown_11           = VBFloose_jesDown_11 , mpp_dy_v5_jesDown_11
 ## NOTE: no weight is applied for data (the simple Fill() is used)
 [selectionWeights]
 baseline  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF_new, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_nominal      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM10 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesUp_DM11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_tesDown_DM11 = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM0    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM0  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesUp_DM1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_eesDown_DM1  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesUp        = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_mesDown      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape
+baseline_jesUp_Tot    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_up
+baseline_jesDown_Tot  = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jes_down
+baseline_jesUp_1      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup1
+baseline_jesUp_2      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup2
+baseline_jesUp_3      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup3
+baseline_jesUp_4      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup4
+baseline_jesUp_5      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup5
+baseline_jesUp_6      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup6
+baseline_jesUp_7      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup7
+baseline_jesUp_8      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup8
+baseline_jesUp_9      = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup9
+baseline_jesUp_10     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup10
+baseline_jesUp_11     = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetup11
+baseline_jesDown_1    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown1
+baseline_jesDown_2    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown2
+baseline_jesDown_3    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown3
+baseline_jesDown_4    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown4
+baseline_jesDown_5    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown5
+baseline_jesDown_6    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown6
+baseline_jesDown_7    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown7
+baseline_jesDown_8    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown8
+baseline_jesDown_9    = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown9
+baseline_jesDown_10   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown10
+baseline_jesDown_11   = MC_weight, PUReweight, PUjetID_SF, L1pref_weight, prescaleWeight, trigSF, IdAndIsoAndFakeSF_deep_pt, DYscale_MTT, bTagweightReshape_jetdown11
 
 # remove DY weights, they are already taken into account in baseline weights
 #btagLL    = bTagweightL

--- a/config/skim_Legacy2016_mib.cfg
+++ b/config/skim_Legacy2016_mib.cfg
@@ -6,6 +6,8 @@
 beInclusive = true
 #use deepFlavor to order jets
 useDeepFlavor = true
+# Store only ETau/MuTau/TauTau events in the skims
+onlyFinalChannels = false
 
 [parameters]
 

--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -7,6 +7,8 @@
 beInclusive = true
 #use deepFlavor to order jets
 useDeepFlavor = true
+# Store only ETau/MuTau/TauTau events in the skims
+onlyFinalChannels = false
 
 [parameters]
 

--- a/config/skim_Legacy2018.cfg
+++ b/config/skim_Legacy2018.cfg
@@ -6,6 +6,8 @@
 beInclusive = true
 #use deepFlavor to order jets
 useDeepFlavor = true
+# Store only ETau/MuTau/TauTau events in the skims
+onlyFinalChannels = false
 
 [parameters]
 

--- a/config/skim_Legacy2018_mib.cfg
+++ b/config/skim_Legacy2018_mib.cfg
@@ -6,6 +6,8 @@
 beInclusive = true
 #use deepFlavor to order jets
 useDeepFlavor = true
+# Store only ETau/MuTau/TauTau events in the skims
+onlyFinalChannels = false
 
 [parameters]
 
@@ -73,17 +75,17 @@ vbfTriggers = HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1_v, HLT_VBF_Double
 
 
 [bTagScaleFactors]
-SFFileDeepFlavor  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/bTagWeights/deepjet_2018_Jan2021.csv
-effFileDeepFlavor = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/bTagWeights/bTagEfficiencies_DeepFlavor_Legacy2018_1Jun2020.root
+SFFileDeepFlavor  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/bTagWeights/deepjet_2018_Jan2021.csv
+effFileDeepFlavor = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/bTagWeights/bTagEfficiencies_DeepFlavor_Legacy2018_1Jun2020.root
 
-#SFFileDeepCSV  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/bTagWeights/DeepCSV_102XSF_V1.csv
-SFFileDeepCSV  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/bTagWeights/DeepCSV_102XSF_V2.csv
+#SFFileDeepCSV  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/bTagWeights/DeepCSV_102XSF_V1.csv
+SFFileDeepCSV  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/bTagWeights/DeepCSV_102XSF_V2.csv
 #dummy, we leave it implemented just in case but for the time being it was not necessary to update these efficiencies 
-effFileDeepCSV = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/bTagWeights/bTagEfficiencies_DeepCSV_2018_Jan20.root
+effFileDeepCSV = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/bTagWeights/bTagEfficiencies_DeepCSV_2018_Jan20.root
 
 
 [PUjetIDScaleFactors]
-files = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/PUjetIDSF/
+files = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/PUjetIDSF/
 
 [JetSmearing]
 doSmearing = true
@@ -97,14 +99,14 @@ skipTriggers = false
 
 [BDTsm]
 computeMVA = false
-weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/newBDT/BDTnewSM.xml
+weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/newBDT/BDTnewSM.xml
 kl         = 1
 variables  = bjet2_pt:pt_b2, bH_pt:pt_hbb, dau1_pt:pt_l1, dau2_pt:pt_l2, tauH_SVFIT_pt:pt_htautau_sv, BDT_HT20:HT_otherjets, p_zeta:p_zeta, p_zeta_visible:p_zetavisible, BDT_ditau_deltaPhi:dphi_l1l2, BDT_tauHsvfitMet_deltaPhi:dphi_METhtautau_sv, mT_tauH_MET:MT_htautau, mT_total:MT_tot, MT2:MT2, BDT_MX:mass_X, BDT_bH_tauH_MET_InvMass:mass_H, BDT_bH_tauH_SVFIT_InvMass:mass_H_sv, BDT_bH_tauH_InvMass:mass_H_vis, HHKin_mass_raw:mass_H_kinfit, HHKin_mass_raw_chi2:mass_H_kinfit_chi2, BDT_MET_bH_cosTheta:costheta_METhbb
 
 
 [BDTlm]
 computeMVA = false
-weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/newBDT/BDTnewLM.xml
+weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/newBDT/BDTnewLM.xml
 mass       = 250, 280, 320, 350, 400, 450, 650, 900
 spin       = 0 #, 1
 variables  = bH_pt:pt_hbb, tauH_MET_pt:pt_htautau, met_et:pt_MET, p_zeta_visible:p_zetavisible, BDT_ditau_deltaPhi:dphi_l1l2, BDT_dib_deltaPhi:dphi_b1b2, BDT_dau1MET_deltaPhi:dphi_l1MET, bH_MET_deltaR:dR_hbbMET, ditau_deltaR_per_tauH_MET_pt:dR_l1l2Pt_htautau, ditau_deltaR_per_tauHsvfitpt:dR_l1l2Pt_htautau_sv, mT1:MT_l1, mT_tauH_SVFIT_MET:MT_htautau_sv, MT2:MT2, BDT_topPairMasses:mass_top1, BDT_bH_tauH_MET_InvMass:mass_H, BDT_bH_tauH_InvMass:mass_H_vis, HHKin_mass_raw:mass_H_kinfit, HHKin_mass_raw_chi2:mass_H_kinfit_chi2, BDT_dib_CalcPhi:phi_2_sv,  BDT_MET_tauH_SVFIT_cosTheta:costheta_METhtautau_sv
@@ -112,7 +114,7 @@ variables  = bH_pt:pt_hbb, tauH_MET_pt:pt_htautau, met_et:pt_MET, p_zeta_visible
 
 [BDTmm]
 computeMVA = false
-weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/newBDT/BDTnewMM.xml
+weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/newBDT/BDTnewMM.xml
 mass       = 250, 280, 320, 350, 400, 450, 650, 900
 spin       = 0 #, 1
 variables  = tauH_pt:pt_l1l2, p_zeta:p_zeta, BDT_dib_abs_deltaPhi:abs_dphi_b1b2, BDT_tauHsvfitMet_abs_deltaPhi:abs_dphi_METhtautau_sv, BDT_HHsvfit_abs_deltaPhi:abs_dphi_hbbhatutau_sv, dib_deltaEta:abs_deta_b1b2, dau2_MET_deltaEta:abs_deta_l2MET, bH_MET_deltaEta:abs_deta_hbbMET, ditau_deltaR:dR_l1l2, mT1:MT_l1, mT_tauH_SVFIT_MET:MT_htautau_sv, mT_total:MT_tot, BDT_MX:mass_X, BDT_bH_tauH_InvMass:mass_H_vis,  HHKin_mass_raw:mass_H_kinfit, HHKin_mass_raw_chi2:mass_H_kinfit_chi2, BDT_total_CalcPhi:phi_sv, BDT_ditau_CalcPhi:phi_1_sv, BDT_b1_bH_cosTheta:costheta_b1hbb, BDT_tauH_SVFIT_reson_cosTheta:costheta_htautau_svhhMET
@@ -120,7 +122,7 @@ variables  = tauH_pt:pt_l1l2, p_zeta:p_zeta, BDT_dib_abs_deltaPhi:abs_dphi_b1b2,
 
 [BDThm]
 computeMVA = false
-weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/newBDT/BDTnewHM.xml
+weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/newBDT/BDTnewHM.xml
 mass       = 250, 280, 320, 350, 400, 450, 650, 900
 spin       = 0 #, 1
 variables  = bH_pt:pt_hbb, dau1_pt:pt_l1, dau2_pt:pt_l2, tauH_SVFIT_pt:pt_htautau_sv, BDT_HT20:HT_otherjets, p_zeta:p_zeta, p_zeta_visible:p_zetavisible, BDT_tauHsvfitMet_abs_deltaPhi:abs_dphi_METhtautau_sv, BDT_bHMet_deltaPhi:dphi_hbbMET, ditau_deltaR:dR_l1l2, bH_tauH_MET_deltaR:dR_hbbhtautau, tauH_SVFIT_mass:mass_htautau_sv, mT_tauH_MET:MT_htautau, MT2:MT2, BDT_MX:mass_X,  BDT_bH_tauH_MET_InvMass:mass_H, BDT_bH_tauH_SVFIT_InvMass:mass_H_sv, BDT_bH_tauH_InvMass:mass_H_vis, HHKin_mass_raw:mass_H_kinfit, HHKin_mass_raw_chi2:mass_H_kinfit_chi2
@@ -128,7 +130,7 @@ variables  = bH_pt:pt_hbb, dau1_pt:pt_l1, dau2_pt:pt_l2, tauH_SVFIT_pt:pt_htauta
 
 [BDTVBF]
 computeMVA = false
-weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/newBDT/BDTVBF.xml
+weights    = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/newBDT/BDTVBF.xml
 #variables  = VBFjj_dEtaSign:BDT_j1j2n_dEtaSign, HH_deltaR:BDT_n_HH_deltaR, dib_dEtaSign:BDT_n_b1b2_dEtaSign, VBFjj_deltaEta:BDT_j1j2n_dEta, VBFjj_mass:BDT_j1j2n_Mjj, VBFjet2_pt:BDT_j2n_pt, tauH_pt:BDT_n_ditau_pt, bH_VBF1_deltaEta:BDT_bbH_j1n_dEta, VBFjet1_btag:BDT_j1n_csv, VBFjet1_pt:BDT_j1n_pt, dib_deltaR:BDT_n_dib_deltaR, VBFjet2_PUjetID:BDT_j2n_PUjetID
 variables  = VBFjet1_pt:BDT_j1n_pt, bH_pt:BDT_n_bH_pt, dib_dEtaSign:BDT_n_b1b2_dEtaSign, ditau_deltaR:ditau_deltaR, HH_deltaR:BDT_n_HH_deltaR, HH_zV:BDT_HH_zV_n, VBFjj_dEtaSign:BDT_j1j2n_dEtaSign, VBFjj_mass:BDT_j1j2n_Mjj
 
@@ -136,17 +138,17 @@ variables  = VBFjet1_pt:BDT_j1n_pt, bH_pt:BDT_n_bH_pt, dib_dEtaSign:BDT_n_b1b2_d
 
 [DNN]
 computeMVA = true
-weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
-features = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
+weights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
+features = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
 kl = 1
 
 [HHbtag]
-weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/HHTools/HHbtag/models/HHbtag_v1_par_
+weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/HHTools/HHbtag/models/HHbtag_v1_par_
 
 [HHReweight]
-inputFile = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/outMap_5Dbinning_Legacy2018.root
+inputFile = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/outMap_5Dbinning_Legacy2018.root
 histoName = allHHNodeMap
-coeffFile = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/coefficientsByBin_extended_3M_costHHSim_19-4.txt
+coeffFile = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weights/coefficientsByBin_extended_3M_costHHSim_19-4.txt
 
 [Multiclass]
 computeMVA = true
@@ -158,15 +160,15 @@ doMT2      = true
 doKinFit   = true
 doSVfit    = true
 doDNN      = true
-doBDT      = true
+doBDT      = false
 doMult     = true
 
-doVBFtrig  = true
+doVBFtrig  = false
 doNominal  = false
 doMES      = true
 doEES      = true
 doTES      = true
-doSplitJES = false
+doSplitJES = true
 doTotalJES = true
 
 kl       = 1

--- a/config/systematics_QCD2016.cfg
+++ b/config/systematics_QCD2016.cfg
@@ -7,14 +7,25 @@
 # 'unc1 = systName:systValue'
 # 'unc2 = systName:systValue'
 
+###############
+### boosted ###
+###############
+[ETau_boosted] # No uncertainty, just here for correct parsing
+
+[MuTau_boosted] # No uncertainty, just here for correct parsing
+
+[TauTau_boosted]
+unc1 = CMS_bbtt_2016_QCDratio:0./2.98
+
+
 #############
 ### res1b ###
 #############
 [ETau_res1b]
-unc1 = CMS_bbtt_2016_QCDratio:1.214
+unc1 = CMS_bbtt_2016_QCDratio:1.148
 
 [MuTau_res1b]
-unc1 = CMS_bbtt_2016_QCDratio:1.068
+unc1 = CMS_bbtt_2016_QCDratio:1.071
 
 [TauTau_res1b]
 unc1 = CMS_bbtt_2016_QCDratio:1.076
@@ -24,25 +35,26 @@ unc1 = CMS_bbtt_2016_QCDratio:1.076
 ### res2b ###
 #############
 [ETau_res2b]
-unc1 = CMS_bbtt_2016_QCDratio:1.728
-unc2 = CMS_bbtt_2016_QCDadditional:0./5.089
+unc1 = CMS_bbtt_2016_QCDratio:1.428
 
 [MuTau_res2b]
-unc1 = CMS_bbtt_2016_QCDratio:1.161
+unc1 = CMS_bbtt_2016_QCDratio:1.186
 
 [TauTau_res2b]
-unc1 = CMS_bbtt_2016_QCDratio:0./2.027
+unc1 = CMS_bbtt_2016_QCDratio:0./2.185
 
 
-###############
-### boosted ###
-###############
-[ETau_boosted] # No uncertainty, just here for correct parsing
+################
+### classVBF ###
+################
+[ETau_classVBF]
+unc1 = CMS_bbtt_2016_QCDratio:2.22
 
-[MuTau_boosted] # No uncertainty, just here for correct parsing
+[MuTau_classVBF]
+unc1 = CMS_bbtt_2016_QCDratio:1.817
 
-[TauTau_boosted]
-unc1 = CMS_bbtt_2016_QCDratio:0./2.705
+[TauTau_classVBF]
+unc1 = CMS_bbtt_2016_QCDratio:1.272
 
 
 ################
@@ -50,24 +62,21 @@ unc1 = CMS_bbtt_2016_QCDratio:0./2.705
 ################
 [ETau_classGGF] # No uncertainty, just here for correct parsing
 
-[MuTau_classGGF]
-unc1 = CMS_bbtt_2016_QCDratio:1.204
+[MuTau_classGGF] # No uncertainty, just here for correct parsing
 
 [TauTau_classGGF]
-unc1 = CMS_bbtt_2016_QCDratio:1.269
+unc1 = CMS_bbtt_2016_QCDratio:1.272
 
 
-################
-### classVBF ###
-################
-[ETau_classVBF]
-unc1 = CMS_bbtt_2016_QCDratio:1.922
+###############
+### classTT ###
+###############
+[ETau_classTT] # No uncertainty, just here for correct parsing
 
-[MuTau_classVBF]
-unc1 = CMS_bbtt_2016_QCDratio:1.204
+[MuTau_classTT] # No uncertainty, just here for correct parsing
 
-[TauTau_classVBF]
-unc1 = CMS_bbtt_2016_QCDratio:1.269
+[TauTau_classTT]
+unc1 = CMS_bbtt_2016_QCDratio:1.272
 
 
 ################
@@ -76,33 +85,19 @@ unc1 = CMS_bbtt_2016_QCDratio:1.269
 [ETau_classttH] # No uncertainty, just here for correct parsing
 
 [MuTau_classttH]
-unc1 = CMS_bbtt_2016_QCDratio:1.204
+unc1 = CMS_bbtt_2016_QCDratio:1.817
 
-[TauTau_classttH] # No uncertainty, just here for correct parsing 
+[TauTau_classttH] # No uncertainty, just here for correct parsing
 
 
 ###############
 ### classDY ###
 ###############
-[ETau_classDY]
-unc1 = CMS_bbtt_2016_QCDratio:1.922
-unc2 = CMS_bbtt_2016_QCDadditional:0./2.638
+[ETau_classDY] # No uncertainty, just here for correct parsing
 
 [MuTau_classDY]
-unc1 = CMS_bbtt_2016_QCDratio:1.204
+unc1 = CMS_bbtt_2016_QCDratio:1.817
+unc2 = CMS_bbtt_2016_QCDadditional:1.812
 
 [TauTau_classDY]
-unc1 = CMS_bbtt_2016_QCDratio:1.269
-
-
-###############
-### classTT ###
-###############
-[ETau_classTT]
-unc1 = CMS_bbtt_2016_QCDratio:1.922
-
-[MuTau_classTT]
-unc1 = CMS_bbtt_2016_QCDratio:1.204
-
-[TauTau_classTT]
-unc1 = CMS_bbtt_2016_QCDratio:1.269
+unc1 = CMS_bbtt_2016_QCDratio:1.272

--- a/config/systematics_QCD2017.cfg
+++ b/config/systematics_QCD2017.cfg
@@ -7,14 +7,25 @@
 # 'unc1 = systName:systValue'
 # 'unc2 = systName:systValue'
 
+###############
+### boosted ###
+###############
+[ETau_boosted] # No uncertainty, just here for correct parsing
+
+[MuTau_boosted] # No uncertainty, just here for correct parsing
+
+[TauTau_boosted]
+unc1 = CMS_bbtt_2017_QCDratio:1.445
+
+
 #############
 ### res1b ###
 #############
 [ETau_res1b]
-unc1 = CMS_bbtt_2017_QCDratio:1.137
+unc1 = CMS_bbtt_2017_QCDratio:1.10
 
 [MuTau_res1b]
-unc1 = CMS_bbtt_2017_QCDratio:1.057
+unc1 = CMS_bbtt_2017_QCDratio:1.074
 
 [TauTau_res1b]
 unc1 = CMS_bbtt_2017_QCDratio:1.059
@@ -26,84 +37,66 @@ unc1 = CMS_bbtt_2017_QCDratio:1.059
 [ETau_res2b] # No uncertainty, just here for correct parsing
 
 [MuTau_res2b]
-unc1 = CMS_bbtt_2017_QCDratio:1.227
+unc1 = CMS_bbtt_2017_QCDratio:1.177
 
 [TauTau_res2b]
-unc1 = CMS_bbtt_2017_QCDratio:1.213
-
-
-###############
-### boosted ###
-###############
-[ETau_boosted] # No uncertainty, just here for correct parsing
-
-[MuTau_boosted] # No uncertainty, just here for correct parsing
-
-[TauTau_boosted]
-unc1 = CMS_bbtt_2017_QCDratio:1.430
-
-
-################
-### classGGF ###
-################
-[ETau_classGGF]
-unc1 = CMS_bbtt_2017_QCDratio:1.331
-
-[MuTau_classGGF]
-unc1 = CMS_bbtt_2017_QCDratio:1.149
-
-[TauTau_classGGF]
-unc1 = CMS_bbtt_2017_QCDratio:1.202
+unc1 = CMS_bbtt_2017_QCDratio:1.219
 
 
 ################
 ### classVBF ###
 ################
 [ETau_classVBF]
-unc1 = CMS_bbtt_2017_QCDratio:1.331
+unc1 = CMS_bbtt_2017_QCDratio:1.683
 
 [MuTau_classVBF]
-unc1 = CMS_bbtt_2017_QCDratio:1.149
+unc1 = CMS_bbtt_2017_QCDratio:1.267
 
 [TauTau_classVBF]
-unc1 = CMS_bbtt_2017_QCDratio:1.202
+unc1 = CMS_bbtt_2017_QCDratio:1.232
 
 
 ################
-### classttH ###
+### classGGF ###
 ################
-[ETau_classttH]
-unc1 = CMS_bbtt_2017_QCDratio:1.331
+[ETau_classGGF] # No uncertainty, just here for correct parsing
 
-[MuTau_classttH]
-unc1 = CMS_bbtt_2017_QCDratio:1.149
+[MuTau_classGGF] # No uncertainty, just here for correct parsing
 
-[TauTau_classttH]
-unc1 = CMS_bbtt_2017_QCDratio:1.202
-
-
-###############
-### classDY ###
-###############
-[ETau_classDY]
-unc1 = CMS_bbtt_2017_QCDratio:1.331
-unc2 = CMS_bbtt_2016_QCDadditional:1.396
-
-[MuTau_classDY]
-unc1 = CMS_bbtt_2017_QCDratio:1.149
-
-[TauTau_classDY]
-unc1 = CMS_bbtt_2017_QCDratio:1.202
+[TauTau_classGGF]
+unc1 = CMS_bbtt_2017_QCDratio:1.232
 
 
 ###############
 ### classTT ###
 ###############
-[ETau_classTT]
-unc1 = CMS_bbtt_2017_QCDratio:1.331
+[ETau_classTT] # No uncertainty, just here for correct parsing
 
 [MuTau_classTT]
-unc1 = CMS_bbtt_2017_QCDratio:1.149
+unc1 = CMS_bbtt_2017_QCDratio:1.267
 
 [TauTau_classTT]
-unc1 = CMS_bbtt_2017_QCDratio:1.202
+unc1 = CMS_bbtt_2017_QCDratio:1.232
+
+
+################
+### classttH ###
+################
+[ETau_classttH] # No uncertainty, just here for correct parsing
+
+[MuTau_classttH] # No uncertainty, just here for correct parsing
+
+[TauTau_classttH]
+unc1 = CMS_bbtt_2017_QCDratio:1.232
+
+
+###############
+### classDY ###
+###############
+[ETau_classDY] # No uncertainty, just here for correct parsing
+
+[MuTau_classDY]
+unc1 = CMS_bbtt_2017_QCDratio:1.267
+
+[TauTau_classDY]
+unc1 = CMS_bbtt_2017_QCDratio:1.232

--- a/config/systematics_QCD2018.cfg
+++ b/config/systematics_QCD2018.cfg
@@ -7,32 +7,6 @@
 # 'unc1 = systName:systValue'
 # 'unc2 = systName:systValue'
 
-#############
-### res1b ###
-#############
-[ETau_res1b]
-unc1 = CMS_bbtt_2018_QCDratio:1.138
-
-[MuTau_res1b]
-unc1 = CMS_bbtt_2018_QCDratio:1.154
-
-[TauTau_res1b]
-unc1 = CMS_bbtt_2018_QCDratio:1.046
-
-
-#############
-### res2b ###
-#############
-[ETau_res2b]
-unc1 = CMS_bbtt_2018_QCDratio:1.269
-
-[MuTau_res2b]
-unc1 = CMS_bbtt_2018_QCDratio:1.111
-
-[TauTau_res2b]
-unc1 = CMS_bbtt_2018_QCDratio:1.212
-
-
 ###############
 ### boosted ###
 ###############
@@ -41,20 +15,32 @@ unc1 = CMS_bbtt_2018_QCDratio:1.212
 [MuTau_boosted] # No uncertainty, just here for correct parsing
 
 [TauTau_boosted]
-unc1 = CMS_bbtt_2018_QCDratio:1.650
+unc1 = CMS_bbtt_2018_QCDratio:1.606
 
 
-################
-### classGGF ###
-################
-[ETau_classGGF]  # No uncertainty, just here for correct parsing
-
-[MuTau_classGGF]
+#############
+### res1b ###
+#############
+[ETau_res1b]
 unc1 = CMS_bbtt_2018_QCDratio:1.100
-unc2 = CMS_bbtt_2016_QCDadditional:0./2.537
 
-[TauTau_classGGF]
-unc1 = CMS_bbtt_2018_QCDratio:1.138
+[MuTau_res1b]
+unc1 = CMS_bbtt_2018_QCDratio:1.136
+
+[TauTau_res1b]
+unc1 = CMS_bbtt_2018_QCDratio:1.047
+
+
+#############
+### res2b ###
+#############
+[ETau_res2b] # No uncertainty, just here for correct parsing
+
+[MuTau_res2b]
+unc1 = CMS_bbtt_2018_QCDratio:1.108
+
+[TauTau_res2b]
+unc1 = CMS_bbtt_2018_QCDratio:1.216
 
 
 ################
@@ -63,47 +49,58 @@ unc1 = CMS_bbtt_2018_QCDratio:1.138
 [ETau_classVBF] # No uncertainty, just here for correct parsing
 
 [MuTau_classVBF]
-unc1 = CMS_bbtt_2018_QCDratio:1.100
+unc1 = CMS_bbtt_2018_QCDratio:1.116
 
 [TauTau_classVBF]
-unc1 = CMS_bbtt_2018_QCDratio:1.138
+unc1 = CMS_bbtt_2018_QCDratio:1.141
 
 
 ################
-### classttH ###
+### classGGF ###
 ################
-[ETau_classttH]
-unc1 = CMS_bbtt_2018_QCDratio:1.299
+[ETau_classGGF] # No uncertainty, just here for correct parsing
 
-[MuTau_classttH]
-unc1 = CMS_bbtt_2018_QCDratio:1.100
+[MuTau_classGGF]
+unc1 = CMS_bbtt_2018_QCDratio:1.116
+#unc2 = CMS_bbtt_2016_QCDadditional:0./16.0 # too large, makes no sense, commented out for now
 
-[TauTau_classttH] 
-unc1 = CMS_bbtt_2018_QCDratio:1.138
-unc2 = CMS_bbtt_2016_QCDadditional:0./3.884
-
-
-###############
-### classDY ###
-###############
-[ETau_classDY]
-unc1 = CMS_bbtt_2018_QCDratio:1.299
-
-[MuTau_classDY]
-unc1 = CMS_bbtt_2018_QCDratio:1.100
-
-[TauTau_classDY]
-unc1 = CMS_bbtt_2018_QCDratio:1.138
+[TauTau_classGGF]
+unc1 = CMS_bbtt_2018_QCDratio:1.141
 
 
 ###############
 ### classTT ###
 ###############
 [ETau_classTT]
-unc1 = CMS_bbtt_2018_QCDratio:1.299
+unc1 = CMS_bbtt_2018_QCDratio:1.257
 
 [MuTau_classTT]
-unc1 = CMS_bbtt_2018_QCDratio:1.100
+unc1 = CMS_bbtt_2018_QCDratio:1.116
 
 [TauTau_classTT]
-unc1 = CMS_bbtt_2018_QCDratio:1.138
+unc1 = CMS_bbtt_2018_QCDratio:1.141
+
+
+################
+### classttH ###
+################
+[ETau_classttH] # No uncertainty, just here for correct parsing
+
+[MuTau_classttH] # No uncertainty, just here for correct parsing
+
+[TauTau_classttH] 
+unc1 = CMS_bbtt_2018_QCDratio:1.141
+
+
+###############
+### classDY ###
+###############
+[ETau_classDY]
+unc1 = CMS_bbtt_2018_QCDratio:1.257
+
+[MuTau_classDY]
+unc1 = CMS_bbtt_2018_QCDratio:1.116
+unc2 = CMS_bbtt_2018_QCDadditional:1.077
+
+[TauTau_classDY]
+unc1 = CMS_bbtt_2018_QCDratio:1.141

--- a/scripts/bTagReshapeRfactor.py
+++ b/scripts/bTagReshapeRfactor.py
@@ -1,0 +1,73 @@
+import ROOT
+
+year = '2018'
+
+channels = ['TauTau', 'MuTau', 'ETau']
+#channels = ['ETau']
+
+systs = [
+    ['central'     , 'totBkg_baseline_SR_DNNoutSM_kl_1'],
+#    ['JESUp'       , 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeJESUp'],
+#    ['LFUp'        , 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeLFUp'],
+#    ['HFUp'        , 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeHFUp'],
+#    ['HFSTATS1Up'  , 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeHFSTATS1Up'],
+#    ['HFSTATS2Up'  , 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeHFSTATS2Up'],
+#    ['LFSTATS1Up'  , 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeLFSTATS1Up'],
+#    ['LFSTATS2Up'  , 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeLFSTATS2Up'],
+#    ['CFERR1Up'    , 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeCFERR1Up'],
+#    ['CFERR2Up'    , 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeCFERR2Up'],
+#    ['JESDown'     , 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeJESDown'],
+#    ['LFDown'      , 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeLFDown'],
+#    ['HFDown'      , 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeHFDown'],
+#    ['HFSTATS1Down', 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeHFSTATS1Down'],
+#    ['HFSTATS2Down', 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeHFSTATS2Down'],
+#    ['LFSTATS1Down', 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeLFSTATS1Down'],
+#    ['LFSTATS2Down', 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeLFSTATS2Down'],
+#    ['CFERR1Down'  , 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeCFERR1Down'],
+#    ['CFERR2Down'  , 'totBkg_baseline_SR_DNNoutSM_kl_1_bTagweightReshapeCFERR2Down'],
+]
+
+
+for channel in channels:
+
+    print '----------------------------------------------------'
+    print ' Doing channel', channel, 'for year', year
+
+    # Infile
+    infileName = '/gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/KLUBAnalysis/analysis_20Feb2021_rfactor/'+channel+'_'+year+'/outPlotter.root'
+    infile = ROOT.TFile(infileName, "READ")
+
+    # Before histo and integral
+    h_b = infile.Get('totBkg_baselineNoBtag_SR_DNNoutSM_kl_1')
+    y_b = h_b.Integral() * 1.0
+
+    print ' %-15s : %10s / %-10s --> r = %-10s' % ('syst', 'before', 'after', 'Rfactor')
+    for syst in systs:    
+        # After
+        h_a = infile.Get(syst[1])
+        y_a = h_a.Integral() * 1.0
+
+        r = y_b/y_a * 1.0
+
+        print ' %-15s : %10.3f / %-10.3f --> r = %-10.4f' % (syst[0], y_b, y_a, r)
+
+    print '----------------------------------------------------'
+
+
+#    # CP5 samples
+#    # Before histo and integral
+#    h_b_CP5 = infile.Get('totBkgCP5_baselineNobtag_SR_DNNoutSM_kl_1')
+#    y_b_CP5 = h_b_CP5.Integral() * 1.0
+#
+#    print '%-15s : %10s / %-10s --> r = %-10s' % ('syst', 'before', 'after', 'Rfactor')
+#    print '----------------------------------------------------'
+#    for syst in systs:    
+#        # After
+#        h_a_CP5 = infile.Get(syst[1].replace('totBkg_','totBkgCP5_'))
+#        y_a_CP5 = h_a_CP5.Integral() * 1.0
+#
+#        r_CP5 = y_b_CP5/y_a_CP5 * 1.0
+#
+#        print '%-15s : %10.3f / %-10.3f --> r = %-10.4f' % (syst[0], y_b_CP5, y_a_CP5, r_CP5)
+#
+#    print '----------------------------------------------------'

--- a/scripts/harvestHistoFiller.py
+++ b/scripts/harvestHistoFiller.py
@@ -43,6 +43,7 @@ for uncDir in uncDirs:
 
     # Read the main config for each unc and store the variables names
     for line in open(inDir+'/mainCfg_'+channel+'_Legacy'+year+'_limits.cfg'):
+        if 'JER' in inDir: continue
         if line.startswith('variables'):
             varNames = line.split('=')[1] # Get variables only
             varNames = varNames.strip()   # Remove carriage return
@@ -65,7 +66,7 @@ os.system(copyCommand)
 # Create a new main config starting from the central config,
 # but containing all the variables (central and shifted ones)
 newMainCfg = open(newDir+'/mainCfg_'+channel+'_Legacy'+year+'_limits.cfg','w')
-for line in open(inDir+'/mainCfg_'+channel+'_Legacy'+year+'_limits.cfg'):
+for line in open(tagDir+'/central/mainCfg_'+channel+'_Legacy'+year+'_limits.cfg'):
     # Edit line with variables
     if line.startswith('variables'):
         line = 'variables = ' + allVars + '\n'

--- a/scripts/harvestHistoFiller.py
+++ b/scripts/harvestHistoFiller.py
@@ -92,12 +92,12 @@ for uncDir in uncDirs:
         originalName = inDir+'/'+rootFile
         newName = originalName.replace('outPlotter_','NEWoutPlotter_')
 
-        # If not running on a JER subdirectory just copy/paste
-        # the root file wiht the updated name
-        if 'JER' not in uncDir:
+        # For central subdirectory just copy/paste the
+        # the root file with the updated name
+        if 'central' in uncDir:
             os.system('cp %s %s' % (originalName, newName))
 
-        # Else if running on the JER subdirectories
+        # Else if running on the shifted subdirectories
         # loop on all the histos and change names if needed
         else:
 
@@ -110,11 +110,14 @@ for uncDir in uncDirs:
                 kname = key.GetName()
                 template = fin.Get(kname)
 
+                # Do not copy the data for shifted subdirectories
+                if 'data_obs' in kname: continue
+
                 # Change name to histos in the JER subdirectories
                 # by adding '_JERup' or '_JERdown'
-                #if 'JER' in uncDir:
-                template.SetName(kname+'_'+uncDir)
-                template.SetTitle(kname+'_'+uncDir)
+                if 'JER' in uncDir:
+                    template.SetName(kname+'_'+uncDir)
+                    template.SetTitle(kname+'_'+uncDir)
 
                 # Store histos to be save in the new file
                 listHistos.append(template.Clone())
@@ -130,6 +133,3 @@ for uncDir in uncDirs:
 haddCommand = 'hadd '+newDir+'/outPlotter.root '+tagDir+'/*/NEWoutPlotter_*root '
 print haddCommand
 os.system(haddCommand)
-
-
-

--- a/scripts/launchHistoFiller.py
+++ b/scripts/launchHistoFiller.py
@@ -5,58 +5,60 @@ import sys
 import argparse
 import datetime
 
-
 # Configurables
 isCondor = 'True'    # allowed options: 'True' - 'False'
 year     = '2016'    # allowed options: '2016' - '2017' - 2018'
 channel  = 'TauTau'  # allowed options: 'ETau' - 'MuTau' - TauTau'
-tagDir   = 'analysis_2021_02_07'
+tagDir   = 'analysis_2021_03_01'
 
 # Variations to be run:
-# syntax --> [name of dir, name of var suffix, doSyst, njobs, bTagReshapeWeight suffix]
+# syntax --> [name of dir, name of var suffix, doSyst, njobs, bTagReshapeWeight suffix, JER suffix]
 uncertainties = [
- ['central'     ,''             , True ,'10', ''],
- ['tauup_DM0'   ,'_tauup_DM0'   , False, '1', ''],
- ['taudown_DM0' ,'_taudown_DM0' , False, '1', ''],
- ['tauup_DM1'   ,'_tauup_DM1'   , False, '1', ''],
- ['taudown_DM1' ,'_taudown_DM1' , False, '1', ''],
- ['tauup_DM10'  ,'_tauup_DM10'  , False, '1', ''],
- ['taudown_DM10','_taudown_DM10', False, '1', ''],
- ['tauup_DM11'  ,'_tauup_DM11'  , False, '1', ''],
- ['taudown_DM11','_taudown_DM11', False, '1', ''],
- ['eleup_DM0'   ,'_eleup_DM0'   , False, '1', ''],
- ['eledown_DM0' ,'_eledown_DM0' , False, '1', ''],
- ['eleup_DM1'   ,'_eleup_DM1'   , False, '1', ''],
- ['eledown_DM1' ,'_eledown_DM1' , False, '1', ''],
- ['muup'        ,'_muup'        , False, '1', ''],
- ['mudown'      ,'_mudown'      , False, '1', ''],
+ ['central'     ,''             , True ,'30', '', ''],
+ ['tauup_DM0'   ,'_tauup_DM0'   , False, '1', '', ''],
+ ['taudown_DM0' ,'_taudown_DM0' , False, '1', '', ''],
+ ['tauup_DM1'   ,'_tauup_DM1'   , False, '1', '', ''],
+ ['taudown_DM1' ,'_taudown_DM1' , False, '1', '', ''],
+ ['tauup_DM10'  ,'_tauup_DM10'  , False, '1', '', ''],
+ ['taudown_DM10','_taudown_DM10', False, '1', '', ''],
+ ['tauup_DM11'  ,'_tauup_DM11'  , False, '1', '', ''],
+ ['taudown_DM11','_taudown_DM11', False, '1', '', ''],
+ ['eleup_DM0'   ,'_eleup_DM0'   , False, '1', '', ''],
+ ['eledown_DM0' ,'_eledown_DM0' , False, '1', '', ''],
+ ['eleup_DM1'   ,'_eleup_DM1'   , False, '1', '', ''],
+ ['eledown_DM1' ,'_eledown_DM1' , False, '1', '', ''],
+ ['muup'        ,'_muup'        , False, '1', '', ''],
+ ['mudown'      ,'_mudown'      , False, '1', '', ''],
 
- ['jetupTot'    ,'_jetupTot'    , False, '1', '_jes_up'  ],
- ['jetdownTot'  ,'_jetdownTot'  , False, '1', '_jes_down'],
+ ['JERup'       ,''             , False, '1', '', '_JERup'],
+ ['JERdown'     ,''             , False, '1', '', '_JERdown'],
 
- ['jetup1'      ,'_jetup1'      , False, '1', '_jetup1' ],
- ['jetup2'      ,'_jetup2'      , False, '1', '_jetup2' ],
- ['jetup3'      ,'_jetup3'      , False, '1', '_jetup3' ],
- ['jetup4'      ,'_jetup4'      , False, '1', '_jetup4' ],
- ['jetup5'      ,'_jetup5'      , False, '1', '_jetup5' ],
- ['jetup6'      ,'_jetup6'      , False, '1', '_jetup6' ],
- ['jetup7'      ,'_jetup7'      , False, '1', '_jetup7' ],
- ['jetup8'      ,'_jetup8'      , False, '1', '_jetup8' ],
- ['jetup9'      ,'_jetup9'      , False, '1', '_jetup9' ],
- ['jetup10'     ,'_jetup10'     , False, '1', '_jetup10'],
- ['jetup11'     ,'_jetup11'     , False, '1', '_jetup11'],
+ ['jetupTot'    ,'_jetupTot'    , False, '1', '_jes_up'  , ''],
+ ['jetdownTot'  ,'_jetdownTot'  , False, '1', '_jes_down', ''],
 
- ['jetdown1'    ,'_jetdown1'    , False, '1', '_jetdown1' ],
- ['jetdown2'    ,'_jetdown2'    , False, '1', '_jetdown2' ],
- ['jetdown3'    ,'_jetdown3'    , False, '1', '_jetdown3' ],
- ['jetdown4'    ,'_jetdown4'    , False, '1', '_jetdown4' ],
- ['jetdown5'    ,'_jetdown5'    , False, '1', '_jetdown5' ],
- ['jetdown6'    ,'_jetdown6'    , False, '1', '_jetdown6' ],
- ['jetdown7'    ,'_jetdown7'    , False, '1', '_jetdown7' ],
- ['jetdown8'    ,'_jetdown8'    , False, '1', '_jetdown8' ],
- ['jetdown9'    ,'_jetdown9'    , False, '1', '_jetdown9' ],
- ['jetdown10'   ,'_jetdown10'   , False, '1', '_jetdown10'],
- ['jetdown11'   ,'_jetdown11'   , False, '1', '_jetdown11']
+ ['jetup1'      ,'_jetup1'      , False, '1', '_jetup1' , ''],
+ ['jetup2'      ,'_jetup2'      , False, '1', '_jetup2' , ''],
+ ['jetup3'      ,'_jetup3'      , False, '1', '_jetup3' , ''],
+ ['jetup4'      ,'_jetup4'      , False, '1', '_jetup4' , ''],
+ ['jetup5'      ,'_jetup5'      , False, '1', '_jetup5' , ''],
+ ['jetup6'      ,'_jetup6'      , False, '1', '_jetup6' , ''],
+ ['jetup7'      ,'_jetup7'      , False, '1', '_jetup7' , ''],
+ ['jetup8'      ,'_jetup8'      , False, '1', '_jetup8' , ''],
+ ['jetup9'      ,'_jetup9'      , False, '1', '_jetup9' , ''],
+ ['jetup10'     ,'_jetup10'     , False, '1', '_jetup10', ''],
+ ['jetup11'     ,'_jetup11'     , False, '1', '_jetup11', ''],
+
+ ['jetdown1'    ,'_jetdown1'    , False, '1', '_jetdown1' , ''],
+ ['jetdown2'    ,'_jetdown2'    , False, '1', '_jetdown2' , ''],
+ ['jetdown3'    ,'_jetdown3'    , False, '1', '_jetdown3' , ''],
+ ['jetdown4'    ,'_jetdown4'    , False, '1', '_jetdown4' , ''],
+ ['jetdown5'    ,'_jetdown5'    , False, '1', '_jetdown5' , ''],
+ ['jetdown6'    ,'_jetdown6'    , False, '1', '_jetdown6' , ''],
+ ['jetdown7'    ,'_jetdown7'    , False, '1', '_jetdown7' , ''],
+ ['jetdown8'    ,'_jetdown8'    , False, '1', '_jetdown8' , ''],
+ ['jetdown9'    ,'_jetdown9'    , False, '1', '_jetdown9' , ''],
+ ['jetdown10'   ,'_jetdown10'   , False, '1', '_jetdown10', ''],
+ ['jetdown11'   ,'_jetdown11'   , False, '1', '_jetdown11', '']
 ]
 
 
@@ -113,6 +115,17 @@ for uncertainty in uncertainties:
         # Set the correct selection config
         if 'ZZZZ' in line:
             line = line.replace('ZZZZ', outDir+'/selectionCfg_%s_Legacy%s.cfg' % (channel,year))
+
+        # Set the correct filelist (used for JERup/down)
+        if 'WWWW' in line:
+            line = line.replace('WWWW', uncertainty[5])
+
+        # Set correct input files pattern
+        if 'PPPP' in line:
+            if 'JER' in uncertainty[0]:
+                line = line.replace('PPPP', 'goodfiles')
+            else:
+                line = line.replace('PPPP', 'goodsystfiles')
 
         newMainCfg.write(line)
     originalMainCfg.close()

--- a/scripts/makeLegacyPlots.py
+++ b/scripts/makeLegacyPlots.py
@@ -631,13 +631,14 @@ if __name__ == "__main__" :
     hSingleH = makeSum("singleH",hSingleHlist)
     hothers = makeSum("other",hothersList)
 
-    hBkgList = [hothers, hSingleH, hTT, hDY] # list for stack
-    hBkgNameList = ["Others", "single H", "t#bar{t}", "DY + jets"] # list for legend
-
+    hBkgList     = [hothers , hSingleH  ] # list for stack
+    hBkgNameList = ["Others", "Single H"] # list for legend
     if doQCD:
         hQCD = getHisto ("QCD", hBkgs,doOverflow)
         hBkgList.append(hQCD)
         hBkgNameList.append("QCD")
+    hBkgList     = [hTT       , hDY        ] # list for stack
+    hBkgNameList = ["t#bar{t}", "Drell-Yan"] # list for legend
 
     hData = getHisto("data_obs", hDatas , doOverflow)
 

--- a/scripts/makeLegacyPlots.py
+++ b/scripts/makeLegacyPlots.py
@@ -70,14 +70,13 @@ def makeTGraphFromHist (histo, newName):
     feXLeft  = []
 
     for ibin in range (1, nPoints+1):
-        x = hData.GetBinCenter(ibin);
-        y = hData.GetBinContent(ibin);
-        dxRight = hData.GetBinLowEdge(ibin+1) - hData.GetBinCenter(ibin);
-        dxLeft  = hData.GetBinCenter(ibin) - hData.GetBinLowEdge(ibin);
-        dyUp    = hData.GetBinErrorUp(ibin);
-        dyLow   = hData.GetBinErrorLow(ibin);
+        x = hData.GetBinCenter(ibin)
+        y = hData.GetBinContent(ibin)
+        dxRight = hData.GetBinLowEdge(ibin+1) - hData.GetBinCenter(ibin)
+        dxLeft  = hData.GetBinCenter(ibin) - hData.GetBinLowEdge(ibin)
+        dyUp    = hData.GetBinErrorUp(ibin)
+        dyLow   = hData.GetBinErrorLow(ibin)
 
-        #if (!drawGrass && (int) y == 0) continue;
         fY.append(y)
         fX.append(x)
         feYUp.append(dyUp)
@@ -92,13 +91,13 @@ def makeTGraphFromHist (histo, newName):
     afeXRight = array ("d", feXRight)
     afeXLeft  = array ("d", feXLeft )
 
-    gData = TGraphAsymmErrors (len(afX), afX, afY, afeXLeft, afeXRight, afeYDown, afeYUp);
-    gData.SetMarkerStyle(8);
-    gData.SetMarkerSize(1.);
-    gData.SetMarkerColor(kBlack);
-    gData.SetLineColor(kBlack);
+    gData = TGraphAsymmErrors (len(afX), afX, afY, afeXLeft, afeXRight, afeYDown, afeYUp)
+    gData.SetMarkerStyle(8)
+    gData.SetMarkerSize(1.)
+    gData.SetMarkerColor(kBlack)
+    gData.SetLineColor(kBlack)
     gData.SetName(newName)
-    return gData;
+    return gData
 
 # set all horizontal bar errors to 0
 def removeHErrors (graph):
@@ -188,8 +187,8 @@ def makeStatUncertaintyBand (bkgSum):
     afeYDown  = array ("d", feYDown )
     afeXRight = array ("d", feXRight)
     afeXLeft  = array ("d", feXLeft )
-    gBand = TGraphAsymmErrors (len(afX), afX, afY, afeXLeft, afeXRight, afeYDown, afeYUp);
-    return gBand;
+    gBand = TGraphAsymmErrors (len(afX), afX, afY, afeXLeft, afeXRight, afeYDown, afeYUp)
+    return gBand
 
 ## do ratio of Data/MC
 # horErrs : do horizontal errors
@@ -226,15 +225,15 @@ def makeDataOverMCRatioPlot (hData, hMC, newName, horErrs=False):
     afeYDown  = array ("d", feYDown )
     afeXRight = array ("d", feXRight)
     afeXLeft  = array ("d", feXLeft )
-    gRatio = TGraphAsymmErrors (len(afX), afX, afY, afeXLeft, afeXRight, afeYDown, afeYUp);
+    gRatio = TGraphAsymmErrors (len(afX), afX, afY, afeXLeft, afeXRight, afeYDown, afeYUp)
     
-    gRatio.SetMarkerStyle(8);
-    gRatio.SetMarkerSize(1.);
-    gRatio.SetMarkerColor(kBlack);
-    gRatio.SetLineColor(kBlack);
+    gRatio.SetMarkerStyle(8)
+    gRatio.SetMarkerSize(1.)
+    gRatio.SetMarkerColor(kBlack)
+    gRatio.SetLineColor(kBlack)
     gRatio.SetName(newName)
 
-    return gRatio;
+    return gRatio
 
 ## find maximum of tgraph, including error
 def findMaxOfGraph (graph):
@@ -416,8 +415,8 @@ def makeStatSystUncertaintyBand (sumOfBkg,listOfSplitBkgHists,namesOfSplitBkgHis
     afeXRight = array ("d", feXRight)
     afeXLeft  = array ("d", feXLeft )
 
-    gBand = TGraphAsymmErrors (len(afX), afX, afY, afeXLeft, afeXRight, afeYDown, afeYUp);
-    return gBand;
+    gBand = TGraphAsymmErrors (len(afX), afX, afY, afeXLeft, afeXRight, afeYDown, afeYUp)
+    return gBand
 
 def retrieveShapes (rootFile, namelist, var, sel, reg, shapeNameList):
     res = {}
@@ -426,23 +425,7 @@ def retrieveShapes (rootFile, namelist, var, sel, reg, shapeNameList):
         if 'QCD' in name: continue
         for shapeName in shapeNameList:
 
-            # Possible to make plots both for DNN output...
-            if 'DNN' in var:
-                fullName = name + "_" + sel + "_" + reg + "_" + var + '_' + shapeName
-            # ...and for other varaibles...
-            else:
-                # ...that do not have the ES shifted variations...
-                if 'tauup' in shapeName or 'taudown' in shapeName or \
-                   'eleup' in shapeName or 'eledown' in shapeName or \
-                   'muup'  in shapeName or 'mudown'  in shapeName or \
-                   'jetup' in shapeName or 'jetdown' in shapeName:
-
-                    fullName = name + "_" + sel + "_" + reg + "_" + var
-
-                # ...but still have the other shapes (PUjetID, tauID, trigSF...)
-                else:
-                    fullName = name + "_" + sel + "_" + reg + "_" + var + '_' + shapeName
-
+            fullName = name + "_" + sel + "_" + reg + "_" + var + '_' + shapeName
             if not rootFile.GetListOfKeys().Contains(fullName):
                 print "*** WARNING: shape " , fullName , " not available"
                 continue
@@ -478,8 +461,8 @@ def scaleStatSystUncertaintyBandForStack (grUncert,bkgSum):
     afeXRight = array ("d", feXRight)
     afeXLeft  = array ("d", feXLeft )
 
-    gBand = TGraphAsymmErrors (len(afX), afX, afY, afeXLeft, afeXRight, afeYDown, afeYUp);
-    return gBand;
+    gBand = TGraphAsymmErrors (len(afX), afX, afY, afeXLeft, afeXRight, afeYDown, afeYUp)
+    return gBand
 
 #######################################################################
 ######################### SCRIPT BODY #################################
@@ -533,9 +516,6 @@ if __name__ == "__main__" :
     if args.quit : gROOT.SetBatch(True)
 
     c1 = TCanvas ("c1", "c1", 600, 600)
-    # c1.SetLeftMargin(0.15);
-    # c1.SetBottomMargin(0.12);
-    # c1.SetTopMargin(0.055);
 
     pad1 = None
     pad2 = None
@@ -543,16 +523,16 @@ if __name__ == "__main__" :
     if args.ratio:
         pad1 = TPad ("pad1", "pad1", 0, 0.25, 1, 1.0)
         pad1.SetFrameLineWidth(3)
-        pad1.SetLeftMargin(0.12);
-        pad1.SetBottomMargin(0.02);
-        pad1.SetTopMargin(0.055);
+        pad1.SetLeftMargin(0.12)
+        pad1.SetBottomMargin(0.02)
+        pad1.SetTopMargin(0.055)
         pad1.Draw()
     else:
         pad1 = TPad ("pad1", "pad1", 0, 0.0, 1.0, 1.0)
         pad1.SetFrameLineWidth(3)
-        pad1.SetLeftMargin(0.12);
-        pad1.SetBottomMargin(0.12);
-        pad1.SetTopMargin(0.055);
+        pad1.SetLeftMargin(0.12)
+        pad1.SetBottomMargin(0.12)
+        pad1.SetTopMargin(0.055)
         pad1.Draw()
 
     pad1.cd()
@@ -1046,17 +1026,16 @@ if __name__ == "__main__" :
 
     ###################### RATIO PLOT #################################
     if args.ratio:
-        bkgStack.GetXaxis().SetTitleSize(0.00);
-        bkgStack.GetXaxis().SetLabelSize(0.00);
+        bkgStack.GetXaxis().SetTitleSize(0.00)
+        bkgStack.GetXaxis().SetLabelSize(0.00)
 
         c1.cd()
         pad2 = TPad ("pad2", "pad2", 0, 0.0, 1, 0.2496)
-        pad2.SetLeftMargin(0.12);
-        pad2.SetTopMargin(0.045);
-        pad2.SetBottomMargin(0.4);
-        pad2.SetGridy(True);
+        pad2.SetLeftMargin(0.12)
+        pad2.SetTopMargin(0.045)
+        pad2.SetBottomMargin(0.4)
+        pad2.SetGridy(True)
         pad2.SetFrameLineWidth(3)
-        #pad2.SetGridx(True);
         pad2.Draw()
         pad2.cd()
 
@@ -1077,10 +1056,10 @@ if __name__ == "__main__" :
         hRatio.GetXaxis().SetTitleOffset(3.9)
         hRatio.GetYaxis().SetTitleOffset(1.2)
 
-        hRatio.GetXaxis().SetTitleSize(titleSize);
-        hRatio.GetXaxis().SetLabelSize(labelSize);
-        hRatio.GetYaxis().SetTitleSize(titleSize);
-        hRatio.GetYaxis().SetLabelSize(labelSize);
+        hRatio.GetXaxis().SetTitleSize(titleSize)
+        hRatio.GetXaxis().SetLabelSize(labelSize)
+        hRatio.GetYaxis().SetTitleSize(titleSize)
+        hRatio.GetYaxis().SetLabelSize(labelSize)
 
         hRatio.GetXaxis().SetTickSize(0.10)
         hRatio.GetYaxis().SetTickSize(0.05)
@@ -1122,8 +1101,8 @@ if __name__ == "__main__" :
         grUncertRatio.SetFillStyle(3002)
         grUncertRatio.Draw("e2")
 
-        pad2.RedrawAxis();
-        pad2.RedrawAxis("g"); #otherwise no grid..
+        pad2.RedrawAxis()
+        pad2.RedrawAxis("g") #otherwise no grid..
 
     ###################### DISPLAY ###################################
     if not args.quit:
@@ -1140,6 +1119,7 @@ if __name__ == "__main__" :
         if args.binwidth: saveName = saveName+"_binWidth"
         if args.doStatSystBand: saveName = saveName+'_StatSystBand'
         if args.removeESsystBand: saveName = saveName+'_noES'
+        if args.addJERunc: saveName = saveName+'_JER'
 
         c1.SaveAs (saveName+".pdf")
         c1.SaveAs (saveName+".png")

--- a/scripts/makeLegacyPlots.py
+++ b/scripts/makeLegacyPlots.py
@@ -425,10 +425,26 @@ def retrieveShapes (rootFile, namelist, var, sel, reg, shapeNameList):
         # because the QCD syst is only lnN and no shape variations are produced
         if 'QCD' in name: continue
         for shapeName in shapeNameList:
-            fullName = name + "_" + sel + "_" + reg + "_" + var + '_' + shapeName
+
+            # Possible to make plots both for DNN output...
+            if 'DNN' in var:
+                fullName = name + "_" + sel + "_" + reg + "_" + var + '_' + shapeName
+            # ...and for other varaibles...
+            else:
+                # ...that do not have the ES shifted variations...
+                if 'tauup' in shapeName or 'taudown' in shapeName or \
+                   'eleup' in shapeName or 'eledown' in shapeName or \
+                   'muup'  in shapeName or 'mudown'  in shapeName or \
+                   'jetup' in shapeName or 'jetdown' in shapeName:
+
+                    fullName = name + "_" + sel + "_" + reg + "_" + var
+
+                # ...but still have the other shapes (PUjetID, tauID, trigSF...)
+                else:
+                    fullName = name + "_" + sel + "_" + reg + "_" + var + '_' + shapeName
 
             if not rootFile.GetListOfKeys().Contains(fullName):
-                print "*** WARNING: histo " , fullName , " not available"
+                print "*** WARNING: shape " , fullName , " not available"
                 continue
             h = rootFile.Get(fullName)
 
@@ -503,6 +519,7 @@ if __name__ == "__main__" :
     parser.add_argument('--dynamicRatioY', dest='dynamicRatioY', help='ratio plot with ad hoc y-range?', default=False)
     parser.add_argument('--doStatSystBand', dest='doStatSystBand', help='create stat+syst uncertainty band?', action='store_true', default=False)
     parser.add_argument('--removeESsystBand', dest='removeESsystBand', help='remove energy scales from stat+syst band?', action='store_true', default=False)
+    parser.add_argument('--addJERunc', dest='addJERunc', help='add JER shape uncertainty', action='store_true', default=False)
     # list options
     parser.add_argument('--blind-range',   dest='blindrange', nargs=2, help='start and end of blinding range', default=None)
     parser.add_argument('--sigscale', dest='sigscale', nargs=2, help='scale to apply to the signals (GGHH VBFHH)', default=None)
@@ -621,7 +638,7 @@ if __name__ == "__main__" :
     hZH        = getHisto("ZH", hBkgs, doOverflow)
     hWH        = getHisto("WH", hBkgs, doOverflow)
     hVV        = getHisto("VV", hBkgs, doOverflow)
-    httH       = getHisto("ttH", hBkgs, doOverflow)
+    hTTH       = getHisto("ttH", hBkgs, doOverflow)
     hTTX       = getHisto("TTX", hBkgs, doOverflow)
     hggH       = getHisto("ggH", hBkgs, doOverflow)
     hqqH       = getHisto("qqH", hBkgs, doOverflow)
@@ -629,7 +646,7 @@ if __name__ == "__main__" :
     
     hDYlist = [hDY_LM, hDY_0b_1Pt, hDY_0b_2Pt, hDY_0b_3Pt, hDY_0b_4Pt, hDY_0b_5Pt, hDY_0b_6Pt, hDY_1b_1Pt, hDY_1b_2Pt, hDY_1b_3Pt, hDY_1b_4Pt, hDY_1b_5Pt, hDY_1b_6Pt, hDY_2b_1Pt, hDY_2b_2Pt, hDY_2b_3Pt, hDY_2b_4Pt, hDY_2b_5Pt, hDY_2b_6Pt]
     hothersList = [hEWK, hsingleT, hTW, hVV, hTTX, hVVV, hWJets]
-    hSingleHlist = [hZH, hWH, httH, hggH, hqqH]
+    hSingleHlist = [hZH, hWH, hTTH, hggH, hqqH]
     hDY = makeSum("DY",hDYlist)
     hSingleH = makeSum("singleH",hSingleHlist)
     hothers = makeSum("other",hothersList)
@@ -657,7 +674,7 @@ if __name__ == "__main__" :
         # these two lists are used for the calculation of the syst error band. They must:
         #       1. be in the same order
         #       2. use the same names as those in the mainCfg (for hSystBkgNameList)
-        hSystBkgList = [hDY_LM.Clone(), hDY_0b_1Pt.Clone(), hDY_0b_2Pt.Clone(), hDY_0b_3Pt.Clone(), hDY_0b_4Pt.Clone(), hDY_0b_5Pt.Clone(), hDY_0b_6Pt.Clone(), hDY_1b_1Pt.Clone(), hDY_1b_2Pt.Clone(), hDY_1b_3Pt.Clone(), hDY_1b_4Pt.Clone(), hDY_1b_5Pt.Clone(), hDY_1b_6Pt.Clone(), hDY_2b_1Pt.Clone(), hDY_2b_2Pt.Clone(), hDY_2b_3Pt.Clone(), hDY_2b_4Pt.Clone(), hDY_2b_5Pt.Clone(), hDY_2b_6Pt.Clone(), hTT.Clone(), hWJets.Clone(), hEWK.Clone(), hsingleT.Clone(), hTW.Clone(), hZH.Clone(), hWH.Clone(), hVV.Clone(), httH.Clone(), hTTX.Clone(), hggH.Clone(), hqqH.Clone(), hVVV.Clone(), hQCD.Clone()]
+        hSystBkgList = [hDY_LM.Clone(), hDY_0b_1Pt.Clone(), hDY_0b_2Pt.Clone(), hDY_0b_3Pt.Clone(), hDY_0b_4Pt.Clone(), hDY_0b_5Pt.Clone(), hDY_0b_6Pt.Clone(), hDY_1b_1Pt.Clone(), hDY_1b_2Pt.Clone(), hDY_1b_3Pt.Clone(), hDY_1b_4Pt.Clone(), hDY_1b_5Pt.Clone(), hDY_1b_6Pt.Clone(), hDY_2b_1Pt.Clone(), hDY_2b_2Pt.Clone(), hDY_2b_3Pt.Clone(), hDY_2b_4Pt.Clone(), hDY_2b_5Pt.Clone(), hDY_2b_6Pt.Clone(), hTT.Clone(), hWJets.Clone(), hEWK.Clone(), hsingleT.Clone(), hTW.Clone(), hZH.Clone(), hWH.Clone(), hVV.Clone(), hTTH.Clone(), hTTX.Clone(), hggH.Clone(), hqqH.Clone(), hVVV.Clone(), hQCD.Clone()]
         hSystBkgNameList = ['DY_LM', 'DY_0b_1Pt', 'DY_0b_2Pt', 'DY_0b_3Pt', 'DY_0b_4Pt', 'DY_0b_5Pt', 'DY_0b_6Pt', 'DY_1b_1Pt', 'DY_1b_2Pt', 'DY_1b_3Pt', 'DY_1b_4Pt', 'DY_1b_5Pt', 'DY_1b_6Pt', 'DY_2b_1Pt', 'DY_2b_2Pt', 'DY_2b_3Pt', 'DY_2b_4Pt', 'DY_2b_5Pt', 'DY_2b_6Pt', 'TT', 'W', 'EWK', 'singleT', 'TW', 'ZH', 'WH', 'VV', 'ttH', 'TTX', 'ggH', 'qqH', 'VVV', 'QCD']
         hShapesNameList = ['etauFR_barrelUp', 'etauFR_endcapUp', 'PUjetIDSFUp', 'etauFR_barrelDown', 'etauFR_endcapDown', 'PUjetIDSFDown', 'bTagweightReshapeLFUp', 'bTagweightReshapeHFUp', 'bTagweightReshapeHFSTATS1Up', 'bTagweightReshapeHFSTATS2Up', 'bTagweightReshapeLFSTATS1Up', 'bTagweightReshapeLFSTATS2Up', 'bTagweightReshapeCFERR1Up', 'bTagweightReshapeCFERR2Up', 'bTagweightReshapeLFDown', 'bTagweightReshapeHFDown', 'bTagweightReshapeHFSTATS1Down', 'bTagweightReshapeHFSTATS2Down', 'bTagweightReshapeLFSTATS1Down', 'bTagweightReshapeLFSTATS2Down', 'bTagweightReshapeCFERR1Down', 'bTagweightReshapeCFERR2Down']
         # the ETau, MuTau, and TauTau channels have some different shapes -> we add them here separately
@@ -677,6 +694,10 @@ if __name__ == "__main__" :
             #addES = ['tauup_DM0', 'taudown_DM0', 'tauup_DM1', 'taudown_DM1', 'tauup_DM10', 'taudown_DM10', 'tauup_DM11', 'taudown_DM11', 'eleup_DM0', 'eledown_DM0', 'eleup_DM1', 'eledown_DM1', 'muup', 'mudown', 'jetup1', 'jetup2', 'jetup3', 'jetup4', 'jetup5', 'jetup6', 'jetup7', 'jetup8', 'jetup9', 'jetup10', 'jetup11', 'jetdown1', 'jetdown2', 'jetdown3', 'jetdown4', 'jetdown5', 'jetdown6', 'jetdown7', 'jetdown8', 'jetdown9', 'jetdown10', 'jetdown11']
             addES = ['tauup_DM0', 'taudown_DM0', 'tauup_DM1', 'taudown_DM1', 'tauup_DM10', 'taudown_DM10', 'tauup_DM11', 'taudown_DM11', 'eleup_DM0', 'eledown_DM0', 'eleup_DM1', 'eledown_DM1', 'muup', 'mudown', 'jetupTot', 'jetdownTot']
             for sh in addES: hShapesNameList.append(sh)
+
+        if args.addJERunc:
+            addShapes = ['JERup', 'JERdown']
+            for sh in addShapes: hShapesNameList.append(sh)
 
         hShapes = retrieveShapes(rootFile, bkgList, args.var, args.sel, args.reg, hShapesNameList)
 
@@ -898,6 +919,8 @@ if __name__ == "__main__" :
                 sel_qcd = 'classTT'
         if "VBFloose" in args.sel:
                 sel_qcd = "VBFloose" # this does not exist in the systematics_QCD.cfg file --> it is just a dummy to avoid the breaking of makeStatSystUncertaintyBand()
+        if "baseline" in args.sel:
+                sel_qcd = "baseline" # this does not exist in the systematics_QCD.cfg file --> it is just a dummy to avoid the breaking of makeStatSystUncertaintyBand()
 
         #print("-----------------------------------------------------------------------")
         #print("Stack plot stat+syst band calculation info")
@@ -1119,6 +1142,7 @@ if __name__ == "__main__" :
         if args.removeESsystBand: saveName = saveName+'_noES'
 
         c1.SaveAs (saveName+".pdf")
+        c1.SaveAs (saveName+".png")
 
 
 

--- a/scripts/modules/OutputManager.py
+++ b/scripts/modules/OutputManager.py
@@ -283,6 +283,14 @@ class OutputManager:
                 for syst in allSysts:
 
                     # If var already contains one of the shape systs (tauup, taudown, jetup...)
+                    # do not create the shifted QCD template
+                    if 'tauup' in var or 'taudown' in var or \
+                       'eleup' in var or 'eledown' in var or \
+                       'muup'  in var or 'mudown'  in var or \
+                       'jetup' in var or 'jetdown' in var:
+                       continue
+
+                    # If var already contains one of the shape systs (tauup, taudown, jetup...)
                     # skip the syst from allSysts (otherwise it look for histograms with two systematics
                     # like 'var_sel_SR_tauup_PUjetIDUp' which do not make sense)
                     doubleSyst = False

--- a/scripts/systNtuple.py
+++ b/scripts/systNtuple.py
@@ -91,8 +91,9 @@ if __name__ == "__main__":
 
     tagname = "/" + opt.tag if opt.tag else ''
     jobsDir = currFolder + tagname + '/SYST_' + basename(opt.workdir)
-    if os.path.exists (jobsDir) : os.system ('rm -f ' + jobsDir + '/*')
-    else                        : os.system ('mkdir -p ' + jobsDir)
+    #if os.path.exists (jobsDir) : os.system ('rm -f ' + jobsDir + '/*')
+    #else                        : os.system ('mkdir -p ' + jobsDir)
+    os.system ('mkdir -p ' + jobsDir)
 
     commandFile = open (jobsDir + '/submit.sh', 'w')
     for inputfile in inputfiles : 

--- a/scripts/systNtuple_mib.py
+++ b/scripts/systNtuple_mib.py
@@ -91,8 +91,9 @@ if __name__ == "__main__":
 
     tagname = "/" + opt.tag if opt.tag else ''
     jobsDir = currFolder + tagname + '/SYST_' + basename(opt.workdir)
-    if os.path.exists (jobsDir) : os.system ('rm -f ' + jobsDir + '/*')
-    else                        : os.system ('mkdir -p ' + jobsDir)
+    #if os.path.exists (jobsDir) : os.system ('rm -f ' + jobsDir + '/*')
+    #else                        : os.system ('mkdir -p ' + jobsDir)
+    os.system ('mkdir -p ' + jobsDir)
 
     commandFile = open (jobsDir + "/submit.sh", 'w')
     for inputfile in inputfiles : 

--- a/test/skimNtuple2016_HHbtag.cpp
+++ b/test/skimNtuple2016_HHbtag.cpp
@@ -334,6 +334,7 @@ int main (int argc, char** argv)
 
   bool   beInclusive         = gConfigParser->readBoolOption   ("selections::beInclusive") ;
   bool   useDeepFlavor       = gConfigParser->readBoolOption   ("selections::useDeepFlavor") ;
+  bool   onlyFinalChannels   = gConfigParser->readBoolOption   ("selections::onlyFinalChannels") ;
   float  PUjetID_WP          = gConfigParser->readFloatOption  ("parameters::PUjetIDWP") ;
   float  PFjetID_WP          = gConfigParser->readIntOption    ("parameters::PFjetIDWP") ;
   // int    saveOS              = gConfigParser->readIntOption    ("parameters::saveOS") ;
@@ -594,7 +595,6 @@ int main (int argc, char** argv)
   TauIDSFTool * Deep_antiJet_medium_pt  = new TauIDSFTool("2016Legacy","DeepTau2017v2p1VSjet","Medium");   // for DeepTauv2p1 vs jets Medium
   TauIDSFTool * Deep_antiEle_vvloose    = new TauIDSFTool("2016Legacy","DeepTau2017v2p1VSe"  ,"VVLoose");  // for DeepTauv2p1 vs ele VVLoose
   TauIDSFTool * Deep_antiEle_vloose     = new TauIDSFTool("2016Legacy","DeepTau2017v2p1VSe"  ,"VLoose");   // for DeepTauv2p1 vs ele VLoose
-  //TauIDSFTool * Deep_antiEle_tight      = new TauIDSFTool("2016Legacy","DeepTau2017v2p1VSe"  ,"Tight");    // for DeepTauv2p1 vs ele Tight
   TauIDSFTool * Deep_antiMu_vloose      = new TauIDSFTool("2016Legacy","DeepTau2017v2p1VSmu" ,"VLoose");   // for DeepTauv2p1 vs mu VLoose
   TauIDSFTool * Deep_antiMu_tight       = new TauIDSFTool("2016Legacy","DeepTau2017v2p1VSmu" ,"Tight");    // for DeepTauv2p1 vs mu Tight
 
@@ -2011,8 +2011,8 @@ int main (int argc, char** argv)
       // ----------------------------------------------------------
       // pair selection is now complete, compute oher quantitites
 
-      // Temporary fix: only skim ETau events
-      if (pairType != 1) continue;
+      // If skimming the final ntuples skip not interesting channels
+      if (onlyFinalChannels && pairType>2) continue;
 
       // First create a map to associate <jetIdx, smearFactor> that will be
       // used to smear the jets always in the same way in the event.
@@ -2547,7 +2547,7 @@ int main (int argc, char** argv)
 
         idAndIsoSF_leg2_deep_vsJet    = Deep_antiJet_medium    ->getSFvsDM (tau2pt,  tau2DM, tau2Genmatch);
         idAndIsoSF_leg2_deep_vsJet_pt = Deep_antiJet_medium_pt ->getSFvsPT (tau2pt,  tau2Genmatch);
-        idAndIsoSF_leg2_deep_vsEle    = Deep_antiEle_vloose     ->getSFvsEta(tau2eta, tau2Genmatch);
+        idAndIsoSF_leg2_deep_vsEle    = Deep_antiEle_vloose    ->getSFvsEta(tau2eta, tau2Genmatch);
         idAndIsoSF_leg2_deep_vsMu     = Deep_antiMu_tight      ->getSFvsEta(tau2eta, tau2Genmatch);
 
         vector<float> idAndIsoSF_leg2_deep_vsJet_pt_up (5, idAndIsoSF_leg2_deep_vsJet_pt); // in bins of pt: 20, 25, 30, 35, 40, infty

--- a/test/skimNtuple2017_HHbtag.cpp
+++ b/test/skimNtuple2017_HHbtag.cpp
@@ -332,6 +332,7 @@ int main (int argc, char** argv)
 
   bool   beInclusive         = gConfigParser->readBoolOption   ("selections::beInclusive") ;
   bool   useDeepFlavor       = gConfigParser->readBoolOption   ("selections::useDeepFlavor") ;
+  bool   onlyFinalChannels   = gConfigParser->readBoolOption   ("selections::onlyFinalChannels") ;
   float  PUjetID_WP          = gConfigParser->readFloatOption  ("parameters::PUjetIDWP") ;
   float  PFjetID_WP          = gConfigParser->readIntOption    ("parameters::PFjetIDWP") ;
   // int    saveOS              = gConfigParser->readIntOption    ("parameters::saveOS") ;
@@ -601,7 +602,6 @@ int main (int argc, char** argv)
   TauIDSFTool * Deep_antiJet_medium_pt = new TauIDSFTool("2017ReReco","DeepTau2017v2p1VSjet","Medium");   // for DeepTauv2p1 vs jets Medium
   TauIDSFTool * Deep_antiEle_vvloose   = new TauIDSFTool("2017ReReco","DeepTau2017v2p1VSe"  ,"VVLoose");  // for DeepTauv2p1 vs ele VVLoose
   TauIDSFTool * Deep_antiEle_vloose    = new TauIDSFTool("2017ReReco","DeepTau2017v2p1VSe"  ,"VLoose");   // for DeepTauv2p1 vs ele VLoose
-  //TauIDSFTool * Deep_antiEle_tight     = new TauIDSFTool("2017ReReco","DeepTau2017v2p1VSe"  ,"Tight");    // for DeepTauv2p1 vs ele Tight
   TauIDSFTool * Deep_antiMu_vloose     = new TauIDSFTool("2017ReReco","DeepTau2017v2p1VSmu" ,"VLoose");   // for DeepTauv2p1 vs mu VLoose
   TauIDSFTool * Deep_antiMu_tight      = new TauIDSFTool("2017ReReco","DeepTau2017v2p1VSmu" ,"Tight");    // for DeepTauv2p1 vs mu Tight
 
@@ -2060,8 +2060,8 @@ int main (int argc, char** argv)
       // ----------------------------------------------------------
       // pair selection is now complete, compute oher quantitites
 
-      // Temporary fix: only skim ETau events
-      if (pairType != 1) continue;
+      // If skimming the final ntuples skip not interesting channels
+      if (onlyFinalChannels && pairType>2) continue;
 
       // First create a map to associate <jetIdx, smearFactor> that will be
       // used to smear the jets always in the same way in the event.
@@ -2608,7 +2608,7 @@ int main (int argc, char** argv)
 
         idAndIsoSF_leg2_deep_vsJet    = Deep_antiJet_medium    ->getSFvsDM (tau2pt,  tau2DM, tau2Genmatch);
         idAndIsoSF_leg2_deep_vsJet_pt = Deep_antiJet_medium_pt ->getSFvsPT (tau2pt,  tau2Genmatch);
-        idAndIsoSF_leg2_deep_vsEle    = Deep_antiEle_vloose     ->getSFvsEta(tau2eta, tau2Genmatch);
+        idAndIsoSF_leg2_deep_vsEle    = Deep_antiEle_vloose    ->getSFvsEta(tau2eta, tau2Genmatch);
         idAndIsoSF_leg2_deep_vsMu     = Deep_antiMu_tight      ->getSFvsEta(tau2eta, tau2Genmatch);
 
         vector<float> idAndIsoSF_leg2_deep_vsJet_pt_up (5, idAndIsoSF_leg2_deep_vsJet_pt); // in bins of pt: 20, 25, 30, 35, 40, infty

--- a/test/skimNtuple2018_HHbtag.cpp
+++ b/test/skimNtuple2018_HHbtag.cpp
@@ -323,6 +323,7 @@ int main (int argc, char** argv)
 
   bool   beInclusive         = gConfigParser->readBoolOption   ("selections::beInclusive") ;
   bool   useDeepFlavor       = gConfigParser->readBoolOption   ("selections::useDeepFlavor") ;
+  bool   onlyFinalChannels   = gConfigParser->readBoolOption   ("selections::onlyFinalChannels") ;
   float  PUjetID_WP          = gConfigParser->readFloatOption  ("parameters::PUjetIDWP") ;
   float  PFjetID_WP          = gConfigParser->readIntOption    ("parameters::PFjetIDWP") ;
   // int    saveOS              = gConfigParser->readIntOption    ("parameters::saveOS") ;
@@ -603,7 +604,6 @@ int main (int argc, char** argv)
   TauIDSFTool * Deep_antiJet_medium_pt = new TauIDSFTool("2018ReReco","DeepTau2017v2p1VSjet","Medium");   // for DeepTauv2p1 vs jets Medium
   TauIDSFTool * Deep_antiEle_vvloose   = new TauIDSFTool("2018ReReco","DeepTau2017v2p1VSe"  ,"VVLoose");  // for DeepTauv2p1 vs ele VVLoose
   TauIDSFTool * Deep_antiEle_vloose    = new TauIDSFTool("2018ReReco","DeepTau2017v2p1VSe"  ,"VLoose");   // for DeepTauv2p1 vs ele VLoose
-  //TauIDSFTool * Deep_antiEle_tight     = new TauIDSFTool("2018ReReco","DeepTau2017v2p1VSe"  ,"Tight");    // for DeepTauv2p1 vs ele Tight
   TauIDSFTool * Deep_antiMu_vloose     = new TauIDSFTool("2018ReReco","DeepTau2017v2p1VSmu" ,"VLoose");   // for DeepTauv2p1 vs mu VLoose
   TauIDSFTool * Deep_antiMu_tight      = new TauIDSFTool("2018ReReco","DeepTau2017v2p1VSmu" ,"Tight");    // for DeepTauv2p1 vs mu Tight
 
@@ -2098,8 +2098,8 @@ int main (int argc, char** argv)
       // ----------------------------------------------------------
       // pair selection is now complete, compute oher quantitites
 
-      // Temporary fix: only skim ETau events
-      if (pairType != 1) continue;
+      // If skimming the final ntuples skip not interesting channels
+      if (onlyFinalChannels && pairType>2) continue;
 
       // First create a map to associate <jetIdx, smearFactor> that will be
       // used to smear the jets always in the same way in the event.
@@ -2638,7 +2638,7 @@ int main (int argc, char** argv)
 
           idAndIsoSF_leg2_deep_vsJet    = Deep_antiJet_medium    ->getSFvsDM (tau2pt,  tau2DM, tau2Genmatch);
           idAndIsoSF_leg2_deep_vsJet_pt = Deep_antiJet_medium_pt ->getSFvsPT (tau2pt,  tau2Genmatch);
-          idAndIsoSF_leg2_deep_vsEle    = Deep_antiEle_vloose     ->getSFvsEta(tau2eta, tau2Genmatch);
+          idAndIsoSF_leg2_deep_vsEle    = Deep_antiEle_vloose    ->getSFvsEta(tau2eta, tau2Genmatch);
           idAndIsoSF_leg2_deep_vsMu     = Deep_antiMu_tight      ->getSFvsEta(tau2eta, tau2Genmatch);
 
           vector<float> idAndIsoSF_leg2_deep_vsJet_pt_up (5, idAndIsoSF_leg2_deep_vsJet_pt); // in bins of pt: 20, 25, 30, 35, 40, infty


### PR DESCRIPTION
- Reverted the temporary fix to skim only ETau events introduced in #213 and reported in #214 
- Added an option in the skim config (`onlyFinalChannels`) to allow to skim and store only the interesting channels (ETau, MuTau and TauTau), by default it is set to `false`