### PR TITLE
[WIP] Add jet->tau_h fake SF and uncertainty

### DIFF
--- a/config/skim_Legacy2016_mib.cfg
+++ b/config/skim_Legacy2016_mib.cfg
@@ -3,7 +3,7 @@
 # do not select events with at least two jets in the final state
 # false : only >= 2 b jet ; true : all events
 ## for sync use beInclusive==true, for full porduction use false
-beInclusive = true
+beInclusive = false
 #use deepFlavor to order jets
 useDeepFlavor = true
 # Store only ETau/MuTau/TauTau events in the skims
@@ -152,22 +152,23 @@ computeMVA = true
 
 [outPutter]
 nMaxEvts   = -1 # use -1 to analyze all events
-useTmpFile = false
+useTmpFile = true
 
-doMT2       = true
-doKinFit    = true
-doSVfit     = true
+doMT2       = false
+doKinFit    = false
+doSVfit     = false
 doPropSVfit = false
-doDNN       = true
+doDNN       = false
 doBDT       = false
-doMult      = true
+doMult      = false
 
+doTauhFake = true
 doNominal  = false
-doMES      = true
-doEES      = true
-doTES      = true
-doSplitJES = true
-doTotalJES = true
+doMES      = false
+doEES      = false
+doTES      = false
+doSplitJES = false
+doTotalJES = false
 
 kl       = 1
 year     = 2016

--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -4,11 +4,11 @@
 # false : only >= 2 b jet ; true : all events
 # use beInclusive==true also for homemade TauID SF
 ## for sync use beInclusive==true, for full porduction use false
-beInclusive = true
+beInclusive = false
 #use deepFlavor to order jets
 useDeepFlavor = true
 # Store only ETau/MuTau/TauTau events in the skims
-onlyFinalChannels = false
+onlyFinalChannels = true
 
 [parameters]
 
@@ -154,21 +154,22 @@ computeMVA = true
 nMaxEvts   = -1 # use -1 to analyze all events
 useTmpFile = false
 
-doMT2       = true
-doKinFit    = true
-doSVfit     = true
+doMT2       = false
+doKinFit    = false
+doSVfit     = false
 doPropSVfit = false
-doDNN       = true
-doBDT       = true
-doMult      = true
+doDNN       = false
+doBDT       = false
+doMult      = false
 
-doVBFtrig  = true
+doVBFtrig  = false
+doTauhFake = true
 doNominal  = false
-doMES      = true
-doEES      = true
-doTES      = true
+doMES      = false
+doEES      = false
+doTES      = false
 doSplitJES = false
-doTotalJES = true
+doTotalJES = false
 
 kl       = 1
 year     = 2017

--- a/config/skim_Legacy2018.cfg
+++ b/config/skim_Legacy2018.cfg
@@ -3,11 +3,11 @@
 # do not select events with at least two jets in the final state
 # false : only >= 2 b jet ; true : all events
 ## for sync use beInclusive==true, for full porduction use false
-beInclusive = true
+beInclusive = false
 #use deepFlavor to order jets
 useDeepFlavor = true
 # Store only ETau/MuTau/TauTau events in the skims
-onlyFinalChannels = True
+onlyFinalChannels = true
 
 [parameters]
 
@@ -161,21 +161,22 @@ computeMVA = true
 nMaxEvts   = -1 # use -1 to analyze all events
 useTmpFile = false
 
-doMT2       = true
-doKinFit    = true
-doSVfit     = true
+doMT2       = false
+doKinFit    = false
+doSVfit     = false
 doPropSVfit = false
-doDNN       = true
+doDNN       = false
 doBDT       = false
-doMult      = true
+doMult      = false
 
 doVBFtrig  = false
+doTauhFake = true
 doNominal  = false
-doMES      = true
-doEES      = true
-doTES      = true
-doSplitJES = true
-doTotalJES = true
+doMES      = false
+doEES      = false
+doTES      = false
+doSplitJES = false
+doTotalJES = false
 
 kl       = 1
 year     = 2018

--- a/config/skim_Legacy2018_mib.cfg
+++ b/config/skim_Legacy2018_mib.cfg
@@ -3,11 +3,11 @@
 # do not select events with at least two jets in the final state
 # false : only >= 2 b jet ; true : all events
 ## for sync use beInclusive==true, for full porduction use false
