### PR TITLE
Datacards and Limits Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ git clone git@github.com:hh-italian-group/HHbtag.git HHTools/HHbtag
 git clone git@github.com:LLRCMS/HHKinFit2.git -b bbtautau_LegacyRun2
 git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
 cd HiggsAnalysis/CombinedLimit
-git checkout v8.0.1
+git checkout v8.2.0
 cd -
 
 # SVfit packages

--- a/config/systematics_DY2017.cfg
+++ b/config/systematics_DY2017.cfg
@@ -40,7 +40,7 @@ DY_1b_1Pt     = 1.001
 
 [CMS_bbtt_2017_DYSFunc8]
 type = lnN
-DY_1b_2Pt     = 0./2.736
+DY_1b_2Pt     = 0.01/2.736
 DY_1b_4Pt     = 0.998
 DY_2b_2Pt     = 0.982
 DY_2b_4Pt     = 1.001

--- a/config/systematics_QCD2016.cfg
+++ b/config/systematics_QCD2016.cfg
@@ -15,7 +15,8 @@
 [MuTau_boosted] # No uncertainty, just here for correct parsing
 
 [TauTau_boosted]
-unc1 = CMS_bbtt_2016_QCDratio:0./2.98
+# should be 0./2.98, but combine does not like it
+unc1 = CMS_bbtt_2016_QCDratio:0.01/2.98
 
 
 #############
@@ -41,7 +42,8 @@ unc1 = CMS_bbtt_2016_QCDratio:1.428
 unc1 = CMS_bbtt_2016_QCDratio:1.186
 
 [TauTau_res2b]
-unc1 = CMS_bbtt_2016_QCDratio:0./2.185
+# should be 0./2.185, but combine does not like it
+unc1 = CMS_bbtt_2016_QCDratio:0.01/2.185
 
 
 ################

--- a/config/systematics_QCD2017.cfg
+++ b/config/systematics_QCD2017.cfg
@@ -51,6 +51,7 @@ unc1 = CMS_bbtt_2017_QCDratio:1.683
 
 [MuTau_classVBF]
 unc1 = CMS_bbtt_2017_QCDratio:1.267
+unc2 = CMS_bbtt_2017_QCDadditional:1.362
 
 [TauTau_classVBF]
 unc1 = CMS_bbtt_2017_QCDratio:1.232
@@ -72,8 +73,7 @@ unc1 = CMS_bbtt_2017_QCDratio:1.232
 ###############
 [ETau_classTT] # No uncertainty, just here for correct parsing
 
-[MuTau_classTT]
-unc1 = CMS_bbtt_2017_QCDratio:1.267
+[MuTau_classTT] # No uncertainty, just here for correct parsing
 
 [TauTau_classTT]
 unc1 = CMS_bbtt_2017_QCDratio:1.232

--- a/config/systematics_VBFdipole.cfg
+++ b/config/systematics_VBFdipole.cfg
@@ -1,0 +1,110 @@
+# VBF dipole systematics from : 
+# https://jleonhol.web.cern.ch/multiclass/dipole_systs/dipole_systs_conservative.json
+# which represent the most conservative values among the three methods and among the two years
+#
+# Set uncertainty as:
+# [channel_category]
+# 'unc1 = systName:systValue'
+
+###############
+### boosted ###
+###############
+[ETau_boosted]
+unc1 = qqHH_pythiaDipoleOn_ETau:0.796/1.204
+
+[MuTau_boosted]
+unc1 = qqHH_pythiaDipoleOn_MuTau:0.607/1.393
+
+[TauTau_boosted]
+unc1 = qqHH_pythiaDipoleOn_TauTau:0.802/1.198
+
+
+#############
+### res1b ###
+#############
+[ETau_res1b]
+unc1 = qqHH_pythiaDipoleOn_ETau:0.855/1.145
+
+[MuTau_res1b]
+unc1 = qqHH_pythiaDipoleOn_MuTau:0.882/1.118
+
+[TauTau_res1b]
+unc1 = qqHH_pythiaDipoleOn_TauTau:0.781/1.219
+
+
+#############
+### res2b ###
+#############
+[ETau_res2b]
+unc1 = qqHH_pythiaDipoleOn_ETau:0.731/1.269
+
+[MuTau_res2b]
+unc1 = qqHH_pythiaDipoleOn_MuTau:0.846/1.154
+
+[TauTau_res2b]
+unc1 = qqHH_pythiaDipoleOn_TauTau:0.829/1.171
+
+
+################
+### classVBF ###
+################
+[ETau_classVBF]
+unc1 = qqHH_pythiaDipoleOn_ETau:0.837/1.163
+
+[MuTau_classVBF]
+unc1 = qqHH_pythiaDipoleOn_MuTau:0.813/1.187
+
+[TauTau_classVBF]
+unc1 = qqHH_pythiaDipoleOn_TauTau:0.910/1.090
+
+
+################
+### classGGF ###
+################
+[ETau_classGGF]
+unc1 = qqHH_pythiaDipoleOn_ETau:0.448/1.552
+
+[MuTau_classGGF]
+unc1 = qqHH_pythiaDipoleOn_MuTau:0.496/1.504
+
+[TauTau_classGGF]
+unc1 = qqHH_pythiaDipoleOn_TauTau:0.663/1.337
+
+
+###############
+### classTT ###
+###############
+[ETau_classTT]
+unc1 = qqHH_pythiaDipoleOn_ETau:0.580/1.420
+
+[MuTau_classTT]
+unc1 = qqHH_pythiaDipoleOn_MuTau:0.583/1.417
+
+[TauTau_classTT]
+unc1 = qqHH_pythiaDipoleOn_TauTau:0.433/1.567
+
+
+################
+### classttH ###
+################
+[ETau_classttH]
+unc1 = qqHH_pythiaDipoleOn_ETau:0.328/1.672
+
+[MuTau_classttH]
+unc1 = qqHH_pythiaDipoleOn_MuTau:0.304/1.696
+
+[TauTau_classttH]
+unc1 = qqHH_pythiaDipoleOn_TauTau:0.295/1.705
+
+
+###############
+### classDY ###
+###############
+[ETau_classDY]
+unc1 = qqHH_pythiaDipoleOn_ETau:0.533/1.467
+
+[MuTau_classDY]
+unc1 = qqHH_pythiaDipoleOn_MuTau:0.517/1.483
+
+[TauTau_classDY]
+unc1 = qqHH_pythiaDipoleOn_TauTau:0.477/1.523

