### PR TITLE
Add option to skimOutputter_HHbtag to use temporary output file

### DIFF
--- a/config/skim_Legacy2016_mib.cfg
+++ b/config/skim_Legacy2016_mib.cfg
@@ -151,7 +151,8 @@ coeffFileLO = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1
 computeMVA = true
 
 [outPutter]
-nMaxEvts = -1 # use -1 to analyze all events
+nMaxEvts   = -1 # use -1 to analyze all events
+useTmpFile = false
 
 doMT2      = true
 doKinFit   = true

--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -151,7 +151,8 @@ coeffFileLO = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/s
 computeMVA = true
 
 [outPutter]
-nMaxEvts = -1 # use -1 to analyze all events
+nMaxEvts   = -1 # use -1 to analyze all events
+useTmpFile = false
 
 doMT2      = true
 doKinFit   = true

--- a/config/skim_Legacy2018.cfg
+++ b/config/skim_Legacy2018.cfg
@@ -158,7 +158,8 @@ coeffFileLO = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/KLUBAnalysis/we
 computeMVA = true
 
 [outPutter]
-nMaxEvts = -1 # use -1 to analyze all events
+nMaxEvts   = -1 # use -1 to analyze all events
+useTmpFile = false
 
 doMT2      = true
 doKinFit   = true

--- a/config/skim_Legacy2018_mib.cfg
+++ b/config/skim_Legacy2018_mib.cfg
@@ -155,7 +155,8 @@ coeffFileLO = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1
 computeMVA = true
 
 [outPutter]
-nMaxEvts = -1 # use -1 to analyze all events
+nMaxEvts   = -1 # use -1 to analyze all events
+useTmpFile = false
 
 doMT2      = true
 doKinFit   = true

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ SONAME	 =  libDoubleHiggs.so
 SONAME2  =  DoubleHiggs
 SOFLAGS  =  -Wl,-soname,$(SONAME)
 
-GLIBS   =  -lm -ldl -rdynamic $(ROOTGLIBS) -lGenVector -lFoam -lMinuit -lTMVA -lMLP -lXMLIO -lGpad  -lTreePlayer -lRooFit -lRooFitCore -lRooStats -lHHKinFit2 -L../../HHKinFit2 -lboost_regex -ltensorflow_cc -ltensorflow_framework $(TensFLowFLAGS)
+GLIBS   =  -lm -ldl -rdynamic $(ROOTGLIBS) -lGenVector -lFoam -lMinuit -lTMVA -lMLP -lXMLIO -lGpad  -lTreePlayer -lRooFit -lRooFitCore -lRooStats -lHHKinFit2 -L../../HHKinFit2 -lboost_regex -lboost_system -lboost_filesystem -ltensorflow_cc -ltensorflow_framework $(TensFLowFLAGS)
 
 DNNARCH = $(shell scram arch)
 DNNPATH = $(shell echo $$CMSSW_BASE | grep "CMSSW" | sed -e 's/$$/\/lib/')/$(DNNARCH)/


### PR DESCRIPTION
Hi!
This PR adds an option to the skimOutputter_HHbtag called "outPutter::useTmpFile" (defaulting to false) which, when true, causes the skimmer to write the output first to a temporary location (typically in /tmp) and then move it back once finished.

This can prevent ROOT's incremental file write operations to happen on distributed file systems such as EOS which don't play nicely with this type of file ops. I tested this with ~200 files over the weekend and there hasn't been a single error :)