-beInclusive = true
+beInclusive = false
 #use deepFlavor to order jets
 useDeepFlavor = true
 # Store only ETau/MuTau/TauTau events in the skims
-onlyFinalChannels = false
+onlyFinalChannels = true
 
 [parameters]
 
@@ -158,21 +158,22 @@ computeMVA = true
 nMaxEvts   = -1 # use -1 to analyze all events
 useTmpFile = false
 
-doMT2       = true
-doKinFit    = true
-doSVfit     = true
+doMT2       = false
+doKinFit    = false
+doSVfit     = false
 doPropSVfit = false
-doDNN       = true
+doDNN       = false
 doBDT       = false
-doMult      = true
+doMult      = false
 
 doVBFtrig  = false
+doTauhFake = true
 doNominal  = false
-doMES      = true
-doEES      = true
-doTES      = true
-doSplitJES = true
-doTotalJES = true
+doMES      = false
+doEES      = false
+doTES      = false
+doSplitJES = false
+doTotalJES = false
 
 kl       = 1
 year     = 2018

--- a/test/skimOutputter_HHbtag.cpp
+++ b/test/skimOutputter_HHbtag.cpp
@@ -125,6 +125,7 @@ int main (int argc, char** argv)
   cout << "** INFO: doMult      : " << doMult      << endl;
 
   bool doVBFtrig  = gConfigParser->isDefined("outPutter::doVBFtrig") ? gConfigParser->readBoolOption("outPutter::doVBFtrig") : false;
+  bool doTauhFake = gConfigParser->readBoolOption("outPutter::doTauhFake");
   bool doNominal  = gConfigParser->readBoolOption("outPutter::doNominal" );
   bool doMES      = gConfigParser->readBoolOption("outPutter::doMES"     );
   bool doEES      = gConfigParser->readBoolOption("outPutter::doEES"     );
@@ -132,6 +133,7 @@ int main (int argc, char** argv)
   bool doSplitJES = gConfigParser->readBoolOption("outPutter::doSplitJES");
   bool doTotalJES = gConfigParser->readBoolOption("outPutter::doTotalJES");
   cout << "** INFO: doVBFtrig  : " << doVBFtrig  << endl;
+  cout << "** INFO: doTauhFake : " << doTauhFake << endl;
   cout << "** INFO: doNominal  : " << doNominal  << endl;
   cout << "** INFO: doMES      : " << doMES      << endl;
   cout << "** INFO: doEES      : " << doEES      << endl;
@@ -212,6 +214,7 @@ int main (int argc, char** argv)
   "IdAndIsoAndFakeSF_deep","IdAndIsoAndFakeSF_deep_pt",
   "TTtopPtreweight*","idAndIsoAndFakeSF_tauid*",
   "idAndIsoAndFakeSF_mutauFR*","idAndIsoAndFakeSF_etauFR*",
+  "jetFakeSF",
 
   "isVBFtrigger", "isVBF",                                             // Trigger vbf selection
 
@@ -434,6 +437,30 @@ int main (int argc, char** argv)
   //int mdnnSM2_size = (mci.getNodeNames(2)).size();
   //int mdnnSM3_size = (mci.getNodeNames(3)).size();
 
+  // jet->tau_h uncertainties:
+  // - 2016 barrel :  5 %  // random number for now
+  // -      endcap : 10 %  // random number for now
+  // - 2017 barrel :  5 %  // random number for now
+  // -      endcap : 10 %  // random number for now
+  // - 2018 barrel :  5 %  // random number for now
+  // -      endcap : 10 %  // random number for now
+  float jetFakeRateUnc_barrel, jetFakeRateUnc_endcap;
+  if (YEAR == 2016)
+  {
+    jetFakeRateUnc_barrel = 0.05;
+    jetFakeRateUnc_endcap = 0.10;
+  }
+  else if (YEAR == 2017)
+  {
+    jetFakeRateUnc_barrel = 0.05;
+    jetFakeRateUnc_endcap = 0.10;
+  }
+  else /*YEAR == 2018*/
+  {
+    jetFakeRateUnc_barrel = 0.05;
+    jetFakeRateUnc_endcap = 0.10;
+  }
+
   // Fix VBF trig SF
   // Load VBF trigger SF (both jet and tau legs)
   std::string YEARstring = std::to_string(YEAR);