--- a/limits/compute_scales.py
+++ b/limits/compute_scales.py
@@ -47,13 +47,13 @@ toscan = ['tesXXX_DM0', 'tesXXX_DM1', 'tesXXX_DM10', 'tesXXX_DM11', 'eesXXX_DM0'
 
 for channel in channels:
 	print "doing channel: ", channel 
-	inputFile = '../analysis_24Dec2020_syst/%s_%s/outPlotter.root' % (channel, opt.year)
-	print inputFile	
+	inputFile = '../analysis_12Mar2021_syst/%s_%s/outPlotter.root' % (channel, opt.year)
+	print "inputfile:", inputFile
 	fIn = TFile.Open(inputFile)
 	
 	## retrieve histograms
 	for sel in selections:
-	    print "doing selection: ", sel
+	    print "  doing selection: ", sel
 	    for scale in toscan:
 	        histos_nominal = {}
 	        histos_up      = {}
@@ -75,10 +75,10 @@ for channel in channels:
 	
 	            shiftUp   = 1.0
 	            shiftDown = 1.0
-	            if ynom > 0 and histos_nominal[proc].GetEntries() > 10:
+	            if ynom > 0. and yup > 0. and ydown > 0. and histos_nominal[proc].GetEntries() > 10:
 	                shiftUp = 1.*yup/ynom
 	                shiftDown = 1.*ydown/ynom
-	
+
 	            fout.write('%30s     ' % proc)
 	            fout.write('%.3f     ' % shiftUp)
 	            fout.write('%.3f'      % shiftDown)

--- a/limits/plotCompare_categories_HH.py
+++ b/limits/plotCompare_categories_HH.py
@@ -1,0 +1,250 @@
+import re, optparse
+import os.path
+from math import *
+# from ROOT import *
+import ROOT
+
+#####
+
+def redrawBorder():
+   # this little macro redraws the axis tick marks and the pad border lines.
+   ROOT.gPad.Update();
+   ROOT.gPad.RedrawAxis();
+   l = ROOT.TLine()
+   l.SetLineWidth(3)
+   l.DrawLine(ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymax(), ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymax());
+   l.DrawLine(ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymin(), ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymax());
+   l.DrawLine(ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymin(), ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymax());
+   l.DrawLine(ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymin(), ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymin());
+
+def getExpValue( kl,  yt): 
+    BR =1 
+    return (2.09*yt*yt*yt*yt +   0.28*yt*yt*kl*kl  -1.37*yt*yt*yt*kl)*2.44477/BR;
+
+
+def parseFile(filename, CL='50.0', exp=True):
+    f = open(filename)
+    matches = []
+    for line in f:
+        search = ('Expected %s%%: r <'%CL)
+        if not exp: search = 'Observed Limit: r <'
+
+        if not search in line:
+            continue
+        val = line.replace(search, '')
+        val = float(val)
+        matches.append(val)
+
+    if len(matches) == 0:
+        print "did not find any expected in file: " , filename, 'CL=', CL, 'exp?=', exp
+        #return -1.0
+        return 0
+    else:
+        return matches[-1]
+
+def parseROOTFile(filename, CL=0.5):
+    f = ROOT.TFile(filename,"read")
+    ttree = f.Get("limit")
+
+    res = -1.0
+    for i,ev in enumerate(ttree):
+        if ev.quantileExpected != CL: continue
+        else: res = ev.limit
+
+    return res
+
+def getXStheoGGF (kL): 
+    A = 62.5339
+    B = -44.323
+    C = 9.6340
+
+    val = A + B*kL + C*kL*kL
+    return val
+
+def getXStheoVBF (c2v,KL,year): 
+    C2V = c2v
+    kl = KL
+    CV = 1.0
+
+    #s1 = HHModel.VBF_sample_list[0].val_xs # VBFHHSample(1,1,1,   val_xs = 0.00054/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_1'  ),
+    #s2 = HHModel.VBF_sample_list[1].val_xs # VBFHHSample(1,2,1,   val_xs = 0.00472/(0.3364), label = 'qqHH_CV_1_C2V_2_kl_1'  ),
+    #s3 = HHModel.VBF_sample_list[2].val_xs # VBFHHSample(1,1,2,   val_xs = 0.00044/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_2'  ),
+    #s4 = HHModel.VBF_sample_list[3].val_xs # VBFHHSample(1,1,0,   val_xs = 0.00145/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_0'  ),
+    #s5 = HHModel.VBF_sample_list[4].val_xs # VBFHHSample(0.5,1,1, val_xs = 0.00353/(0.3364), label = 'qqHH_CV_0p5_C2V_1_kl_1'),
+    #s6 = HHModel.VBF_sample_list[5].val_xs # VBFHHSample(1.5,1,1, val_xs = 0.02149/(0.3364), label = 'qqHH_CV_1p5_C2V_1_kl_1'),
+
+    if year == '2016':
+        s1 = 0.001601
+        s2 = 0.01335
+        s3 = 0.001327
+        s4 = 0.004259
+        s5 = 0.01009
+        s6 = 0.06153
+    else:
+        s1 = 0.001668
+        s2 = 0.01374
+        s3 = 0.001375
+        s4 = 0.004454
+        s5 = 0.01046
+        s6 = 0.0638
+
+    val = s1*(-3.3*C2V**2 + 1.3*C2V*CV**2 + 7.6*C2V*CV*kl + 2.0*CV**4 - 5.6*CV**3*kl - 1.0*CV**2*kl**2) + s2*(1.5*C2V**2 + 0.5*C2V*CV**2 - 4.0*C2V*CV*kl - 2.0*CV**4 + 4.0*CV**3*kl) + s3*(0.35*C2V**2 - 0.0166666666666667*C2V*CV**2 - 1.03333333333333*C2V*CV*kl - 0.333333333333333*CV**4 + 0.533333333333333*CV**3*kl + 0.5*CV**2*kl**2) + s4*(-0.45*C2V**2 + 0.45*C2V*CV**2 + 0.9*C2V*CV*kl + 1.0*CV**4 - 2.4*CV**3*kl + 0.5*CV**2*kl**2) + s5*(-2.0*C2V**2 - 3.33333333333333*C2V*CV**2 + 9.33333333333333*C2V*CV*kl + 5.33333333333333*CV**4 - 9.33333333333333*CV**3*kl) + s6*(0.4*C2V**2 - 0.4*C2V*CV**2 - 0.8*C2V*CV*kl + 0.8*CV**3*kl)
+
+    return val
+
+c1 = ROOT.TCanvas("c1", "c1", 650, 500)
+c1.SetFrameLineWidth(3)
+c1.SetBottomMargin (0.15)
+c1.SetRightMargin (0.05)
+c1.SetLeftMargin (0.15)
+c1.SetGridx()
+c1.SetGridy()
+
+mg = ROOT.TMultiGraph()
+
+year = "2017" # 2016 2017 2018
+
+
+if   year == "2016":
+    tag = [year,"DNNoutSM_kl_1","2016 - 35.9"]
+elif year == "2017":
+    tag = [year,"DNNoutSM_kl_1","2017 - 41.5"]
+else:  #year == "2018"
+    tag = [year,"DNNoutSM_kl_1","2018 - 59.7"]
+
+colors = [ROOT.kBlue, ROOT.kRed, ROOT.kCyan, ROOT.kBlack]
+
+channels = ['res1b','res2b','boost','VBFcomb']
+names    = ['res1b','res2b','boosted','VBFcomb']
+
+lambdas = [x for x in range(1, 82)]
+print lambdas
+
+klval = [-20  , -19.5, -19  , -18.5, -18  , -17.5, -17  , -16.5, -16  , -15.5, -15  , -14.5, -14  , -13.5, -13  , -12.5, -12  , -11.5, -11  , -10.5, -10  , -9.5 , -9   , -8.5 , -8   , -7.5 , -7   , -6.5 , -6   , -5.5 , -5   , -4.5 , -4   , -3.5 , -3   , -2.5 , -2   , -1.5 , -1   , -0.5 , 0    , 0.5  , 1    , 1.5  , 2    , 2.5  , 3    , 3.5  , 4    , 4.5  , 5    , 5.5  , 6    , 6.5  , 7    , 7.5  , 8    , 8.5  , 9    , 9.5  , 10   , 10.5 , 11   , 11.5 , 12   , 12.5 , 13   , 13.5 , 14   , 14.5 , 15   , 15.5 , 16   , 16.5 , 17   , 17.5 , 18   , 18.5 , 19   , 19.5 , 20]
+print klval
+
+graphs = []
+
+for i,channel in enumerate(channels):
+    print '--- Doing category {0} ---'.format(names[i])
+
+    grexp = ROOT.TGraph()
+    ptsList = [] # (x, exp)
+
+    for ipt,ikl in enumerate(klval):
+        #fName = 'datacards_'+year+'_'+channel+'/m125.0/r__kl/test1/limit__r__kl_{0}.0.root'.format(str(ikl))
+        fName = 'datacards_'+year+'_'+channel+'/out_Asym_{0}_noTH.log'.format(lambdas[ipt])
+
+        xval = ikl
+
+        if xval == 1: fName = fName.replace('_noTH','')
+
+        corrFactor = 1.034772182
+        if year == "2016": 
+            corrFactor = 1.078076202
+
+        xstheoVBF = getXStheoVBF (1,xval,year) * corrFactor   # C2V,kl,year
+        xstheoGGF = getXStheoGGF (xval) * 1.115               # kl
+        xstheoTOT = xstheoVBF + xstheoGGF
+
+        # Can get different results on r_gghh:
+        #exp = parseFile(fName)                      # <- How many times the SM I'm excluding
+        #exp = parseFile(fName) * xstheoTOT          # <- Excluded HH cross section
+        exp = parseFile(fName)  * xstheoTOT * 0.073  # <- Excluded HH cross section times BR(bbtautau)
+
+        # read directly from root file
+        #exp = parseROOTFile(fName)  * xstheoTOT * 0.073  # <- Excluded HH cross section times BR(bbtautau)
+
+        ptsList.append((xval, exp))
+
+    ptsList.sort()
+    for ipt, pt in enumerate(ptsList):
+        xval = pt[0]
+        exp  = pt[1]
+        print xval, exp
+        grexp.SetPoint(ipt, xval, exp)
+
+    ######## set styles
+    grexp.SetMarkerStyle(8)
+    grexp.SetMarkerColor(colors[i])
+    grexp.SetLineColor(colors[i])
+    grexp.SetLineWidth(1)
+
+    graphs.append(grexp)
+
+
+leg = ROOT.TLegend(0,0,0,0)
+leg.SetX1(0.17284)
+leg.SetY1(0.630526)
+leg.SetX2(0.420062)
+leg.SetY2(0.88)
+leg.SetFillColor(ROOT.kWhite)
+
+for i,graph in enumerate(graphs):
+    leg.AddEntry(graph, names[i], "pl")
+
+
+##### text
+pt = ROOT.TPaveText(0.1663218-0.02,0.886316,0.3045977-0.02,0.978947,"brNDC")
+pt.SetBorderSize(0)
+pt.SetTextAlign(12)
+pt.SetTextFont(62)
+pt.SetTextSize(0.05)
+pt.SetFillColor(0)
+pt.SetFillStyle(0)
+pt.AddText("CMS #font[52]{Internal}" )
+
+pt2 = ROOT.TPaveText(0.736111,0.9066667,0.847222,0.954641,"brNDC")
+pt2.SetBorderSize(0)
+pt2.SetFillColor(0)
+pt2.SetTextSize(0.040)
+pt2.SetTextFont(42)
+pt2.SetFillStyle(0)
+pt2.AddText(tag[2]+" fb^{-1} (13 TeV)")
+
+pt3 = ROOT.TPaveText(0.6819196+0.036,0.7780357+0.015+0.02,0.9008929+0.036,0.8675595+0.015,"brNDC")
+pt3.SetTextAlign(12)
+pt3.SetFillColor(ROOT.kWhite)
+pt3.SetFillStyle(1001)
+pt3.SetTextFont(42)
+pt3.SetTextSize(0.05)
+pt3.SetBorderSize(0)
+pt3.SetTextAlign(32)
+pt3.AddText("Combined channels")
+
+
+hframe = ROOT.TH1F('hframe', '', 100, -22, 22)
+#hframe = ROOT.TH1F('hframe', '', 100, -5, 5)
+hframe.SetMinimum(0.1)
+if year == "2016" or year=="2017" : hframe.SetMaximum(900)
+else                              : hframe.SetMaximum(900)
+hframe.GetYaxis().SetTitleSize(0.047)
+hframe.GetXaxis().SetTitleSize(0.055)
+hframe.GetYaxis().SetLabelSize(0.045)
+hframe.GetXaxis().SetLabelSize(0.045)
+hframe.GetXaxis().SetLabelOffset(0.012)
+hframe.GetYaxis().SetTitleOffset(1.2)
+hframe.GetXaxis().SetTitleOffset(1.1)
+hframe.GetYaxis().SetTitle("95% CL on #sigma #times #bf{#it{#Beta}}(HH#rightarrow bb#tau#tau) [fb]")
+hframe.GetXaxis().SetTitle("k_{#lambda}")
+hframe.SetStats(0)
+ROOT.gPad.SetTicky()
+hframe.Draw()
+
+
+for i,graph in enumerate(graphs):
+    graph.Draw("plsame")
+pt.Draw()
+pt2.Draw()
+pt3.Draw()
+
+redrawBorder()
+c1.Update()
+c1.RedrawAxis("g")
+
+leg.Draw()
+c1.Update()
+
+c1.Print('../plots/comparison_categoriesHH_'+year+'.pdf','pdf')
+
+import pdb; pdb.set_trace()

--- a/limits/plotCompare_categories_VBF.py
+++ b/limits/plotCompare_categories_VBF.py
@@ -1,0 +1,247 @@
+import re, optparse
+import os.path
+from math import *
+# from ROOT import *
+import ROOT
+
+#####
+
+def redrawBorder():
+   # this little macro redraws the axis tick marks and the pad border lines.
+   ROOT.gPad.Update();
+   ROOT.gPad.RedrawAxis();
+   l = ROOT.TLine()
+   l.SetLineWidth(3)
+   l.DrawLine(ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymax(), ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymax());
+   l.DrawLine(ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymin(), ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymax());
+   l.DrawLine(ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymin(), ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymax());
+   l.DrawLine(ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymin(), ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymin());
+
+def getExpValue( kl,  yt): 
+    BR =1 
+    return (2.09*yt*yt*yt*yt +   0.28*yt*yt*kl*kl  -1.37*yt*yt*yt*kl)*2.44477/BR;
+
+
+def parseFile(filename, CL='50.0', exp=True):
+    f = open(filename)
+    matches = []
+    for line in f:
+        search = ('Expected %s%%: r_qqhh <'%CL)
+        if not exp: search = 'Observed Limit: r <'
+
+        if not search in line:
+            continue
+        val = line.replace(search, '')
+        val = float(val)
+        matches.append(val)
+
+    if len(matches) == 0:
+        print "did not find any expected in file: " , filename, 'CL=', CL, 'exp?=', exp
+        #return -1.0
+        return 0
+    else:
+        return matches[-1]
+
+def parseROOTFile(filename, CL=0.5):
+    f = ROOT.TFile(filename,"read")
+    ttree = f.Get("limit")
+
+    res = -1.0
+    for i,ev in enumerate(ttree):
+        if ev.quantileExpected != CL: continue
+        else: res = ev.limit
+
+    return res
+
+def getXStheoGGF (kL): 
+    A = 62.5339
+    B = -44.323
+    C = 9.6340
+
+    val = A + B*kL + C*kL*kL
+    return val
+
+def getXStheoVBF (c2v,KL,year): 
+    C2V = c2v
+    kl = KL
+    CV = 1.0
+
+    #s1 = HHModel.VBF_sample_list[0].val_xs # VBFHHSample(1,1,1,   val_xs = 0.00054/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_1'  ),
+    #s2 = HHModel.VBF_sample_list[1].val_xs # VBFHHSample(1,2,1,   val_xs = 0.00472/(0.3364), label = 'qqHH_CV_1_C2V_2_kl_1'  ),
+    #s3 = HHModel.VBF_sample_list[2].val_xs # VBFHHSample(1,1,2,   val_xs = 0.00044/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_2'  ),
+    #s4 = HHModel.VBF_sample_list[3].val_xs # VBFHHSample(1,1,0,   val_xs = 0.00145/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_0'  ),
+    #s5 = HHModel.VBF_sample_list[4].val_xs # VBFHHSample(0.5,1,1, val_xs = 0.00353/(0.3364), label = 'qqHH_CV_0p5_C2V_1_kl_1'),
+    #s6 = HHModel.VBF_sample_list[5].val_xs # VBFHHSample(1.5,1,1, val_xs = 0.02149/(0.3364), label = 'qqHH_CV_1p5_C2V_1_kl_1'),
+
+    if year == '2016':
+        s1 = 0.001601
+        s2 = 0.01335
+        s3 = 0.001327
+        s4 = 0.004259
+        s5 = 0.01009
+        s6 = 0.06153
+    else:
+        s1 = 0.001668
+        s2 = 0.01374
+        s3 = 0.001375
+        s4 = 0.004454
+        s5 = 0.01046
+        s6 = 0.0638
+
+    val = s1*(-3.3*C2V**2 + 1.3*C2V*CV**2 + 7.6*C2V*CV*kl + 2.0*CV**4 - 5.6*CV**3*kl - 1.0*CV**2*kl**2) + s2*(1.5*C2V**2 + 0.5*C2V*CV**2 - 4.0*C2V*CV*kl - 2.0*CV**4 + 4.0*CV**3*kl) + s3*(0.35*C2V**2 - 0.0166666666666667*C2V*CV**2 - 1.03333333333333*C2V*CV*kl - 0.333333333333333*CV**4 + 0.533333333333333*CV**3*kl + 0.5*CV**2*kl**2) + s4*(-0.45*C2V**2 + 0.45*C2V*CV**2 + 0.9*C2V*CV*kl + 1.0*CV**4 - 2.4*CV**3*kl + 0.5*CV**2*kl**2) + s5*(-2.0*C2V**2 - 3.33333333333333*C2V*CV**2 + 9.33333333333333*C2V*CV*kl + 5.33333333333333*CV**4 - 9.33333333333333*CV**3*kl) + s6*(0.4*C2V**2 - 0.4*C2V*CV**2 - 0.8*C2V*CV*kl + 0.8*CV**3*kl)
+
+    return val
+
+c1 = ROOT.TCanvas("c1", "c1", 650, 500)
+c1.SetFrameLineWidth(3)
+c1.SetBottomMargin (0.15)
+c1.SetRightMargin (0.05)
+c1.SetLeftMargin (0.15)
+c1.SetGridx()
+c1.SetGridy()
+
+mg = ROOT.TMultiGraph()
+
+year = "2018" # 2016 2017 2018
+
+
+if   year == "2016":
+    tag = [year,"DNNoutSM_kl_1","2016 - 35.9"]
+elif year == "2017":
+    tag = [year,"DNNoutSM_kl_1","2017 - 41.5"]
+else:  #year == "2018"
+    tag = [year,"DNNoutSM_kl_1","2018 - 59.7"]
+
+colors = [ROOT.kBlue, ROOT.kRed, ROOT.kCyan, ROOT.kBlack]
+
+channels = ['res1b','res2b','boost','VBFcomb']
+names    = ['res1b','res2b','boosted','VBFcomb']
+
+klval = [-5.5, -5  , -4.5, -4  , -3.5, -3  , -2.5, -2  , -1.5, -1  , -0.8, -0.6, -0.4, -0.2, 0   , 0.2 , 0.4 , 0.6 , 0.8 , 1   , 1.2 , 1.4 , 1.6 , 1.8 , 2   , 2.2 , 2.4 , 2.6 , 2.8 , 3   , 3.5 , 4   , 4.5 , 5   , 5.5]
+print klval
+
+lambdas = [x for x in range(1, len(klval)+1)]
+print lambdas
+
+graphs = []
+
+for i,channel in enumerate(channels):
+    print '--- Doing category {0} ---'.format(names[i])
+
+    grexp = ROOT.TGraph()
+    ptsList = [] # (x, exp)
+
+    for ipt,ikl in enumerate(klval):
+        fName = 'datacards_'+year+'_'+channel+'/out_Asym_VBF{0}_noTH.log'.format(lambdas[ipt])
+
+        xval = ikl
+
+        if xval == 1: fName = fName.replace('_noTH','')
+
+        corrFactor = 1.034772182
+        if year == "2016":
+            corrFactor = 1.078076202
+
+        xstheoVBF = getXStheoVBF (xval,1,year) * corrFactor * 1000.0  # C2V,kl,year (VBF needs correction to [fb])
+
+        # Can get different results on r_gghh:
+        #exp  = parseFile(fName)                       # <- How many times the SM I'm excluding
+        exp  = parseFile(fName)  * xstheoVBF           # <- Excluded HH cross section
+        #exp  = parseFile(fName)  * xstheoVBF * 0.073  # <- Excluded HH cross section times BR(bbtautau)
+
+        # read directly from root file
+        #exp = parseROOTFile(fName)  * xstheoTOT * 0.073  # <- Excluded HH cross section times BR(bbtautau)
+
+        ptsList.append((xval, exp))
+
+    ptsList.sort()
+    for ipt, pt in enumerate(ptsList):
+        xval = pt[0]
+        exp  = pt[1]
+        print xval, exp
+        grexp.SetPoint(ipt, xval, exp)
+
+    ######## set styles
+    grexp.SetMarkerStyle(8)
+    grexp.SetMarkerColor(colors[i])
+    grexp.SetLineColor(colors[i])
+    grexp.SetLineWidth(1)
+
+    graphs.append(grexp)
+
+
+leg = ROOT.TLegend(0,0,0,0)
+leg.SetX1(0.17284)
+leg.SetY1(0.630526)
+leg.SetX2(0.420062)
+leg.SetY2(0.88)
+leg.SetFillColor(ROOT.kWhite)
+
+for i,graph in enumerate(graphs):
+    leg.AddEntry(graph, names[i], "pl")
+
+
+##### text
+pt = ROOT.TPaveText(0.1663218-0.02,0.886316,0.3045977-0.02,0.978947,"brNDC")
+pt.SetBorderSize(0)
+pt.SetTextAlign(12)
+pt.SetTextFont(62)
+pt.SetTextSize(0.05)
+pt.SetFillColor(0)
+pt.SetFillStyle(0)
+pt.AddText("CMS #font[52]{Internal}" )
+
+pt2 = ROOT.TPaveText(0.736111,0.9066667,0.847222,0.954641,"brNDC")
+pt2.SetBorderSize(0)
+pt2.SetFillColor(0)
+pt2.SetTextSize(0.040)
+pt2.SetTextFont(42)
+pt2.SetFillStyle(0)
+pt2.AddText(tag[2]+" fb^{-1} (13 TeV)")
+
+pt3 = ROOT.TPaveText(0.6819196+0.036,0.7780357+0.015+0.02,0.9008929+0.036,0.8675595+0.015,"brNDC")
+pt3.SetTextAlign(12)
+pt3.SetFillColor(ROOT.kWhite)
+pt3.SetFillStyle(1001)
+pt3.SetTextFont(42)
+pt3.SetTextSize(0.05)
+pt3.SetBorderSize(0)
+pt3.SetTextAlign(32)
+pt3.AddText("Combined channels")
+
+
+hframe = ROOT.TH1F('hframe', '', 100, -6, 6)
+hframe.SetMinimum(0.1)
+if year == "2016" or year=="2017" : hframe.SetMaximum(10000)
+else                              : hframe.SetMaximum(10000)
+hframe.GetYaxis().SetTitleSize(0.047)
+hframe.GetXaxis().SetTitleSize(0.055)
+hframe.GetYaxis().SetLabelSize(0.045)
+hframe.GetXaxis().SetLabelSize(0.045)
+hframe.GetXaxis().SetLabelOffset(0.012)
+hframe.GetYaxis().SetTitleOffset(1.2)
+hframe.GetXaxis().SetTitleOffset(1.1)
+hframe.GetYaxis().SetTitle("95% CL on #sigma_{VBF} (pp#rightarrow HHjj) [fb]")
+
+hframe.GetXaxis().SetTitle("C_{2V}")
+hframe.SetStats(0)
+ROOT.gPad.SetTicky()
+hframe.Draw()
+
+
+for i,graph in enumerate(graphs):
+    graph.Draw("plsame")
+pt.Draw()
+pt2.Draw()
+pt3.Draw()
+
+redrawBorder()
+c1.Update()
+c1.RedrawAxis("g")
+
+leg.Draw()
+c1.Update()
+
+c1.Print('../plots/comparison_categoriesVBF_'+year+'.pdf','pdf')
+
+import pdb; pdb.set_trace()

--- a/limits/plotCompare_channels_HH.py
+++ b/limits/plotCompare_channels_HH.py
@@ -1,0 +1,254 @@
+import re, optparse
+import os.path
+from math import *
+# from ROOT import *
+import ROOT
+
+#####
+
+def redrawBorder():
+   # this little macro redraws the axis tick marks and the pad border lines.
+   ROOT.gPad.Update();
+   ROOT.gPad.RedrawAxis();
+   l = ROOT.TLine()
+   l.SetLineWidth(3)
+   l.DrawLine(ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymax(), ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymax());
+   l.DrawLine(ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymin(), ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymax());
+   l.DrawLine(ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymin(), ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymax());
+   l.DrawLine(ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymin(), ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymin());
+
+def getExpValue( kl,  yt): 
+    BR =1 
+    return (2.09*yt*yt*yt*yt +   0.28*yt*yt*kl*kl  -1.37*yt*yt*yt*kl)*2.44477/BR;
+
+
+def parseFile(filename, CL='50.0', exp=True):
+    f = open(filename)
+    matches = []
+    for line in f:
+        search = ('Expected %s%%: r <'%CL)
+        if not exp: search = 'Observed Limit: r <'
+
+        if not search in line:
+            continue
+        val = line.replace(search, '')
+        val = float(val)
+        matches.append(val)
+
+    if len(matches) == 0:
+        print "did not find any expected in file: " , filename, 'CL=', CL, 'exp?=', exp
+        #return -1.0
+        return 0
+    else:
+        return matches[-1]
+
+def getXStheoGGF (kL): 
+    A = 62.5339
+    B = -44.323
+    C = 9.6340
+
+    val = A + B*kL + C*kL*kL
+    return val
+
+def getXStheoVBF (c2v,KL,year): 
+    C2V = c2v
+    kl = KL
+    CV = 1.0
+
+    #s1 = HHModel.VBF_sample_list[0].val_xs # VBFHHSample(1,1,1,   val_xs = 0.00054/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_1'  ),
+    #s2 = HHModel.VBF_sample_list[1].val_xs # VBFHHSample(1,2,1,   val_xs = 0.00472/(0.3364), label = 'qqHH_CV_1_C2V_2_kl_1'  ),
+    #s3 = HHModel.VBF_sample_list[2].val_xs # VBFHHSample(1,1,2,   val_xs = 0.00044/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_2'  ),
+    #s4 = HHModel.VBF_sample_list[3].val_xs # VBFHHSample(1,1,0,   val_xs = 0.00145/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_0'  ),
+    #s5 = HHModel.VBF_sample_list[4].val_xs # VBFHHSample(0.5,1,1, val_xs = 0.00353/(0.3364), label = 'qqHH_CV_0p5_C2V_1_kl_1'),
+    #s6 = HHModel.VBF_sample_list[5].val_xs # VBFHHSample(1.5,1,1, val_xs = 0.02149/(0.3364), label = 'qqHH_CV_1p5_C2V_1_kl_1'),
+
+    if year == '2016':
+        s1 = 0.001601
+        s2 = 0.01335
+        s3 = 0.001327
+        s4 = 0.004259
+        s5 = 0.01009
+        s6 = 0.06153
+    else:
+        s1 = 0.001668
+        s2 = 0.01374
+        s3 = 0.001375
+        s4 = 0.004454
+        s5 = 0.01046
+        s6 = 0.0638
+
+    val = s1*(-3.3*C2V**2 + 1.3*C2V*CV**2 + 7.6*C2V*CV*kl + 2.0*CV**4 - 5.6*CV**3*kl - 1.0*CV**2*kl**2) + s2*(1.5*C2V**2 + 0.5*C2V*CV**2 - 4.0*C2V*CV*kl - 2.0*CV**4 + 4.0*CV**3*kl) + s3*(0.35*C2V**2 - 0.0166666666666667*C2V*CV**2 - 1.03333333333333*C2V*CV*kl - 0.333333333333333*CV**4 + 0.533333333333333*CV**3*kl + 0.5*CV**2*kl**2) + s4*(-0.45*C2V**2 + 0.45*C2V*CV**2 + 0.9*C2V*CV*kl + 1.0*CV**4 - 2.4*CV**3*kl + 0.5*CV**2*kl**2) + s5*(-2.0*C2V**2 - 3.33333333333333*C2V*CV**2 + 9.33333333333333*C2V*CV*kl + 5.33333333333333*CV**4 - 9.33333333333333*CV**3*kl) + s6*(0.4*C2V**2 - 0.4*C2V*CV**2 - 0.8*C2V*CV*kl + 0.8*CV**3*kl)
+
+    return val
+
+c1 = ROOT.TCanvas("c1", "c1", 650, 500)
+c1.SetFrameLineWidth(3)
+c1.SetBottomMargin (0.15)
+c1.SetRightMargin (0.05)
+c1.SetLeftMargin (0.15)
+c1.SetGridx()
+c1.SetGridy()
+
+mg = ROOT.TMultiGraph()
+
+category = "comb_cat" # sboostedLLMcut  s1b1jresolvedMcut  s2b0jresolvedMcut  VBFloose
+year = "2017" # 2016 2017 2018
+tagName = "13Mar2021"
+
+
+if   year == "2016":
+    tag = [year+"_"+tagName,"DNNoutSM_kl_1","2016 - 35.9"]
+elif year == "2017":
+    tag = [year+"_"+tagName,"DNNoutSM_kl_1","2017 - 41.5"]
+else:  #year == "2018"
+    tag = [year+"_"+tagName,"DNNoutSM_kl_1","2018 - 59.7"]
+
+colors = [ROOT.kBlue, ROOT.kRed, ROOT.kCyan, ROOT.kBlack]
+
+channels = ['TauTau','MuTau','ETau'] #,'CombChan_']
+names    = ['TauTau','MuTau','ETau','Combined']
+
+lambdas = [x for x in range(1, 82)]
+print lambdas
+
+klval = [-20  , -19.5, -19  , -18.5, -18  , -17.5, -17  , -16.5, -16  , -15.5, -15  , -14.5, -14  , -13.5, -13  , -12.5, -12  , -11.5, -11  , -10.5, -10  , -9.5 , -9   , -8.5 , -8   , -7.5 , -7   , -6.5 , -6   , -5.5 , -5   , -4.5 , -4   , -3.5 , -3   , -2.5 , -2   , -1.5 , -1   , -0.5 , 0    , 0.5  , 1    , 1.5  , 2    , 2.5  , 3    , 3.5  , 4    , 4.5  , 5    , 5.5  , 6    , 6.5  , 7    , 7.5  , 8    , 8.5  , 9    , 9.5  , 10   , 10.5 , 11   , 11.5 , 12   , 12.5 , 13   , 13.5 , 14   , 14.5 , 15   , 15.5 , 16   , 16.5 , 17   , 17.5 , 18   , 18.5 , 19   , 19.5 , 20]
+print klval
+
+graphs = []
+
+for i,channel in enumerate(channels):
+    print '--- Doing channel {0} ---'.format(names[i])
+
+    grexp = ROOT.TGraph()
+    ptsList = [] # (x, exp)
+
+    for ipt in range(0, len(lambdas)):
+        if 'CombChan' in channel:
+            fName = 'cards_'+channel+tag[0]+'/out_Asym_{0}_noTH.log'.format(lambdas[ipt])
+        elif 'comb' in category:
+            fName = 'cards_'+channel+tag[0]+'/'+category+'/out_Asym_{0}_noTH.log'.format(lambdas[ipt])
+        else:
+            fName = 'cards_'+channel+tag[0]+'/'+category+tag[1]+'/out_Asym_{0}_noTH.log'.format(lambdas[ipt])
+
+        xval = klval[ipt]
+
+        if xval == 1: fName = fName.replace('_noTH','')
+
+        corrFactor = 1.034772182
+        if year == "2016": 
+            corrFactor = 1.078076202
+
+        xstheoVBF = getXStheoVBF (1,xval,year) * corrFactor   # C2V,kl,year
+        xstheoGGF = getXStheoGGF (xval) * 1.115               # kl
+        xstheoTOT = xstheoVBF + xstheoGGF
+
+        # Can get different results on r_gghh:
+        #exp = parseFile(fName)                      # <- How many times the SM I'm excluding
+        #exp = parseFile(fName) * xstheoTOT          # <- Excluded HH cross section
+        exp = parseFile(fName)  * xstheoTOT * 0.073  # <- Excluded HH cross section times BR(bbtautau)
+
+        ptsList.append((xval, exp))
+
+    ptsList.sort()
+    for ipt, pt in enumerate(ptsList):
+        xval = pt[0]
+        exp  = pt[1]
+        print xval, exp
+        grexp.SetPoint(ipt, xval, exp)
+
+    ######## set styles
+    grexp.SetMarkerStyle(8)
+    grexp.SetMarkerColor(colors[i])
+    grexp.SetLineColor(colors[i])
+    grexp.SetLineWidth(1)
+
+    graphs.append(grexp)
+
+
+leg = ROOT.TLegend(0,0,0,0)
+leg.SetX1(0.17284)
+leg.SetY1(0.630526)
+leg.SetX2(0.420062)
+leg.SetY2(0.88)
+leg.SetFillColor(ROOT.kWhite)
+
+for i,graph in enumerate(graphs):
+    leg.AddEntry(graph, names[i], "pl")
+
+
+##### text
+pt = ROOT.TPaveText(0.1663218-0.02,0.886316,0.3045977-0.02,0.978947,"brNDC")
+pt.SetBorderSize(0)
+pt.SetTextAlign(12)
+pt.SetTextFont(62)
+pt.SetTextSize(0.05)
+pt.SetFillColor(0)
+pt.SetFillStyle(0)
+pt.AddText("CMS #font[52]{Internal}" )
+
+pt2 = ROOT.TPaveText(0.736111,0.9066667,0.847222,0.954641,"brNDC")
+pt2.SetBorderSize(0)
+pt2.SetFillColor(0)
+pt2.SetTextSize(0.040)
+pt2.SetTextFont(42)
+pt2.SetFillStyle(0)
+pt2.AddText(tag[2]+" fb^{-1} (13 TeV)")
+
+pt3 = ROOT.TPaveText(0.6819196+0.036,0.7780357+0.015+0.02,0.9008929+0.036,0.8675595+0.015,"brNDC")
+pt3.SetTextAlign(12)
+pt3.SetFillColor(ROOT.kWhite)
+pt3.SetFillStyle(1001)
+pt3.SetTextFont(42)
+pt3.SetTextSize(0.05)
+pt3.SetBorderSize(0)
+pt3.SetTextAlign(32)
+if   category == "comb_cat"          : pt3.AddText("Combined categories")
+elif category == "sboostedLLMcut"    : pt3.AddText("boosted category")
+elif category == "s1b1jresolvedMcut" : pt3.AddText("1b category")
+elif category == "s2b0jresolvedMcut" : pt3.AddText("2b category")
+elif category == "VBFloose"          : pt3.AddText("VBF category")
+else                                 : pt3.AddText("?category not defined?")
+
+
+hframe = ROOT.TH1F('hframe', '', 100, -22, 22)
+#hframe = ROOT.TH1F('hframe', '', 100, -5, 5)
+hframe.SetMinimum(0.1)
+if year == "2016" or year=="2017" : hframe.SetMaximum(500)
+else                              : hframe.SetMaximum(500)
+#if   category == "comb_cat"          : hframe.SetMaximum(15000)
+#elif category == "sboostedLLMcut"    : hframe.SetMaximum(5000)
+#elif category == "s1b1jresolvedMcut" : hframe.SetMaximum(2000)
+#elif category == "s2b0jresolvedMcut" : hframe.SetMaximum(1000)
+#elif category == "VBFloose"          : hframe.SetMaximum(5000)
+#else                                 : hframe.SetMaximum(5000)
+
+hframe.GetYaxis().SetTitleSize(0.047)
+hframe.GetXaxis().SetTitleSize(0.055)
+hframe.GetYaxis().SetLabelSize(0.045)
+hframe.GetXaxis().SetLabelSize(0.045)
+hframe.GetXaxis().SetLabelOffset(0.012)
+hframe.GetYaxis().SetTitleOffset(1.2)
+hframe.GetXaxis().SetTitleOffset(1.1)
+hframe.GetYaxis().SetTitle("95% CL on #sigma #times #bf{#it{#Beta}}(HH#rightarrow bb#tau#tau) [fb]")
+hframe.GetXaxis().SetTitle("k_{#lambda}")
+hframe.SetStats(0)
+ROOT.gPad.SetTicky()
+hframe.Draw()
+
+
+for i,graph in enumerate(graphs):
+    graph.Draw("plsame")
+pt.Draw()
+pt2.Draw()
+pt3.Draw()
+
+redrawBorder()
+c1.Update()
+c1.RedrawAxis("g")
+
+leg.Draw()
+c1.Update()
+
+c1.Print('plots/comparison_channelsHH_'+category+'_'+tag[0]+'.pdf','pdf')
+
+import pdb; pdb.set_trace()

--- a/limits/plotCompare_channels_VBF.py
+++ b/limits/plotCompare_channels_VBF.py
@@ -1,0 +1,239 @@
+import re, optparse
+import os.path
+from math import *
+# from ROOT import *
+import ROOT
+
+#####
+
+def redrawBorder():
+   # this little macro redraws the axis tick marks and the pad border lines.
+   ROOT.gPad.Update();
+   ROOT.gPad.RedrawAxis();
+   l = ROOT.TLine()
+   l.SetLineWidth(3)
+   l.DrawLine(ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymax(), ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymax());
+   l.DrawLine(ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymin(), ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymax());
+   l.DrawLine(ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymin(), ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymax());
+   l.DrawLine(ROOT.gPad.GetUxmin(), ROOT.gPad.GetUymin(), ROOT.gPad.GetUxmax(), ROOT.gPad.GetUymin());
+
+def getExpValue( kl,  yt): 
+    BR =1 
+    return (2.09*yt*yt*yt*yt +   0.28*yt*yt*kl*kl  -1.37*yt*yt*yt*kl)*2.44477/BR;
+
+
+def parseFile(filename, CL='50.0', exp=True):
+    f = open(filename)
+    matches = []
+    for line in f:
+        search = ('Expected %s%%: r_qqhh <'%CL)
+        if not exp: search = 'Observed Limit: r <'
+
+        if not search in line:
+            continue
+        val = line.replace(search, '')
+        val = float(val)
+        matches.append(val)
+
+    if len(matches) == 0:
+        print "did not find any expected in file: " , filename, 'CL=', CL, 'exp?=', exp
+        #return -1.0
+        return 0
+    else:
+        return matches[-1]
+
+def getXStheo (c2v,year): 
+    C2V = c2v
+    kl = 1.0
+    CV = 1.0
+
+    #s1 = HHModel.VBF_sample_list[0].val_xs # VBFHHSample(1,1,1,   val_xs = 0.00054/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_1'  ),
+    #s2 = HHModel.VBF_sample_list[1].val_xs # VBFHHSample(1,2,1,   val_xs = 0.00472/(0.3364), label = 'qqHH_CV_1_C2V_2_kl_1'  ),
+    #s3 = HHModel.VBF_sample_list[2].val_xs # VBFHHSample(1,1,2,   val_xs = 0.00044/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_2'  ),
+    #s4 = HHModel.VBF_sample_list[3].val_xs # VBFHHSample(1,1,0,   val_xs = 0.00145/(0.3364), label = 'qqHH_CV_1_C2V_1_kl_0'  ),
+    #s5 = HHModel.VBF_sample_list[4].val_xs # VBFHHSample(0.5,1,1, val_xs = 0.00353/(0.3364), label = 'qqHH_CV_0p5_C2V_1_kl_1'),
+    #s6 = HHModel.VBF_sample_list[5].val_xs # VBFHHSample(1.5,1,1, val_xs = 0.02149/(0.3364), label = 'qqHH_CV_1p5_C2V_1_kl_1'),
+
+    if year == 2016:
+        s1 = 0.001601
+        s2 = 0.01335
+        s3 = 0.001327
+        s4 = 0.004259
+        s5 = 0.01009
+        s6 = 0.06153
+    else:
+        s1 = 0.001668
+        s2 = 0.01374
+        s3 = 0.001375
+        s4 = 0.004454
+        s5 = 0.01046
+        s6 = 0.0638
+
+    val = s1*(-3.3*C2V**2 + 1.3*C2V*CV**2 + 7.6*C2V*CV*kl + 2.0*CV**4 - 5.6*CV**3*kl - 1.0*CV**2*kl**2) + s2*(1.5*C2V**2 + 0.5*C2V*CV**2 - 4.0*C2V*CV*kl - 2.0*CV**4 + 4.0*CV**3*kl) + s3*(0.35*C2V**2 - 0.0166666666666667*C2V*CV**2 - 1.03333333333333*C2V*CV*kl - 0.333333333333333*CV**4 + 0.533333333333333*CV**3*kl + 0.5*CV**2*kl**2) + s4*(-0.45*C2V**2 + 0.45*C2V*CV**2 + 0.9*C2V*CV*kl + 1.0*CV**4 - 2.4*CV**3*kl + 0.5*CV**2*kl**2) + s5*(-2.0*C2V**2 - 3.33333333333333*C2V*CV**2 + 9.33333333333333*C2V*CV*kl + 5.33333333333333*CV**4 - 9.33333333333333*CV**3*kl) + s6*(0.4*C2V**2 - 0.4*C2V*CV**2 - 0.8*C2V*CV*kl + 0.8*CV**3*kl)
+
+    return val
+
+
+c1 = ROOT.TCanvas("c1", "c1", 650, 500)
+c1.SetFrameLineWidth(3)
+c1.SetBottomMargin (0.15)
+c1.SetRightMargin (0.05)
+c1.SetLeftMargin (0.15)
+c1.SetGridx()
+c1.SetGridy()
+
+mg = ROOT.TMultiGraph()
+
+category = "comb_cat" # sboostedLLMcut  s1b1jresolvedMcut  s2b0jresolvedMcut  VBFloose
+year = "2018" # 2016 2017 2018
+tagName = "13Mar2021"
+
+
+if   year == "2016":
+    tag = [year+"_"+tagName,"DNNoutSM_kl_1","2016 - 35.9"]
+elif year == "2017":
+    tag = [year+"_"+tagName,"DNNoutSM_kl_1","2017 - 41.5"]
+else:  #year == "2018"
+    tag = [year+"_"+tagName,"DNNoutSM_kl_1","2018 - 59.7"]
+
+colors = [ROOT.kBlue, ROOT.kRed, ROOT.kCyan, ROOT.kBlack]
+
+channels = ['TauTau','MuTau','ETau'] # ,'CombChan_']
+names    = ['TauTau','MuTau','ETau','Combined']
+
+klval = [-5.5, -5  , -4.5, -4  , -3.5, -3  , -2.5, -2  , -1.5, -1  , -0.8, -0.6, -0.4, -0.2, 0   , 0.2 , 0.4 , 0.6 , 0.8 , 1   , 1.2 , 1.4 , 1.6 , 1.8 , 2   , 2.2 , 2.4 , 2.6 , 2.8 , 3   , 3.5 , 4   , 4.5 , 5   , 5.5]
+print klval
+
+lambdas = [x for x in range(1, len(klval)+1)]
+print lambdas
+
+graphs = []
+
+for i,channel in enumerate(channels):
+    print '--- Doing channel {0} ---'.format(names[i])
+
+    grexp = ROOT.TGraph()
+    ptsList = [] # (x, exp)
+
+    for ipt in range(0, len(lambdas)):
+        if 'CombChan' in channel:
+            fName = 'cards_'+channel+tag[0]+'/out_Asym_VBF{0}_noTH.log'.format(lambdas[ipt])
+        elif 'comb' in category:
+            fName = 'cards_'+channel+tag[0]+'/'+category+'/out_Asym_VBF{0}_noTH.log'.format(lambdas[ipt])
+        else:
+            fName = 'cards_'+channel+tag[0]+'/'+category+tag[1]+'/out_Asym_VBF{0}_noTH.log'.format(lambdas[ipt])
+
+        xval = klval[ipt]
+
+        if xval == 1: fName = fName.replace('_noTH','')
+
+        corrFactor = 1.034772182
+        yearN = 2018
+        if '2016' in tag[0]: 
+            corrFactor = 1.078076202
+            yearN = 2016
+
+        # Can get different results on r_qqhh:
+        #exp = parseFile(fName)                                           # <- How many times the SM I'm excluding
+        #exp = parseFile(fName) * getXStheo(klval[ipt]) * 1000.0          # <- Excluded HH cross section [fb]
+        #exp = parseFile(fName) * getXStheo(klval[ipt]) * 1000.0 * 0.073  # <- Excluded HH cross section times BR(bbtautau) [fb]
+
+        exp   = parseFile(fName) * getXStheo(klval[ipt],yearN) * corrFactor * 1000.0
+
+        ptsList.append((xval, exp))
+
+    ptsList.sort()
+    for ipt, pt in enumerate(ptsList):
+        xval = pt[0]
+        exp  = pt[1]
+        print xval, exp
+        grexp.SetPoint(ipt, xval, exp)
+
+    ######## set styles
+    grexp.SetMarkerStyle(8)
+    grexp.SetMarkerColor(colors[i])
+    grexp.SetLineColor(colors[i])
+    grexp.SetLineWidth(1)
+
+    graphs.append(grexp)
+
+
+leg = ROOT.TLegend(0,0,0,0)
+leg.SetX1(0.17284)
+leg.SetY1(0.630526)
+leg.SetX2(0.420062)
+leg.SetY2(0.88)
+leg.SetFillColor(ROOT.kWhite)
+
+for i,graph in enumerate(graphs):
+    leg.AddEntry(graph, names[i], "pl")
+
+
+##### text
+pt = ROOT.TPaveText(0.1663218-0.02,0.886316,0.3045977-0.02,0.978947,"brNDC")
+pt.SetBorderSize(0)
+pt.SetTextAlign(12)
+pt.SetTextFont(62)
+pt.SetTextSize(0.05)
+pt.SetFillColor(0)
+pt.SetFillStyle(0)
+pt.AddText("CMS #font[52]{Internal}" )
+
+pt2 = ROOT.TPaveText(0.736111,0.9066667,0.847222,0.954641,"brNDC")
+pt2.SetBorderSize(0)
+pt2.SetFillColor(0)
+pt2.SetTextSize(0.040)
+pt2.SetTextFont(42)
+pt2.SetFillStyle(0)
+pt2.AddText(tag[2]+" fb^{-1} (13 TeV)")
+
+pt3 = ROOT.TPaveText(0.6819196+0.036,0.7780357+0.015+0.02,0.9008929+0.036,0.8675595+0.015,"brNDC")
+pt3.SetTextAlign(12)
+pt3.SetFillColor(ROOT.kWhite)
+pt3.SetFillStyle(1001)
+pt3.SetTextFont(42)
+pt3.SetTextSize(0.05)
+pt3.SetBorderSize(0)
+pt3.SetTextAlign(32)
+if   category == "comb_cat"          : pt3.AddText("combined categories")
+elif category == "sboostedLLMcut"    : pt3.AddText("boosted category")
+elif category == "s1b1jresolvedMcut" : pt3.AddText("1b category")
+elif category == "s2b0jresolvedMcut" : pt3.AddText("2b category")
+elif category == "VBFloose"          : pt3.AddText("VBF category")
+else                                 : pt3.AddText("?category not defined?")
+
+
+hframe = ROOT.TH1F('hframe', '', 100, -5, 6)
+hframe.SetMinimum(20)
+if   year == "2016"          : hframe.SetMaximum(2300)
+else                         : hframe.SetMaximum(2300)
+hframe.GetYaxis().SetTitleSize(0.047)
+hframe.GetXaxis().SetTitleSize(0.055)
+hframe.GetYaxis().SetLabelSize(0.045)
+hframe.GetXaxis().SetLabelSize(0.045)
+hframe.GetXaxis().SetLabelOffset(0.012)
+hframe.GetYaxis().SetTitleOffset(1.2)
+hframe.GetXaxis().SetTitleOffset(1.1)
+hframe.GetYaxis().SetTitle("95% CL on #sigma_{VBF} (pp#rightarrow HHjj) [fb]")
+hframe.GetXaxis().SetTitle("C_{2V}")
+hframe.SetStats(0)
+ROOT.gPad.SetTicky()
+hframe.Draw()
+
+
+for i,graph in enumerate(graphs):
+    graph.Draw("plsame")
+pt.Draw()
+pt2.Draw()
+pt3.Draw()
+
+redrawBorder()
+c1.Update()
+c1.RedrawAxis("g")
+
+leg.Draw()
+c1.Update()
+
+c1.Print('plots/comparison_channelsVBF_'+category+'_'+tag[0]+'.pdf','pdf')
+
+import pdb; pdb.set_trace()

--- a/limits/plotSimpleSM.py
+++ b/limits/plotSimpleSM.py
@@ -59,7 +59,7 @@ c1.SetGridy()
 mg = ROOT.TMultiGraph()
 
 var = 'DNNoutSM_kl_1'
-tag = '27Nov2020'
+tag = '13Mar2021'
 
 years = ['2016', '2017', '2018', '']
 
@@ -72,9 +72,9 @@ grobs = ROOT.TGraph()
 ptsList = [] # (x, obs, exp, p2s, p1s, m1s, m2s)
 for i, year in enumerate(years):
 
-    fName = 'cards_CombChan_'+year+'_'+tag+'/out_Asym_SM_noTH.log'
+    fName = 'cards_CombChan_'+year+'_'+tag+'/out_Asym_SM.log'
     if year == '':
-        fName = 'cards_CombAll_'+tag+'_autoMC1/out_Asym_SM_noTH.log'
+        fName = 'cards_CombAll_'+tag+'/out_Asym_SM.log'
 
     # Can get different results on r_gghh:
     #exp = parseFile(fName)                  # <- How many times the SM I'm excluding

--- a/limits/plotSimpleSM_C2V.py
+++ b/limits/plotSimpleSM_C2V.py
@@ -51,7 +51,7 @@ c1.SetGridy()
 mg = ROOT.TMultiGraph()
 
 var = 'DNNoutSM_kl_1'
-tag = '27Nov2020'
+tag = '13Mar2021'
 
 years = ['2016', '2017', '2018', '']
 
@@ -64,11 +64,9 @@ grobs = ROOT.TGraph()
 ptsList = [] # (x, obs, exp, p2s, p1s, m1s, m2s)
 for i, year in enumerate(years):
 
-    fName = 'cards_CombChan_'+year+'_'+tag+'/out_Asym_VBFSM_noTH.log'
-    if year == '2017':
-        fName = 'cards_CombChan_'+year+'_'+tag+'_autoMC1/out_Asym_VBFSM_noTH.log'
+    fName = 'cards_CombChan_'+year+'_'+tag+'/out_Asym_VBFSM.log'
     if year == '':
-        fName = 'cards_CombAll_'+tag+'_autoMC1/out_Asym_VBFSM_noTH.log'
+        fName = 'cards_CombAll_'+tag+'/out_Asym_VBFSM.log'
 
     # Can get different results on r_gghh:
     #exp = parseFile(fName)                  # <- How many times the SM I'm excluding

--- a/limits/plotSimple_C2V.py
+++ b/limits/plotSimple_C2V.py
@@ -91,14 +91,14 @@ mg = ROOT.TMultiGraph()
 
 var = 'DNNoutSM_kl_1'
 
-year = '2017'
-tag = 'CombChan_'+year+'_27Nov2020'
 #year = '2018'
-#tag = 'CombAll_27Nov2020'
+#tag = 'CombChan_'+year+'_13Mar2021'
+year = '2018'
+tag = 'CombAll_13Mar2021'
 
 selections = ["comb_cat"]
 
-klval = [-5.5, -5  , -4.5, -4  , -3.5, -3  , -2.5, -2  , -1.5, -1  , -0.5, 0  ,0.5,1  ,1.5,2  ,2.5,3  ,3.5,4  ,4.5,5  ,5.5]
+klval = [-5.5, -5  , -4.5, -4  , -3.5, -3  , -2.5, -2  , -1.5, -1  , -0.8, -0.6, -0.4, -0.2, 0   , 0.2 , 0.4 , 0.6 , 0.8 , 1   , 1.2 , 1.4 , 1.6 , 1.8 , 2   , 2.2 , 2.4 , 2.6 , 2.8 , 3   , 3.5 , 4   , 4.5 , 5   , 5.5]
 print klval
 
 lambdas = [x for x in range(1, len(klval)+1)]
@@ -118,13 +118,15 @@ for sel in selections:
         if 'Chan' in tag:
             fName = 'cards_'+tag+'/out_Asym_VBF{0}_noTH.log'.format(lambdas[ipt])
         elif 'All' in tag:
-            fName = 'cards_CombAll_27Nov2020_autoMC1/out_Asym_VBF{0}_noTH.log'.format(lambdas[ipt])
+            fName = 'cards_'+tag+'/out_Asym_VBF{0}_noTH.log'.format(lambdas[ipt])
         else:
             #fName = 'cards_Combined_2019_10_11/ggHH_bbtt{0}BDToutSM_kl_{1}/out_Asym_ggHH_bbtt{0}_noTH.log'.format(lambdas[ipt], klval[ipt])
             #fName = 'cards_Combined_2017_03_10_lmr70/ggHH_bbtt{0}MT2/out_Asym_ggHH_bbtt{0}_noTH.log'.format(lambdas[ipt])
             fName = 'cards_TauTau1Sept_noShape_GGF/{0}'.format(sel)+var+'/out_Asym_{0}_noTH.log'.format(lambdas[ipt])
 
         xval = klval[ipt]
+
+        if xval == 1: fName = fName.replace('_noTH','')
 
         corrFactor = 1.034772182
         if year == "2016":

--- a/limits/plotSimple_kL.py
+++ b/limits/plotSimple_kL.py
@@ -91,19 +91,18 @@ mg = ROOT.TMultiGraph()
 
 var = 'DNNoutSM_kl_1'
 
-#year = '2016'
-#tag = 'CombChan_'+year+'_27Nov2020'
+#year = '2018'
+#tag = 'CombChan_'+year+'_13Mar2021'
 year = '2018'
-tag = 'CombAll_27Nov2020'
+tag = 'CombAll_13Mar2021'
 
 selections = ["comb_cat"]
 
-lambdas = [x for x in range(1, 42)]
+lambdas = [x for x in range(1, 82)]
 print lambdas
 
-klval = [-20, -19, -18, -17, -16, -15, -14, -13, -12, -11, -10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+klval = [-20  , -19.5, -19  , -18.5, -18  , -17.5, -17  , -16.5, -16  , -15.5, -15  , -14.5, -14  , -13.5, -13  , -12.5, -12  , -11.5, -11  , -10.5, -10  , -9.5 , -9   , -8.5 , -8   , -7.5 , -7   , -6.5 , -6   , -5.5 , -5   , -4.5 , -4   , -3.5 , -3   , -2.5 , -2   , -1.5 , -1   , -0.5 , 0    , 0.5  , 1    , 1.5  , 2    , 2.5  , 3    , 3.5  , 4    , 4.5  , 5    , 5.5  , 6    , 6.5  , 7    , 7.5  , 8    , 8.5  , 9    , 9.5  , 10   , 10.5 , 11   , 11.5 , 12   , 12.5 , 13   , 13.5 , 14   , 14.5 , 15   , 15.5 , 16   , 16.5 , 17   , 17.5 , 18   , 18.5 , 19   , 19.5 , 20]
 print klval
-
 
 ### read the scan with normal width
 for sel in selections:
@@ -119,13 +118,15 @@ for sel in selections:
         if 'Chan' in tag:
             fName = 'cards_'+tag+'/out_Asym_{0}_noTH.log'.format(lambdas[ipt])
         elif 'All' in tag:
-            fName = 'cards_CombAll_27Nov2020_autoMC1/out_Asym_{0}_noTH.log'.format(lambdas[ipt])
+            fName = 'cards_'+tag+'/out_Asym_{0}_noTH.log'.format(lambdas[ipt])
         else:
             #fName = 'cards_Combined_2019_10_11/ggHH_bbtt{0}BDToutSM_kl_{1}/out_Asym_ggHH_bbtt{0}_noTH.log'.format(lambdas[ipt], klval[ipt])
             #fName = 'cards_Combined_2017_03_10_lmr70/ggHH_bbtt{0}MT2/out_Asym_ggHH_bbtt{0}_noTH.log'.format(lambdas[ipt])
             fName = 'cards_TauTau1Sept_noShape_GGF/{0}'.format(sel)+var+'/out_Asym_{0}_noTH.log'.format(lambdas[ipt])
 
         xval = klval[ipt]
+
+        if xval == 1: fName = fName.replace('_noTH','')
 
         corrFactor = 1.034772182
         if year == "2016":

--- a/limits/write_card.py
+++ b/limits/write_card.py
@@ -171,6 +171,10 @@ def  writeCard(backgrounds,signals,select,region=-1) :
         syst.addQCDSystFile("../config/systematics_QCD"+opt.year+".cfg")
         syst.writeQCDSystematics(opt.channel,theCatName)
 
+        # Add VBFdipole uncertainty
+        syst.addVBFdipoleSystFile("../config/systematics_VBFdipole.cfg")
+        syst.writeVBFdipoleSystematics(opt.channel,theCatName)
+
         # Declare dictionary to be filled with systs
         proc_syst = {} # key = proc name; value = {systName: [systType, systVal]] } # too nested? \_(``)_/
         for proc in backgrounds: proc_syst[proc] = {}
@@ -217,6 +221,7 @@ def  writeCard(backgrounds,signals,select,region=-1) :
         if opt.shapeUnc > 0:
             for name in systsShape:
                 for proc in backgrounds:
+                    if "QCD" in proc: continue
                     proc_syst[proc][name] = ["shape", 1.]   #applying jes or tes to all MC backgrounds
                     shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}Up".format(proc, select,  regionSuffix[region], variable[theCat], name))
                     shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}Down".format(proc, select, regionSuffix[region],variable[theCat], name))
@@ -256,7 +261,6 @@ def  writeCard(backgrounds,signals,select,region=-1) :
                 customTauIdSFname = "customTauIdSF" + customDMname
                 systsShape.append(CMS_customTauIdSFname)
                 for proc in backgrounds:
-                    #if opt.dynamQCD and "QCD" in proc: continue
                     if "QCD" in proc: continue
                     proc_syst[proc][CMS_customTauIdSFname] = ["shape", 1.]   #applying trigger to all MC backgrounds
                     shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}Up"  .format(proc, select, regionSuffix[region], variable[theCat], customTauIdSFname))
@@ -276,7 +280,6 @@ def  writeCard(backgrounds,signals,select,region=-1) :
             PUjetIDname = "PUjetIDSF"
             systsShape.append(CMS_PUjetIDname)
             for proc in backgrounds:
-                #if opt.dynamQCD and "QCD" in proc: continue
                 if "QCD" in proc: continue
                 proc_syst[proc][CMS_PUjetIDname] = ["shape", 1.]   #applying trigger to all MC backgrounds
                 shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}Up"  .format(proc, select, regionSuffix[region], variable[theCat], PUjetIDname))
@@ -322,7 +325,7 @@ def  writeCard(backgrounds,signals,select,region=-1) :
                 bTagSystName = "bTagweightReshape" + bTagSyst
                 systsShape.append(CMS_bTagSystName)
                 for proc in backgrounds:
-                    if opt.dynamQCD and "QCD" in proc: continue
+                    if "QCD" in proc: continue
                     proc_syst[proc][CMS_bTagSystName] = ["shape", 1.]   #applying trigger to all MC backgrounds
                     shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}Up"  .format(proc, select, regionSuffix[region], variable[theCat], bTagSystName))
                     shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}Down".format(proc, select, regionSuffix[region], variable[theCat], bTagSystName))
@@ -342,7 +345,7 @@ def  writeCard(backgrounds,signals,select,region=-1) :
                 bTagSystName = "bTagweightReshape" + bTagSyst
                 systsShape.append(CMS_bTagSystName)
                 for proc in backgrounds:
-                    if opt.dynamQCD and "QCD" in proc: continue
+                    if "QCD" in proc: continue
                     proc_syst[proc][CMS_bTagSystName] = ["shape", 1.]   #applying trigger to all MC backgrounds
                     shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}Up"  .format(proc, select, regionSuffix[region], variable[theCat], bTagSystName))
                     shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}Down".format(proc, select, regionSuffix[region], variable[theCat], bTagSystName))
@@ -373,7 +376,6 @@ def  writeCard(backgrounds,signals,select,region=-1) :
                 trigDMname = "trigSF" + DMname
                 systsShape.append(CMS_trigDMname)
                 for proc in backgrounds:
-                    #if opt.dynamQCD and "QCD" in proc: continue
                     if "QCD" in proc: continue
                     proc_syst[proc][CMS_trigDMname] = ["shape", 1.]   #applying trigger to all MC backgrounds
                     shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}Up"  .format(proc, select, regionSuffix[region], variable[theCat], trigDMname))
@@ -397,7 +399,6 @@ def  writeCard(backgrounds,signals,select,region=-1) :
                 tauPTname = "tauid_pt" + PTname
                 systsShape.append(CMS_tauPTname)
                 for proc in backgrounds:
-                    #if opt.dynamQCD and "QCD" in proc: continue
                     if "QCD" in proc: continue
                     proc_syst[proc][CMS_tauPTname] = ["shape", 1.]   #applying trigger to all MC backgrounds
                     shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}Up"  .format(proc, select, regionSuffix[region], variable[theCat], tauPTname))
@@ -438,7 +439,6 @@ def  writeCard(backgrounds,signals,select,region=-1) :
                 tauELEname = "etauFR_" + ELEname
                 systsShape.append(CMS_tauELEname)
                 for proc in backgrounds:
-                    #if opt.dynamQCD and "QCD" in proc: continue
                     if "QCD" in proc: continue
                     proc_syst[proc][CMS_tauELEname] = ["shape", 1.]   #applying trigger to all MC backgrounds
                     shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}Up"  .format(proc, select, regionSuffix[region], variable[theCat], tauELEname))