@@ -464,6 +491,7 @@ int main (int argc, char** argv)
   float CvsB_b1, CvsB_b2, CvsB_vbf1, CvsB_vbf2;
   float HHbtag_b1, HHbtag_b2, HHbtag_vbf1, HHbtag_vbf2;
   float BDT_HT20;
+  float jetFakeSF;
   float VBFtrigSF, trigSF;
   float trigSF_vbfjet_up, trigSF_DM0_up, trigSF_DM1_up, trigSF_DM10_up, trigSF_DM11_up;
   float trigSF_vbfjet_down, trigSF_DM0_down, trigSF_DM1_down, trigSF_DM10_down, trigSF_DM11_down;
@@ -507,6 +535,7 @@ int main (int argc, char** argv)
   outTree->SetBranchAddress("isBoosted"   , &isBoosted);
   outTree->SetBranchAddress("isVBF"       , &isVBF);
 
+  outTree->SetBranchAddress("jetFakeSF"          , &jetFakeSF);
   outTree->SetBranchAddress("trigSF"             , &trigSF);
   outTree->SetBranchAddress("trigSF_DM0_up"      , &trigSF_DM0_up);
   outTree->SetBranchAddress("trigSF_DM0_down"    , &trigSF_DM0_down);
@@ -759,6 +788,12 @@ int main (int argc, char** argv)
   outTree->SetBranchAddress("BDToutSM_kl_1"  , &BDToutSM_kl_1);
 
   // Declare new branches
+  // Jet->tau_h fakes
+  Float_t jetToTauhFakeSF, jetToTauhFakeSF_up, jetToTauhFakeSF_down;
+  TBranch* b_jetToTauhFakeSF      = outTree->Branch("jetToTauhFakeSF"      , &jetToTauhFakeSF);
+  TBranch* b_jetToTauhFakeSF_up   = outTree->Branch("jetToTauhFakeSF_up"   , &jetToTauhFakeSF_up);
+  TBranch* b_jetToTauhFakeSF_down = outTree->Branch("jetToTauhFakeSF_down" , &jetToTauhFakeSF_down);
+
   // VBF trig SF fix
   Float_t VBFtrigSF_new, trigSF_new;
   Float_t trigSF_vbfjet_up_new, trigSF_DM0_up_new, trigSF_DM1_up_new, trigSF_DM10_up_new, trigSF_DM11_up_new;
@@ -1388,6 +1423,108 @@ int main (int argc, char** argv)
 
     // Timing info
     auto end_prep = high_resolution_clock::now();