--- a/limits/write_card.py
+++ b/limits/write_card.py
@@ -293,6 +293,24 @@ def  writeCard(backgrounds,signals,select,region=-1) :
                 shiftShapes_newName.append(proc+"_"+CMS_PUjetIDname+"Up")
                 shiftShapes_newName.append(proc+"_"+CMS_PUjetIDname+"Down")
 
+            # Add JER uncertainty
+            CMS_JERname = "CMS_JER_"+opt.year
+            JERname = "JER"
+            systsShape.append(CMS_JERname)
+            for proc in backgrounds:
+                if "QCD" in proc: continue
+                proc_syst[proc][CMS_JERname] = ["shape", 1.]   #applying trigger to all MC backgrounds
+                shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}up"  .format(proc, select, regionSuffix[region], variable[theCat], JERname))
+                shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}down".format(proc, select, regionSuffix[region], variable[theCat], JERname))
+                shiftShapes_newName.append(proc+"_"+CMS_JERname+"Up")
+                shiftShapes_newName.append(proc+"_"+CMS_JERname+"Down")
+            for proc in signals:
+                proc_syst[proc][CMS_JERname] = ["shape", 1.]   #applying trigger to all signals
+                shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}up"  .format(proc, select, regionSuffix[region], variable[theCat], JERname))
+                shiftShapes_toSave.append("{0}_{1}_{2}_{3}_{4}down".format(proc, select, regionSuffix[region], variable[theCat], JERname))
+                shiftShapes_newName.append(proc+"_"+CMS_JERname+"Up")
+                shiftShapes_newName.append(proc+"_"+CMS_JERname+"Down")
+
             # Add bTag SF uncertainty - for WP scle factors
             #if "boosted" in select:
             #    WPs = ["L"]


### PR DESCRIPTION
- Added VBF dipole uncertainty (from https://jleonhol.web.cern.ch/multiclass/dipole_systs/dipole_systs_conservative.json) the most conservative values among all year and among the three methods proposed are used
  - modified the script `limits/systReader.py` to parse the VBF dipole uncertainty which is correlated among years, but not among channels
- Added JER uncertainty in ` limits/write_card.py `
- Fixed 2016 QCD uncertainties: 
  - in TauTau2016 (res2b and boost) there are uncertanties larger then 100%, so we originally put for example `0./2.98`, but combine complains that `0.` is not a good value and will generate `NaN`s later on. So we temporarily put `0.01` which should have the same effect. To be followed up in any case.
    - same was happening for one of the DY SF uncertainty in 2017
  - fixed some wrong values in MuTau 2017 QCD uncertainties
- Switched to the new recommended version (`v8.2.0`) of `combine`