+
+    // ---- ---- ---- ---- ---- ---- ---- ----
+    // ---- ----  Do doTauhFake now  ---- ----
+    // ---- ---- ---- ---- ---- ---- ---- ----
+    // Add jet->tau_h SF (always 1) and uncertainty
+    if (doTauhFake)
+    {
+      if (isData)
+      {
+          // No SF for data
+          jetToTauhFakeSF      = 1.0;
+          jetToTauhFakeSF_up   = 1.0;
+          jetToTauhFakeSF_down = 1.0;
+      }
+      else /*isMC*/
+      {
+        // Logic of jet->tau_h uncertainty:
+        // - the "central" SF is always 1 (i.e. no SF is needed)
+        // - up and down variations are computed depending on the channel (tauTau or muTau/eTau),
+        //   on the position of the taus (barrel or endcap) and on the jetFakeSF branch of the skims
+
+        // Central SF always 1
+        jetToTauhFakeSF = 1.0;
+
+        // Up/Down variations
+        if (pType == 2) /*tauTau channel*/
+        {
+          // Possible values of "jetFakeSF":
+          // - only 1 fake
+          //     1.38469 : 1 fake in barrel
+          //     1.69035 : 1 fake in endcap
+          // - both fakes:
+          //     1.38469*1.38469 = 1.9173664 : both in barrel
+          //     1.38469*1.69035 = 2.3406107 : 1 in barrel and 1 in endcap
+          //     1.69035*1.69035 = 2.8572831 : both in endcap
+
+          if (jetFakeSF > 1.9)  /* both fakes */
+          {
+            if (fabs(dau1_eta) < 1.46 && fabs(dau2_eta) < 1.46)  /* both in barrel */
+            {
+              jetToTauhFakeSF_up   = (1+jetFakeRateUnc_barrel)*(1+jetFakeRateUnc_barrel);
+              jetToTauhFakeSF_down = (1-jetFakeRateUnc_barrel)*(1-jetFakeRateUnc_barrel);
+            }
+            else if (fabs(dau1_eta) < 1.46 || fabs(dau2_eta) < 1.46)  /* only one in barrel */
+            {
+              jetToTauhFakeSF_up   = (1+jetFakeRateUnc_barrel)*(1+jetFakeRateUnc_endcap);
+              jetToTauhFakeSF_down = (1-jetFakeRateUnc_barrel)*(1-jetFakeRateUnc_endcap);
+            }
+            else  /* both in endcap */
+            {
+              jetToTauhFakeSF_up   = (1+jetFakeRateUnc_endcap)*(1+jetFakeRateUnc_endcap);
+              jetToTauhFakeSF_down = (1-jetFakeRateUnc_endcap)*(1-jetFakeRateUnc_endcap);
+            }
+          }
+          else if (jetFakeSF > 1.5)  /* only 1 fake in endcap */
+          {
+            jetToTauhFakeSF_up   = (1+jetFakeRateUnc_barrel);
+            jetToTauhFakeSF_down = (1-jetFakeRateUnc_barrel);
+          }
+          else if (jetFakeSF > 1.3)  /* only 1 fake in barrel */
+          {
+            jetToTauhFakeSF_up   = (1+jetFakeRateUnc_endcap);
+            jetToTauhFakeSF_down = (1-jetFakeRateUnc_endcap);
+          }
+          else  /* both true tau_h */
+          {
+            jetToTauhFakeSF_up   = 1.0;
+            jetToTauhFakeSF_down = 1.0;
+          }
+        }
+        else /*muTau or eTau channel*/
+        {
+          if (jetFakeSF > 1) /* fake tau_h */
+          {
+            if (abs(dau2_eta) < 1.46) /* dau2 (tau_h) in barrel */
+            {
+              jetToTauhFakeSF_up   = (1+jetFakeRateUnc_barrel);
+              jetToTauhFakeSF_down = (1-jetFakeRateUnc_barrel);
+            }
+            else
+            {
+              jetToTauhFakeSF_up   = (1+jetFakeRateUnc_endcap);
+              jetToTauhFakeSF_down = (1-jetFakeRateUnc_endcap);
+            }
+          }
+          else /* true tau_h */
+          {
+            jetToTauhFakeSF_up   = 1.0;
+            jetToTauhFakeSF_down = 1.0;
+          }
+        }
+        //std::cout << "------------> jet->tau_h fake SF/unc for Event: " << EventNumber << std::endl;
+        //std::cout << "  pType     : " << pType << std::endl;
+        //std::cout << "  dau1_eta  : " << dau1_eta << std::endl;
+        //std::cout << "  dau2_eta  : " << dau2_eta << std::endl;
+        //std::cout << "  jetFakeSF : " << jetFakeSFval << std::endl;
+        //std::cout << "  Central SF: " << jetToTauhFakeSF << std::endl;
+        //std::cout << "  Up SF     : " << jetToTauhFakeSF_up << std::endl;
+        //std::cout << "  Down SF   : " << jetToTauhFakeSF_down << std::endl;
+      } // End isMC
+    } // End doTauhFake
+
 
     // ---- ---- ---- ---- ---- ---- ---- ----
     // ---- ---- Do VBFtriggerSF now ---- ----
@@ -3526,6 +3663,11 @@ int main (int argc, char** argv)
 
     // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
     // Fill new branches
+    // Add jet->tau_h fakes uncertainty
+    b_jetToTauhFakeSF     ->Fill();
+    b_jetToTauhFakeSF_up  ->Fill();
+    b_jetToTauhFakeSF_down->Fill();
+
     // VBF trig SF fix
     b_trigSF_new            ->Fill();
     b_trigSF_DM0_up_new     ->Fill();


### PR DESCRIPTION
This PR adds the jet->tau_h fake SF and uncertainty in the skimOutputter:
 - SF is always set to 1 (i.e. not used)
 - up/down uncertainties are dummy values for now
   - it's one unc, but values depend on barrel/endcap position of the tau
 - the unc depends on channel, year and the value of the branch `jetFakeSF` stored in the skims

To do:
- [ ] add final unc values
- [ ] modify configs to add this unc
- [ ] modify submission scripts
- [ ] modify limits scripts to add this unc