### PR TITLE
New KinFitter module

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ git clone https://github.com/svfit/SVfitTF TauAnalysis/SVfitTF
 
 scram b -j 12
 
-cd HHKinFit2/
+cd HHKinFit2/HHKinFit2/
 ln -ns interface include
 source setup.sh
 ./compile.sh
-cd ..
+cd ../..
 
 git clone git@github.com:LLRCMS/KLUBAnalysis.git
 cd KLUBAnalysis

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ git clone https://github.com/svfit/SVfitTF TauAnalysis/SVfitTF
 
 scram b -j 12
 
+cd HHKinFit2/
+ln -ns interface include
+source setup.sh
+./compile.sh
+cd ..
+
 git clone git@github.com:LLRCMS/KLUBAnalysis.git
 cd KLUBAnalysis
 git checkout VBF_legacy
@@ -55,3 +61,236 @@ source scripts/setup.sh
 make -j 10
 make exe -j 10
 ```
+
+
+### Instructions for older releases/2016/2017 analysis:
+<details>
+
+
+## Instructions for 2017 Analysis 
+```
+cmsrel CMSSW_9_0_0
+cd CMSSW_9_0_0/src
+cmsenv
+
+git clone https://github.com/bvormwald/HHKinFit2
+git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
+cd HiggsAnalysis/CombinedLimit
+git checkout 94x
+cd -
+
+scram b -j8
+
+cd HHKinFit2/
+git checkout tags/v1.1.0
+ln -ns interface include
+source setup.sh
+./compile.sh
+cd ..
+
+git clone https://github.com/camendola/KLUBAnalysis.git
+cd KLUBAnalysis
+git checkout VBF2017
+
+mkdir interface/exceptions
+cd interface/exceptions
+ln -ns ../../../HHKinFit2/interface/exceptions/HHInvMConstraintException.h
+ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyRangeException.h
+ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyConstraintException.h
+cd -
+
+
+source scripts/setup.sh
+make
+make exe
+```
+
+
+## New Installing CMSSW_7_4_7
+```
+cmsrel CMSSW_7_4_7
+cd CMSSW_7_4_7/src
+cmsenv
+
+git clone https://github.com/bvormwald/HHKinFit2
+git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
+cd HiggsAnalysis/CombinedLimit
+git checkout 74x-root6
+cd -
+scram b -j8
+
+cd HHKinFit2/
+git checkout tags/v1.1.0
+ln -ns interface include
+source setup.sh
+./compile.sh
+cd ..
+
+git clone https://github.com/camendola/KLUBAnalysis.git
+cd KLUBAnalysis
+mkdir interface/exceptions
+cd interface/exceptions
+ln -ns ../../../HHKinFit2/interface/exceptions/HHInvMConstraintException.h 
+ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyRangeException.h
+ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyConstraintException.h
+cd -
+cd weights
+git clone https://github.com/CMS-HTT/LeptonEfficiencies HTT_SF_2016
+git clone -b moriond17 https://github.com/rmanzoni/triggerSF.git tau_trigger_SF_2016
+cd -
+source scripts/setup.sh
+make
+make exe
+```
+
+## Installing
+``` 
+cd /data_CMS/cms/govoni/CMSSW_7_4_3/src
+cmsenv
+git clone https://github.com/bvormwald/HHKinFit2
+git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
+cd HiggsAnalysis/CombinedLimit
+git checkout 74x-root6
+cd -
+scram b -j8
+ls
+cd HHKinFit2/
+git checkout tags/v1.1.0
+ln -ns interface include
+source setup.sh
+./compile.sh
+cd ..
+git clone https://github.com/LLRCMS/KLUBAnalysis
+cd KLUBAnalysis
+mkdir interface/exceptions
+cd interface/exceptions
+ln -ns ../../../HHKinFit2/interface/exceptions/HHInvMConstraintException.h 
+ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyRangeException.h
+ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyConstraintException.h
+cd -
+cd weights
+# 2015 only
+# git clone https://github.com/CMS-HTT/LeptonEfficiencies.git data
+# git clone https://github.com/raspereza/LepEff2016 data
+git clone https://github.com/CMS-HTT/LeptonEfficiencies HTT_SF_2016
+git clone -b moriond17 https://github.com/rmanzoni/triggerSF.git tau_trigger_SF_2016
+cd -
+source scripts/setup.sh
+make
+make exe
+```
+</details>
+
+## How To
+Please refer to:
+```
+https://codimd.web.cern.ch/s/HJM-lQ2AX#
+```
+
+### (Old) How To:
+<details>
+
+## SyncNtupleProducer
+Specify the options (channels, samples, etc.), in:
+```
+config/sync/syncNtuples.cfg
+```
+Specify the selections for each channel in:
+```
+config/sync/syncNtuples_selections_XX.cut
+```
+Run using:
+```
+./bin/syncNtupleProducer.exe config/sync/syncNtuples.cfg
+```
+Output is located in:
+```
+syncNtuples
+```
+(output folder can be specified in config file)
+ 
+## Big ntuples skimming
+
+Example on how to submit a skimming.
+ * the "-i" option indicates the folder where the LLR ntuples are stored
+ * the "-x" option indicates the cross-section of the sample, which will be multiplied to the MC weight variable
+ * jobs to be executed are saved in the folder SKIM_XXX in the current directory, where XXX is the name of the folder containing the LLR ntuples
+   * this means that for a re-skimming the same folder is used, which means that the resubmit can be done only on the last skim performed
+
+```
+python scripts/skimNtuple.py  \
+ -s True -c  config/skim.cfg  -o /data_CMS/cms/govoni/test_submit_to_tier3/Skims5_SS/SKIM_WJet  \
+ -i /data_CMS/cms/govoni/test_submit_to_tier3/HiggsTauTauOutput_WJets_-1Events_0Skipped_1437551416.48 \
+ -x 61526.7 
+``` 
+
+Example on how to check if all the jobs run successfully 
+(based on the presence of the "done" file for any failures at cluster level,
+and on the presence of "Error" in the log file for root problems,
+which sometimes arise.
+ * skim.cfg contains the main parameters to be set
+ * The flag "-i" is the same as the submission job
+ * The "-r" option triggers the checking, always overcomes the initial submission (but if set to "none") and by default lists the problematic jobs.
+ * The "-r run" option triggers the resubmission of the jobs identified as failed
+ * -s True: introduce a sleep of 0.1 s between each submission, to avoid output saving problems
+ * -I True: run the inclusive skim, i.e. does not cut on number of jets
+ * -v True: is verbose in the resubmit step
+ * -H doit: merge all the root files with a hadd
+
+To skim one sample:
+```
+python scripts/skimNtuple.py -d True -s True -o /data_CMS/cms/govoni/test_submit_to_tier3/Skims3/SKIM_Data_SingleMuon     -i /data_CMS/cms/cadamuro/test_submit_to_tier3/HiggsTauTauOutput_Data_SingleMuon_-1Events_0Skipped_1437412858.02
+```
+Once jobs are run to check whether there's files to be resubmitted, 
+```
+python scripts/skimNtuple.py -r list -d True -s True -o /data_CMS/cms/govoni/test_submit_to_tier3/Skims3/SKIM_Data_SingleMuon     -i /data_CMS/cms/cadamuro/test_submit_to_tier3/HiggsTauTauOutput_Data_SingleMuon_-1Events_0Skipped_1437412858.02
+```
+If there's any, actually resubmit, 
+```
+python scripts/skimNtuple.py -r run -d True -s True -o /data_CMS/cms/govoni/test_submit_to_tier3/Skims3/SKIM_Data_SingleMuon     -i /data_CMS/cms/cadamuro/test_submit_to_tier3/HiggsTauTauOutput_Data_SingleMuon_-1Events_0Skipped_1437412858.02
+```
+Once all jobs finished successfully, hadd the results (this is necessary for the analysis to run)
+```
+python scripts/skimNtuple.py -H doit -d True -s True -o /data_CMS/cms/govoni/test_submit_to_tier3/Skims3/SKIM_Data_SingleMuon     -i /data_CMS/cms/cadamuro/test_submit_to_tier3/HiggsTauTauOutput_Data_SingleMuon_-1Events_0Skipped_1437412858.02
+```
+
+## Plotting
+
+Example on how to draw plots of variables already existing in the skimmed ntuples.
+Plots are produced in the "plotter" folder, divided into a set with the proper normalisation
+according to the XS inserted in the processing, and one with shapes, where the backgrounds
+are combined according to the XS and then the total result is normalised, to compare to 
+the signal in shapes.
+ * the config file ```plotter_muTau.cfg``` contains all the relevant information for the run
+ * an additional ```plotter_muTau.cut``` contains the selections to be applied in the plots generation
+
+```
+./bin/plotNEW.exe config/plotter_muTau.cfg 
+```
+
+The 2D plots are done with:
+```
+./bin/plot2D.exe config/plotter_muTau.cfg 
+```
+The config files for plotting are called config/plotter*cfg,
+and the corresponding cut sequences are config/plotter*cut.
+The request of having opposite sign candidates is in the selection sequence itself 
+for the plotting from the skims.
+This is not the case for the analysis sequence, though.
+
+## MVA training
+
+Example on how to run a MVA training on the reduced flat trees.
+The TMVATraining.cpp executable uses the TMVATrainingClass to interface to the TMVA package.
+ * preselections are applied according to the cfg file
+ * BDT training methods available
+ * more training methods could be added copyting them from the TMVATrainingClass, which unfortunately does not work properly, since it would need a artisanal root patch which we don't want to do
+ 
+ ```
+./bin/TMVATrainingZero.exe ./config/TMVATraining.cfg
+```
+The MVA info is then added to the SKIM tree with:
+```
+./bin/addTMVA.exe config/addTMVA.cfg 
+```
+</details>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ git clone git@github.com:hh-italian-group/HHbtag.git HHTools/HHbtag
 # KinFit and Combine packages
 mkdir HHKinFit2
 cd HHKinFit2
-git clone git@github.com:jonamotta/HHKinFit2.git -b bbtautau_Run2DNNtraining
+git clone git@github.com:LLRCMS/HHKinFit2.git -b bbtautau_Run2DNNtraining
 cd ..
 git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
 cd HiggsAnalysis/CombinedLimit

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ git clone https://gitlab.cern.ch/hh/bbtautau/MulticlassInference.git
 git clone git@github.com:hh-italian-group/HHbtag.git HHTools/HHbtag
 
 # KinFit and Combine packages
-git clone git@github.com:LLRCMS/HHKinFit2.git -b bbtautau_LegacyRun2
+mkdir HHKinFit2
+cd HHKinFit2
+git clone git@github.com:jonamotta/HHKinFit2.git -b bbtautau_Run2DNNtraining
+cd ..
 git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
 cd HiggsAnalysis/CombinedLimit
 git checkout v8.2.0
@@ -36,258 +39,19 @@ cd -
 git clone https://github.com/LLRCMS/ClassicSVfit.git TauAnalysis/ClassicSVfit -b bbtautau_LegacyRun2
 git clone https://github.com/svfit/SVfitTF TauAnalysis/SVfitTF
 
-scram b -j8
-
-cd HHKinFit2/
-ln -ns interface include
-source setup.sh
-./compile.sh
-cd ..
+scram b -j 12
 
 git clone git@github.com:LLRCMS/KLUBAnalysis.git
 cd KLUBAnalysis
 git checkout VBF_legacy
 
 cd interface/exceptions
-ln -ns ../../../HHKinFit2/interface/exceptions/HHInvMConstraintException.h
-ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyRangeException.h
-ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyConstraintException.h
+ln -ns ../../../HHKinFit2/HHKinFit2/interface/exceptions/HHInvMConstraintException.h
+ln -ns ../../../HHKinFit2/HHKinFit2/interface/exceptions/HHEnergyRangeException.h
+ln -ns ../../../HHKinFit2/HHKinFit2/interface/exceptions/HHEnergyConstraintException.h
 cd -
 
 source scripts/setup.sh
-make
-make exe
+make -j 10
+make exe -j 10
 ```
-
-
-### Instructions for older releases/2016/2017 analysis:
-<details>
-
-
-## Instructions for 2017 Analysis 
-```
-cmsrel CMSSW_9_0_0
-cd CMSSW_9_0_0/src
-cmsenv
-
-git clone https://github.com/bvormwald/HHKinFit2
-git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
-cd HiggsAnalysis/CombinedLimit
-git checkout 94x
-cd -
-
-scram b -j8
-
-cd HHKinFit2/
-git checkout tags/v1.1.0
-ln -ns interface include
-source setup.sh
-./compile.sh
-cd ..
-
-git clone https://github.com/camendola/KLUBAnalysis.git
-cd KLUBAnalysis
-git checkout VBF2017
-
-mkdir interface/exceptions
-cd interface/exceptions
-ln -ns ../../../HHKinFit2/interface/exceptions/HHInvMConstraintException.h
-ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyRangeException.h
-ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyConstraintException.h
-cd -
-
-
-source scripts/setup.sh
-make
-make exe
-```
-
-
-## New Installing CMSSW_7_4_7
-```
-cmsrel CMSSW_7_4_7
-cd CMSSW_7_4_7/src
-cmsenv
-
-git clone https://github.com/bvormwald/HHKinFit2
-git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
-cd HiggsAnalysis/CombinedLimit
-git checkout 74x-root6
-cd -
-scram b -j8
-
-cd HHKinFit2/
-git checkout tags/v1.1.0
-ln -ns interface include
-source setup.sh
-./compile.sh
-cd ..
-
-git clone https://github.com/camendola/KLUBAnalysis.git
-cd KLUBAnalysis
-mkdir interface/exceptions
-cd interface/exceptions
-ln -ns ../../../HHKinFit2/interface/exceptions/HHInvMConstraintException.h 
-ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyRangeException.h
-ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyConstraintException.h
-cd -
-cd weights
-git clone https://github.com/CMS-HTT/LeptonEfficiencies HTT_SF_2016
-git clone -b moriond17 https://github.com/rmanzoni/triggerSF.git tau_trigger_SF_2016
-cd -
-source scripts/setup.sh
-make
-make exe
-```
-
-## Installing
-``` 
-cd /data_CMS/cms/govoni/CMSSW_7_4_3/src
-cmsenv
-git clone https://github.com/bvormwald/HHKinFit2
-git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
-cd HiggsAnalysis/CombinedLimit
-git checkout 74x-root6
-cd -
-scram b -j8
-ls
-cd HHKinFit2/
-git checkout tags/v1.1.0
-ln -ns interface include
-source setup.sh
-./compile.sh
-cd ..
-git clone https://github.com/LLRCMS/KLUBAnalysis
-cd KLUBAnalysis
-mkdir interface/exceptions
-cd interface/exceptions
-ln -ns ../../../HHKinFit2/interface/exceptions/HHInvMConstraintException.h 
-ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyRangeException.h
-ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyConstraintException.h
-cd -
-cd weights
-# 2015 only
-# git clone https://github.com/CMS-HTT/LeptonEfficiencies.git data
-# git clone https://github.com/raspereza/LepEff2016 data
-git clone https://github.com/CMS-HTT/LeptonEfficiencies HTT_SF_2016
-git clone -b moriond17 https://github.com/rmanzoni/triggerSF.git tau_trigger_SF_2016
-cd -
-source scripts/setup.sh
-make
-make exe
-```
-</details>
-
-## How To
-Please refer to:
-```
-https://codimd.web.cern.ch/s/HJM-lQ2AX#
-```
-
-### (Old) How To:
-<details>
-
-## SyncNtupleProducer
-Specify the options (channels, samples, etc.), in:
-```
-config/sync/syncNtuples.cfg
-```
-Specify the selections for each channel in:
-```
-config/sync/syncNtuples_selections_XX.cut
-```
-Run using:
-```
-./bin/syncNtupleProducer.exe config/sync/syncNtuples.cfg
-```
-Output is located in:
-```
-syncNtuples
-```
-(output folder can be specified in config file)
- 
-## Big ntuples skimming
-
-Example on how to submit a skimming.
- * the "-i" option indicates the folder where the LLR ntuples are stored
- * the "-x" option indicates the cross-section of the sample, which will be multiplied to the MC weight variable
- * jobs to be executed are saved in the folder SKIM_XXX in the current directory, where XXX is the name of the folder containing the LLR ntuples
-   * this means that for a re-skimming the same folder is used, which means that the resubmit can be done only on the last skim performed
-
-```
-python scripts/skimNtuple.py  \
- -s True -c  config/skim.cfg  -o /data_CMS/cms/govoni/test_submit_to_tier3/Skims5_SS/SKIM_WJet  \
- -i /data_CMS/cms/govoni/test_submit_to_tier3/HiggsTauTauOutput_WJets_-1Events_0Skipped_1437551416.48 \
- -x 61526.7 
-``` 
-
-Example on how to check if all the jobs run successfully 
-(based on the presence of the "done" file for any failures at cluster level,
-and on the presence of "Error" in the log file for root problems,
-which sometimes arise.
- * skim.cfg contains the main parameters to be set
- * The flag "-i" is the same as the submission job
- * The "-r" option triggers the checking, always overcomes the initial submission (but if set to "none") and by default lists the problematic jobs.
- * The "-r run" option triggers the resubmission of the jobs identified as failed
- * -s True: introduce a sleep of 0.1 s between each submission, to avoid output saving problems
- * -I True: run the inclusive skim, i.e. does not cut on number of jets
- * -v True: is verbose in the resubmit step
- * -H doit: merge all the root files with a hadd
-
-To skim one sample:
-```
-python scripts/skimNtuple.py -d True -s True -o /data_CMS/cms/govoni/test_submit_to_tier3/Skims3/SKIM_Data_SingleMuon     -i /data_CMS/cms/cadamuro/test_submit_to_tier3/HiggsTauTauOutput_Data_SingleMuon_-1Events_0Skipped_1437412858.02
-```
-Once jobs are run to check whether there's files to be resubmitted, 
-```
-python scripts/skimNtuple.py -r list -d True -s True -o /data_CMS/cms/govoni/test_submit_to_tier3/Skims3/SKIM_Data_SingleMuon     -i /data_CMS/cms/cadamuro/test_submit_to_tier3/HiggsTauTauOutput_Data_SingleMuon_-1Events_0Skipped_1437412858.02
-```
-If there's any, actually resubmit, 
-```
-python scripts/skimNtuple.py -r run -d True -s True -o /data_CMS/cms/govoni/test_submit_to_tier3/Skims3/SKIM_Data_SingleMuon     -i /data_CMS/cms/cadamuro/test_submit_to_tier3/HiggsTauTauOutput_Data_SingleMuon_-1Events_0Skipped_1437412858.02
-```
-Once all jobs finished successfully, hadd the results (this is necessary for the analysis to run)
-```
-python scripts/skimNtuple.py -H doit -d True -s True -o /data_CMS/cms/govoni/test_submit_to_tier3/Skims3/SKIM_Data_SingleMuon     -i /data_CMS/cms/cadamuro/test_submit_to_tier3/HiggsTauTauOutput_Data_SingleMuon_-1Events_0Skipped_1437412858.02
-```
-
-## Plotting
-
-Example on how to draw plots of variables already existing in the skimmed ntuples.
-Plots are produced in the "plotter" folder, divided into a set with the proper normalisation
-according to the XS inserted in the processing, and one with shapes, where the backgrounds
-are combined according to the XS and then the total result is normalised, to compare to 
-the signal in shapes.
- * the config file ```plotter_muTau.cfg``` contains all the relevant information for the run
- * an additional ```plotter_muTau.cut``` contains the selections to be applied in the plots generation
-
-```
-./bin/plotNEW.exe config/plotter_muTau.cfg 
-```
-
-The 2D plots are done with:
-```
-./bin/plot2D.exe config/plotter_muTau.cfg 
-```
-The config files for plotting are called config/plotter*cfg,
-and the corresponding cut sequences are config/plotter*cut.
-The request of having opposite sign candidates is in the selection sequence itself 
-for the plotting from the skims.
-This is not the case for the analysis sequence, though.
-
-## MVA training
-
-Example on how to run a MVA training on the reduced flat trees.
-The TMVATraining.cpp executable uses the TMVATrainingClass to interface to the TMVA package.
- * preselections are applied according to the cfg file
- * BDT training methods available
- * more training methods could be added copyting them from the TMVATrainingClass, which unfortunately does not work properly, since it would need a artisanal root patch which we don't want to do
- 
- ```
-./bin/TMVATrainingZero.exe ./config/TMVATraining.cfg
-```
-The MVA info is then added to the SKIM tree with:
-```
-./bin/addTMVA.exe config/addTMVA.cfg 
-```
-</details>

--- a/config/skim_Legacy2016_mib.cfg
+++ b/config/skim_Legacy2016_mib.cfg
@@ -134,9 +134,16 @@ variables  = VBFjet1_pt:BDT_j1n_pt, bH_pt:BDT_n_bH_pt, dib_dEtaSign:BDT_n_b1b2_d
 
 [DNN]
 computeMVA = true
-weights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
-features = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
 kl = 1
+HHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
+HHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
+
+ZHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/ensemble
+ZHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/features.txt
+
+ZZweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/ensemble
+ZZfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/features.txt
+
 
 [HHbtag]
 weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/HHTools/HHbtag/models/HHbtag_v1_par_

--- a/config/skim_Legacy2016_mib.cfg
+++ b/config/skim_Legacy2016_mib.cfg
@@ -138,11 +138,11 @@ kl = 1
 HHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
 HHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
 
-ZHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/ensemble
-ZHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/features.txt
+ZHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-22-0/ensemble
+ZHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-22-0/features.txt
 
-ZZweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/ensemble
-ZZfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/features.txt
+ZZweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-22-0/ensemble
+ZZfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-22-0/features.txt
 
 
 [HHbtag]

--- a/config/skim_Legacy2016_mib.cfg
+++ b/config/skim_Legacy2016_mib.cfg
@@ -138,11 +138,11 @@ kl = 1
 HHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
 HHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
 
-ZHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/ensemble
-ZHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/features.txt
+ZHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/ensemble
+ZHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/features.txt
 
-ZZweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/ensemble
-ZZfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/features.txt
+ZZweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/ensemble
+ZZfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/features.txt
 
 
 [HHbtag]

--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -134,9 +134,16 @@ variables  = VBFjet1_pt:BDT_j1n_pt, bH_pt:BDT_n_bH_pt, dib_dEtaSign:BDT_n_b1b2_d
 
 [DNN]
 computeMVA = true
-weights = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
-features = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
 kl = 1
+HHweights  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
+HHfeatures = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
+
+ZHweights  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/ensemble
+ZHfeatures = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/features.txt
+
+ZZweights  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/ensemble
+ZZfeatures = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/features.txt
+
 
 [HHbtag]
 weights = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/HHTools/HHbtag/models/HHbtag_v1_par_

--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -138,11 +138,11 @@ kl = 1
 HHweights  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
 HHfeatures = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
 
-ZHweights  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/ensemble
-ZHfeatures = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/features.txt
+ZHweights  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-22-0/ensemble
+ZHfeatures = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-22-0/features.txt
 
-ZZweights  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/ensemble
-ZZfeatures = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/features.txt
+ZZweights  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-22-0/ensemble
+ZZfeatures = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-22-0/features.txt
 
 
 [HHbtag]

--- a/config/skim_Legacy2017_mib.cfg
+++ b/config/skim_Legacy2017_mib.cfg
@@ -138,11 +138,11 @@ kl = 1
 HHweights  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
 HHfeatures = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
 
-ZHweights  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/ensemble
-ZHfeatures = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/features.txt
+ZHweights  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/ensemble
+ZHfeatures = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/features.txt
 
-ZZweights  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/ensemble
-ZZfeatures = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/features.txt
+ZZweights  = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/ensemble
+ZZfeatures = /gwpool/users/dzuolo/HHbbtautatuAnalysisLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/features.txt
 
 
 [HHbtag]

--- a/config/skim_Legacy2018.cfg
+++ b/config/skim_Legacy2018.cfg
@@ -145,11 +145,11 @@ kl = 1
 HHweights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
 HHfeatures = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
 
-ZHweights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/ensemble
-ZHfeatures = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/features.txt
+ZHweights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-22-0/ensemble
+ZHfeatures = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-22-0/features.txt
 
-ZZweights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/ensemble
-ZZfeatures = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/features.txt
+ZZweights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-22-0/ensemble
+ZZfeatures = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-22-0/features.txt
 
 [HHbtag]
 weights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/HHTools/HHbtag/models/HHbtag_v1_par_

--- a/config/skim_Legacy2018.cfg
+++ b/config/skim_Legacy2018.cfg
@@ -145,11 +145,11 @@ kl = 1
 HHweights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
 HHfeatures = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
 
-ZHweights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/ensemble
-ZHfeatures = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/features.txt
+ZHweights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/ensemble
+ZHfeatures = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/features.txt
 
-ZZweights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/ensemble
-ZZfeatures = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/features.txt
+ZZweights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/ensemble
+ZZfeatures = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/features.txt
 
 [HHbtag]
 weights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/HHTools/HHbtag/models/HHbtag_v1_par_

--- a/config/skim_Legacy2018.cfg
+++ b/config/skim_Legacy2018.cfg
@@ -141,9 +141,15 @@ sfFile    = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/KLUBAnalysis/weig
 
 [DNN]
 computeMVA = true
-weights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
-features = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
 kl = 1
+HHweights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
+HHfeatures = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
+
+ZHweights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/ensemble
+ZHfeatures = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/features.txt
+
+ZZweights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/ensemble
+ZZfeatures = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/features.txt
 
 [HHbtag]
 weights = /home/llr/cms/motta/HHLegacy/CMSSW_11_1_0_pre6/src/HHTools/HHbtag/models/HHbtag_v1_par_

--- a/config/skim_Legacy2018_mib.cfg
+++ b/config/skim_Legacy2018_mib.cfg
@@ -142,11 +142,11 @@ kl = 1
 HHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
 HHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
 
-ZHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/ensemble
-ZHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/features.txt
+ZHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-22-0/ensemble
+ZHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-22-0/features.txt
 
-ZZweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/ensemble
-ZZfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/features.txt
+ZZweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-22-0/ensemble
+ZZfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-22-0/features.txt
 
 
 [HHbtag]

--- a/config/skim_Legacy2018_mib.cfg
+++ b/config/skim_Legacy2018_mib.cfg
@@ -142,11 +142,11 @@ kl = 1
 HHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
 HHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
 
-ZHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/ensemble
-ZHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/features.txt
+ZHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/ensemble
+ZHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zh_bbtt/2021-11-20-0/features.txt
 
-ZZweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/ensemble
-ZZfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/features.txt
+ZZweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/ensemble
+ZZfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_checks/zz_bbtt/2021-11-20-0/features.txt
 
 
 [HHbtag]

--- a/config/skim_Legacy2018_mib.cfg
+++ b/config/skim_Legacy2018_mib.cfg
@@ -138,9 +138,16 @@ variables  = VBFjet1_pt:BDT_j1n_pt, bH_pt:BDT_n_bH_pt, dib_dEtaSign:BDT_n_b1b2_d
 
 [DNN]
 computeMVA = true
-weights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
-features = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
 kl = 1
+HHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/ensemble
+HHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/nonres_gluglu/2020-07-31-0/features.txt
+
+ZHweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/ensemble
+ZHfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zh_bbtt/2021-11-20-0/features.txt
+
+ZZweights  = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/ensemble
+ZZfeatures = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/cms_runII_dnn_models/models/arc_chekcs/zz_bbtt/2021-11-20-0/features.txt
+
 
 [HHbtag]
 weights = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_0_pre6/src/HHTools/HHbtag/models/HHbtag_v1_par_

--- a/interface/kinfitter.h
+++ b/interface/kinfitter.h
@@ -1,0 +1,71 @@
+#ifndef KINFITTER_H_
+#define KINFITTER_H_
+
+// C++
+#include <iostream>
+#include <string>
+#include <map>
+#include <vector>
+#include <set>
+#include <stdexcept>
+#include <utility>
+
+// ROOT
+#include <Math/VectorUtil.h>
+#include <Math/LorentzVector.h>
+#include <Math/PtEtaPhiM4D.h>
+#include <Math/PxPyPzM4D.h>
+#include <TFile.h>
+#include <TTree.h>
+#include <TTreeReader.h>
+#include <TTreeReaderValue.h>
+#include <TLorentzVector.h>
+#include <TMatrixD.h>
+
+// HHKinFit2
+#include "../../HHKinFit2/HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
+
+const int Z_MASS  = 91;  //GeV
+const int H_MASS  = 125; //GeV
+
+class KinFitter {
+    // class to calculate KinFit mass of a particle given a mass hypothesis and its decay products
+private:
+    TLorentzVector tlv_l1 = TLorentzVector();
+    TLorentzVector tlv_l2 = TLorentzVector();
+    TLorentzVector tlv_b1 = TLorentzVector();
+    TLorentzVector tlv_b2 = TLorentzVector();
+    TVector2 ptmiss = TVector2();
+    TMatrixD metcov = TMatrixD(2,2);
+    double b1_JER = -1.0;
+    double b2_JER = -1.0;
+
+    HHKinFit2::HHKinFitMasterHeavyHiggs KinFit = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_b1, tlv_b2, tlv_l1, tlv_l2, ptmiss, metcov, b1_JER, b2_JER);
+    bool fitsNotConverging = false;
+
+    int mh1_hpFit;
+    int mh2_hpFit;
+
+    std::pair<HHKinFit2::HHKinFitMasterHeavyHiggs,float> _fit(int mh1_hp, int mh2_hp);
+
+public:
+    KinFitter(TLorentzVector tlv_firstBjet,
+              TLorentzVector tlv_secondBjet,
+              TLorentzVector tlv_firstLepton,
+              TLorentzVector tlv_secondLepton,
+              TVector2 ptmiss,
+              TMatrixD stableMetCov,
+              double bjet1_JER = -1.0,
+              double bjet2_JER = -1.0);
+    ~KinFitter();
+    bool fit(std::string sgnHp = "HH");
+    double getMH();
+    double getChi2();
+    int getConvergence();
+    double getFitProb();
+    TLorentzVector getFittedBJet1();
+    TLorentzVector getFittedBJet2();
+
+};
+
+#endif /* KINFITTER_H_ */

--- a/interface/kinfitter.h
+++ b/interface/kinfitter.h
@@ -21,6 +21,7 @@
 #include <TTreeReaderValue.h>
 #include <TLorentzVector.h>
 #include <TMatrixD.h>
+#include <TString.h>
 
 // HHKinFit2
 #include "../../HHKinFit2/HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
@@ -58,7 +59,7 @@ public:
               double bjet1_JER = -1.0,
               double bjet2_JER = -1.0);
     ~KinFitter();
-    bool fit(std::string sgnHp = "HH");
+    bool fit(TString sgnHp = "HH");
     double getMH();
     double getChi2();
     int getConvergence();

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -25,11 +25,11 @@ done
 if [ "$pathunset" = true ] ; then
     export THISDIR=`pwd`
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${THISDIR}/lib
-    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${THISDIR}/../HHKinFit2
+    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${THISDIR}/../HHKinFit2/HHKinFit2
 
     if [ -n "${DYLD_LIBRARY_PATH}" ] ; then
     export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:${THISDIR}/lib
-    export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:${THISDIR}/../HHKinFit2
+    export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:${THISDIR}/../HHKinFit2/HHKinFit2
     fi
 
     export PATH=${PATH}:${THISDIR}/bin

--- a/scripts/skimNtuple.py
+++ b/scripts/skimNtuple.py
@@ -78,6 +78,7 @@ if __name__ == "__main__":
     parser.add_option ('--ttHToNonBB',       dest='ttHToNonBB', help='if it is a ttHToNonBB sample'         , default=False)
     parser.add_option ('--hhNLO',            dest='hhNLO'     , help='if it is an HH NLO sample'            , default=False,  action = 'store_true')
     parser.add_option ('--doSyst',           dest='doSyst'    , help='compute up/down values of outputs'    , default=False,  action = 'store_true')
+    parser.add_option ('--whichSgnHp',       dest='whichSgnHp', help='HH/ZH/ZZ are supported'               , default='HH')
 
     (opt, args) = parser.parse_args()
 
@@ -266,6 +267,7 @@ if __name__ == "__main__":
         else                  : command += " 0 "
         if opt.hhNLO          : command += " 1 "
         else                  : command += " 0 "
+        command += (" " + opt.whichSgnHp)
         command += ' >& ' + opt.output + '/' + "output_" + str(n) + '.log\n'
         scriptFile.write (command)
         scriptFile.write ('touch ' + jobsDir + '/done_%d\n'%n)

--- a/scripts/skimNtuple_mib.py
+++ b/scripts/skimNtuple_mib.py
@@ -78,6 +78,7 @@ if __name__ == "__main__":
     parser.add_option ('--ttHToNonBB',       dest='ttHToNonBB', help='if it is a ttHToNonBB sample'         , default=False)
     parser.add_option ('--hhNLO',            dest='hhNLO'     , help='if it is an HH NLO sample'            , default=False)
     parser.add_option ('--doSyst',           dest='doSyst'    , help='compute up/down values of outputs'    , default=False)
+    parser.add_option ('--whichSgnHp',       dest='whichSgnHp', help='HH/ZH/ZZ are supported'               , default='HH')
 
     (opt, args) = parser.parse_args()
 
@@ -263,6 +264,7 @@ if __name__ == "__main__":
         else                  : command += " 0 "
         if opt.hhNLO          : command += " 1 "
         else                  : command += " 0 "
+        command += (" " + opt.whichSgnHp)
         command += ' >& ' + opt.output + '/' + "output_" + str(n) + '.log\n'
         scriptFile.write (command)
         scriptFile.write ('touch ' + jobsDir + '/done_%d\n'%n)

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ SONAME	 =  libDoubleHiggs.so
 SONAME2  =  DoubleHiggs
 SOFLAGS  =  -Wl,-soname,$(SONAME)
 
-GLIBS   =  -lm -ldl -rdynamic $(ROOTGLIBS) -lGenVector -lFoam -lMinuit -lTMVA -lMLP -lXMLIO -lGpad  -lTreePlayer -lRooFit -lRooFitCore -lRooStats -lHHKinFit2 -L../../HHKinFit2 -lboost_regex -lboost_system -lboost_filesystem -ltensorflow_cc -ltensorflow_framework $(TensFLowFLAGS)
+GLIBS   =  -lm -ldl -rdynamic $(ROOTGLIBS) -lGenVector -lFoam -lMinuit -lTMVA -lMLP -lXMLIO -lGpad  -lTreePlayer -lRooFit -lRooFitCore -lRooStats -lHHKinFit2 -L../../HHKinFit2/HHKinFit2 -lboost_regex -lboost_system -lboost_filesystem -ltensorflow_cc -ltensorflow_framework $(TensFLowFLAGS)
 
 DNNARCH = $(shell scram arch)
 DNNPATH = $(shell echo $$CMSSW_BASE | grep "CMSSW" | sed -e 's/$$/\/lib/')/$(DNNARCH)/

--- a/src/kinfitter.cc
+++ b/src/kinfitter.cc
@@ -191,7 +191,7 @@ bool KinFitter::fit(TString sgnHp) {
             mh1_hpFit = mh1_hp;
             mh2_hpFit = mh2_hp;
         }
-        else fitsNotConverging = true;;
+        else fitsNotConverging = true;
     }
 
     return fitsNotConverging;

--- a/src/kinfitter.cc
+++ b/src/kinfitter.cc
@@ -1,0 +1,222 @@
+#include "../../HHKinFit2/HHKinFit2/include/exceptions/HHInvMConstraintException.h"
+#include "../../HHKinFit2/HHKinFit2/include/exceptions/HHEnergyRangeException.h"
+#include "../../HHKinFit2/HHKinFit2/include/exceptions/HHEnergyConstraintException.h"
+#include "../../HHKinFit2/HHKinFit2/include/exceptions/HHLimitSettingException.h"
+#include "../../HHKinFit2/HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
+#include "kinfitter.h"
+
+KinFitter::KinFitter(TLorentzVector tlv_firstBjet,
+                     TLorentzVector tlv_secondBjet,
+                     TLorentzVector tlv_firstLepton,
+                     TLorentzVector tlv_secondLepton,
+                     TVector2 ptmiss,
+                     TMatrixD stableMetCov,
+                     double bjet1_JER,
+                     double bjet2_JER) {
+    
+    tlv_l1 = tlv_firstBjet;
+    tlv_l2 = tlv_secondBjet;
+    tlv_b1 = tlv_firstLepton;
+    tlv_b2 = tlv_secondLepton;
+    ptmiss = ptmiss;
+    metcov = stableMetCov;
+    b1_JER = bjet1_JER;
+    b2_JER = bjet2_JER;
+
+    KinFit = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_b1, tlv_b2, tlv_l1, tlv_l2, ptmiss, metcov, b1_JER, b2_JER);
+}
+
+KinFitter::~KinFitter() {}
+
+std::pair<HHKinFit2::HHKinFitMasterHeavyHiggs,float> KinFitter::_fit(int mh1_hp, int mh2_hp) {
+    HHKinFit2::HHKinFitMasterHeavyHiggs localFit = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_b1, tlv_b2, tlv_l1, tlv_l2, ptmiss, metcov);
+    localFit.addHypo(mh1_hp, mh2_hp);
+
+    float localChi2 = -999;
+    bool DEBUG = false;
+
+    bool wrongFit=false;
+    try { localFit.fit(); }
+    catch (HHKinFit2::HHInvMConstraintException const& e) {
+        std::cout<<"THIS FIT DID NOT CONVERGE: INV MASS CONSTRAIN EXCEPTION (mh1_hp = " << mh1_hp << " , mh2_hp = " << mh2_hp << ")" << std::endl;
+        if (DEBUG) {            
+            std::cout<<"INVME Tau1"<<std::endl;
+            std::cout<<"INVME (E,Px,Py,Pz,M) "<< tlv_l1.E() <<","<< tlv_l1.Px() <<","<< tlv_l1.Py() <<","<< tlv_l1.Pz() <<","<< tlv_l1.M() << std::endl;
+            std::cout<<"INVME Tau2"<<std::endl;
+            std::cout<<"INVME (E,Px,Py,Pz,M) "<< tlv_l2.E() <<","<< tlv_l2.Px() <<","<< tlv_l2.Py() <<","<< tlv_l2.Pz() <<","<< tlv_l2.M() << std::endl;
+            std::cout<<"INVME B1"<<std::endl;
+            std::cout<<"INVME (E,Px,Py,Pz,M) "<< tlv_b1.E() <<","<< tlv_b1.Px() <<","<< tlv_b1.Py() <<","<< tlv_b1.Pz() <<","<< tlv_b1.M() << std::endl;
+            std::cout<<"INVME B2"<<std::endl;
+            std::cout<<"INVME (E,Px,Py,Pz,M) "<< tlv_b2.E() <<","<< tlv_b2.Px() <<","<< tlv_b2.Py() <<","<< tlv_b2.Pz() <<","<< tlv_b2.M() << std::endl;
+            std::cout<<"INVME MET"<<std::endl;
+            std::cout<<"INVME (E,Px,Py,Pz,M) "<<","<< ptmiss.Px() <<","<< ptmiss.Py() << std::endl;
+            std::cout<<"INVME METCOV "<<std::endl;
+            std::cout<<"INVME "<< metcov (0,0) <<"  "<< metcov (0,1) << std::endl;
+            std::cout<<"INVME "<< metcov (1,0) <<"  "<< metcov (1,1) << std::endl;
+            std::cout<<"INVME tau1, tau2, b1, b2"<<std::endl;
+            std::cout<<"INVME ";
+            tlv_l1.Print();
+            std::cout<<"INVME ";
+            tlv_l2.Print();
+            std::cout<<"INVME ";
+            tlv_b1.Print();
+            std::cout<<"INVME ";
+            tlv_b2.Print();
+        }
+        wrongFit=true;
+    }
+    catch (HHKinFit2::HHEnergyRangeException const& e) {
+        std::cout<<"THIS FIT DID NOT CONVERGE: INV MASS CONSTRAIN EXCEPTION (mh1_hp = " << mh1_hp << " , mh2_hp = " << mh2_hp << ")" << std::endl;
+        if (DEBUG) {
+            std::cout<<"ERANGE Tau1"<<std::endl;
+            std::cout<<"ERANGE (E,Px,Py,Pz,M) "<< tlv_l1.E() <<","<< tlv_l1.Px() <<","<< tlv_l1.Py() <<","<< tlv_l1.Pz() <<","<< tlv_l1.M() << std::endl;
+            std::cout<<"ERANGE Tau2"<<std::endl;
+            std::cout<<"ERANGE (E,Px,Py,Pz,M) "<< tlv_l2.E() <<","<< tlv_l2.Px() <<","<< tlv_l2.Py() <<","<< tlv_l2.Pz() <<","<< tlv_l2.M() << std::endl;
+            std::cout<<"ERANGE B1"<<std::endl;
+            std::cout<<"ERANGE (E,Px,Py,Pz,M) "<< tlv_b1.E() <<","<< tlv_b1.Px() <<","<< tlv_b1.Py() <<","<< tlv_b1.Pz() <<","<< tlv_b1.M() << std::endl;
+            std::cout<<"ERANGE B2"<<std::endl;
+            std::cout<<"ERANGE (E,Px,Py,Pz,M) "<< tlv_b2.E() <<","<< tlv_b2.Px() <<","<< tlv_b2.Py() <<","<< tlv_b2.Pz() <<","<< tlv_b2.M() << std::endl;
+            std::cout<<"ERANGE MET"<<std::endl;
+            std::cout<<"ERANGE (E,Px,Py,Pz,M) "<<","<< ptmiss.Px() <<","<< ptmiss.Py() <<std::endl;
+            std::cout<<"ERANGE METCOV "<<std::endl;
+            std::cout<<"ERANGE "<< metcov (0,0) <<"  "<< metcov (0,1) << std::endl;
+            std::cout<<"ERANGE "<< metcov (1,0) <<"  "<< metcov (1,1) << std::endl;
+            std::cout<<"ERANGE tau1, tau2, b1, b2"<<std::endl;
+            std::cout<<"ERANGE ";
+            tlv_l1.Print();
+            std::cout<<"ERANGE ";
+            tlv_l2.Print();
+            std::cout<<"ERANGE ";
+            tlv_b1.Print();
+            std::cout<<"ERANGE ";
+            tlv_b2.Print();
+        }
+        wrongFit=true;
+    }
+    catch (HHKinFit2::HHEnergyConstraintException const& e) {
+        std::cout<<"THIS FIT DID NOT CONVERGE: ENERGY CONSTRAIN EXCEPTION (mh1_hp = " << mh1_hp << " , mh2_hp = " << mh2_hp << ")" << std::endl;
+        if (DEBUG) {
+            std::cout<<"ECON Tau1"<<std::endl;
+            std::cout<<"ECON (E,Px,Py,Pz,M) "<< tlv_l1.E() <<","<< tlv_l1.Px() <<","<< tlv_l1.Py() <<","<< tlv_l1.Pz() <<","<< tlv_l1.M() << std::endl;
+            std::cout<<"ECON Tau2"<<std::endl;
+            std::cout<<"ECON (E,Px,Py,Pz,M) "<< tlv_l2.E() <<","<< tlv_l2.Px() <<","<< tlv_l2.Py() <<","<< tlv_l2.Pz() <<","<< tlv_l2.M() << std::endl;
+            std::cout<<"ECON B1"<<std::endl;
+            std::cout<<"ECON (E,Px,Py,Pz,M) "<< tlv_b1.E() <<","<< tlv_b1.Px() <<","<< tlv_b1.Py() <<","<< tlv_b1.Pz() <<","<< tlv_b1.M() << std::endl;
+            std::cout<<"ECON B2"<<std::endl;
+            std::cout<<"ECON (E,Px,Py,Pz,M) "<< tlv_b2.E() <<","<< tlv_b2.Px() <<","<< tlv_b2.Py() <<","<< tlv_b2.Pz() <<","<< tlv_b2.M() << std::endl;
+            std::cout<<"ECON MET"<<std::endl;
+            std::cout<<"ECON (E,Px,Py,Pz,M) "<<","<< ptmiss.Px() <<","<< ptmiss.Py() <<std::endl;
+            std::cout<<"ECON METCOV "<<std::endl;
+            std::cout<<"ECON "<< metcov (0,0) <<"  "<< metcov (0,1) << std::endl;
+            std::cout<<"ECON "<< metcov (1,0) <<"  "<< metcov (1,1) << std::endl;
+            std::cout<<"ECON tau1, tau2, b1, b2"<<std::endl;
+            std::cout<<"ECON ";
+            tlv_l1.Print();
+            std::cout<<"ECON ";
+            tlv_l2.Print();
+            std::cout<<"ECON ";
+            tlv_b1.Print();
+            std::cout<<"ECON ";
+            tlv_b2.Print();
+        }
+        wrongFit=true;
+    }
+    if(!wrongFit) {
+        localChi2 = localFit.getChi2(mh1_hp, mh2_hp);
+        if (localChi2 < 0 || std::isnan(localChi2)) {
+            localChi2 = std::nanf("1");
+        }
+    }
+    else {
+        localChi2 = std::nanf("1");
+    }
+
+    return std::pair(localFit, localChi2);
+}
+
+bool KinFitter::fit(std::string sgnHp) {
+    int mh1_hp = 0;
+    int mh2_hp = 0;
+
+    if (sgnHp == "HH")
+    {
+        mh1_hp = H_MASS;
+        mh2_hp = H_MASS;
+    }
+    else if (sgnHp == "ZZ") {
+        mh1_hp = Z_MASS;
+        mh2_hp = Z_MASS;
+    }
+    else if (sgnHp == "ZH") {
+        mh1_hp = Z_MASS;
+        mh2_hp = H_MASS;
+    }
+    else {
+        std::cout << "**ERROR: only HH/ZH/ZZ supported in KinFitter class, " << sgnHp << " entered." << std::endl;
+        std::cout << "         defaulting to HH hypothesis!" <<std::endl;
+        mh1_hp = H_MASS;
+        mh2_hp = H_MASS;
+    }
+
+    if (mh1_hp == mh2_hp) {
+        std::pair<HHKinFit2::HHKinFitMasterHeavyHiggs,float> res = _fit(mh1_hp, mh2_hp);
+        if (std::isnan(res.second)) fitsNotConverging = true;;
+        KinFit = res.first;
+        mh1_hpFit = mh1_hp;
+        mh2_hpFit = mh2_hp;
+    }
+    else {
+        std::pair<HHKinFit2::HHKinFitMasterHeavyHiggs,float> right_fit = _fit(mh1_hp, mh2_hp);
+        std::pair<HHKinFit2::HHKinFitMasterHeavyHiggs,float> left_fit  = _fit(mh2_hp, mh1_hp);
+
+        if (!std::isnan(right_fit.second) && !std::isnan(left_fit.second )) {
+            if (right_fit.second < left_fit.second) {
+                KinFit = right_fit.first;
+                mh1_hpFit = mh1_hp;
+                mh2_hpFit = mh2_hp;
+            }
+            else {
+                KinFit = left_fit.first;
+                mh1_hpFit = mh2_hp;
+                mh2_hpFit = mh1_hp;
+            }
+        }
+        else if (std::isnan(right_fit.second)) {
+            KinFit = left_fit.first;
+            mh1_hpFit = mh2_hp;
+            mh2_hpFit = mh1_hp;
+        }
+        else if (std::isnan(left_fit.second)) {
+            KinFit = right_fit.first;
+            mh1_hpFit = mh1_hp;
+            mh2_hpFit = mh2_hp;
+        }
+        else fitsNotConverging = true;;
+    }
+
+    return fitsNotConverging;
+}
+
+double KinFitter::getMH() {
+    return KinFit.getMH(mh1_hpFit, mh2_hpFit);
+}
+
+double KinFitter::getChi2() {
+    return KinFit.getChi2(mh1_hpFit, mh2_hpFit);
+}
+
+int KinFitter::getConvergence() {
+    return KinFit.getConvergence(mh1_hpFit, mh2_hpFit);
+}
+
+double KinFitter::getFitProb() {
+    return KinFit.getFitProb(mh1_hpFit, mh2_hpFit);
+}
+
+TLorentzVector KinFitter::getFittedBJet1() {
+    return KinFit.getFittedBJet1(mh1_hpFit, mh2_hpFit);
+}
+
+TLorentzVector KinFitter::getFittedBJet2() {
+    return KinFit.getFittedBJet2(mh1_hpFit, mh2_hpFit);
+}

--- a/src/kinfitter.cc
+++ b/src/kinfitter.cc
@@ -134,7 +134,7 @@ std::pair<HHKinFit2::HHKinFitMasterHeavyHiggs,float> KinFitter::_fit(int mh1_hp,
     return std::pair(localFit, localChi2);
 }
 
-bool KinFitter::fit(std::string sgnHp) {
+bool KinFitter::fit(TString sgnHp) {
     int mh1_hp = 0;
     int mh2_hp = 0;
 

--- a/src/kinfitter.cc
+++ b/src/kinfitter.cc
@@ -160,7 +160,7 @@ bool KinFitter::fit(std::string sgnHp) {
 
     if (mh1_hp == mh2_hp) {
         std::pair<HHKinFit2::HHKinFitMasterHeavyHiggs,float> res = _fit(mh1_hp, mh2_hp);
-        if (std::isnan(res.second)) fitsNotConverging = true;;
+        if (std::isnan(res.second)) fitsNotConverging = true;
         KinFit = res.first;
         mh1_hpFit = mh1_hp;
         mh2_hpFit = mh2_hp;

--- a/test/skimNtuple2016_HHbtag.cpp
+++ b/test/skimNtuple2016_HHbtag.cpp
@@ -25,7 +25,7 @@
 #include "bJetRegrVars.h"
 #include "bTagSF.h"
 #include "HHReweight5D.h"
-#include "../../HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
+#include "../../HHKinFit2/HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
 #include "SFProvider.h"
 #include "BDTfunctionsUtils.h"
 #include "TauIDSFTool.h"

--- a/test/skimNtuple2016_HHbtag.cpp
+++ b/test/skimNtuple2016_HHbtag.cpp
@@ -308,7 +308,7 @@ int main (int argc, char** argv)
   if (isHHNLOI == 1) isHHNLO = true;
   cout << "** INFO: isHHNLO: " << isHHNLO << endl;
 
-  string whichSgnHp = "HH";
+  TString whichSgnHp = "HH";
   string opt32 (argv[32]);
   if (opt32 != "HH") whichSgnHp = opt32;
   cout << "** INFO: signal hypothesis being used is " << whichSgnHp << endl;

--- a/test/skimNtuple2016_HHbtag.cpp
+++ b/test/skimNtuple2016_HHbtag.cpp
@@ -6102,13 +6102,13 @@ int main (int argc, char** argv)
      const double MU_MASS = 0.1056583715; //GeV
 
      // Reaf from configs
-     std::string model_dir = gConfigParser->readStringOption ("DNN::weights");
+     std::string model_dir = gConfigParser->readStringOption ("DNN::"+whichSgnHp+"weights");
      std::cout << "DNN::weights   : " << model_dir << std::endl;
 
      vector<float> DNN_kl;
      DNN_kl = gConfigParser->readFloatListOption("DNN::kl");
      
-     std::string features_file = gConfigParser->readStringOption ("DNN::features");
+     std::string features_file = gConfigParser->readStringOption ("DNN::"+whichSgnHp+"features");
      std::cout << "DNN::features  : " << features_file << std::endl;
 
      // Read from file the requested features to be computed

--- a/test/skimNtuple2016_HHbtag.cpp
+++ b/test/skimNtuple2016_HHbtag.cpp
@@ -26,6 +26,7 @@
 #include "bTagSF.h"
 #include "HHReweight5D.h"
 #include "../../HHKinFit2/HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
+#include "kinfitter.h"
 #include "SFProvider.h"
 #include "BDTfunctionsUtils.h"
 #include "TauIDSFTool.h"
@@ -307,6 +308,11 @@ int main (int argc, char** argv)
   if (isHHNLOI == 1) isHHNLO = true;
   cout << "** INFO: isHHNLO: " << isHHNLO << endl;
 
+  string whichSgnHp = "HH";
+  string opt32 (argv[32]);
+  if (opt32 != "HH") whichSgnHp = opt32;
+  cout << "** INFO: signal hypothesis being used is " << whichSgnHp << endl;
+
   // ------------------  decide what to do for the reweight of HH samples
   enum HHrewTypeList {
     kNone    = 0, //no reweighting
@@ -452,10 +458,6 @@ int main (int argc, char** argv)
   TFile * smallFile = new TFile (outputFile, "recreate") ;
   smallFile->cd () ;
   smallTree theSmallTree ("HTauTauTree") ;
-
-  // for HHKinFit
-  int hypo_mh1 = 125;
-  int hypo_mh2 = 125;
 
   // for efficiencies
   float totalEvents = 0. ;
@@ -4067,155 +4069,40 @@ int main (int argc, char** argv)
         //if (runHHKinFit && pairType <= 2 && tlv_bH_raw.M() > 50 && tlv_bH_raw.M() < 200 && theBigTree.SVfitMass->at (chosenTauPair) > 50 && theBigTree.SVfitMass->at (chosenTauPair) < 200) // no kinfit for ee / mumu + very loose mass window
         if (runHHKinFit && pairType <= 3) // FIXME: temporary
         {
-          HHKinFit2::HHKinFitMasterHeavyHiggs kinFits = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_firstBjet, tlv_secondBjet, tlv_firstLepton, tlv_secondLepton, ptmiss, stableMetCov, bjet1_JER, bjet2_JER) ;
-          HHKinFit2::HHKinFitMasterHeavyHiggs kinFitsraw = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_firstBjet, tlv_secondBjet, tlv_firstLepton, tlv_secondLepton,  ptmiss, stableMetCov, bjet1_JER, bjet2_JER) ;
+          if(DEBUG)
+            {
+               cout<<"---Kinfit Input debug---"<<endl;
+               cout<<"L1"<<endl;
+               cout<<"(pt,eta,phi,e) "<<tlv_firstLepton.Pt()<<","<<tlv_firstLepton.Eta()<<","<<tlv_firstLepton.Phi()<<","<<tlv_firstLepton.E()<<endl;
+               cout<<"L2"<<endl;
+               cout<<"(pt,eta,phi,e) "<<tlv_secondLepton.Pt()<<","<<tlv_secondLepton.Eta()<<","<<tlv_secondLepton.Phi()<<","<<tlv_secondLepton.E()<<endl;
+               cout<<"B1"<<endl;
+               cout<<"(pt,eta,phi,e,res) "<<tlv_firstBjet.Pt()<<","<<tlv_firstBjet.Eta()<<","<<tlv_firstBjet.Phi()<<","<<tlv_firstBjet.E()<<","<<bjet1_JER<<endl;
+               cout<<"B2"<<endl;
+               cout<<"(pt,eta,phi,e,res) "<<tlv_secondBjet.Pt()<<","<<tlv_secondBjet.Eta()<<","<<tlv_secondBjet.Phi()<<","<<tlv_secondBjet.E()<<","<<bjet2_JER<<endl;
+               cout<<"MET"<<endl;
+               cout<<"(Px,Py) "<<","<<ptmiss.Px()<<","<<ptmiss.Py()<<endl;
+               cout<<"METCOV "<<endl;
+               cout<<metcov(0,0)<<"  "<<metcov(0,1)<<endl;
+               cout<<metcov(1,0)<<"  "<<metcov(1,1)<<endl;
+             }
 
-          //           kinFits.setAdvancedBalance (&ptmiss, metcov) ;
-          //           kinFits.setSimpleBalance (ptmiss.Pt (),10) ; //alternative which uses only the absolute value of ptmiss in the fit
-          //
-          //           kinFits.addMh1Hypothesis (hypo_mh1) ;
-          //           kinFits.addMh2Hypothesis (hypo_mh2) ;
-          kinFits.   addHypo(hypo_mh1,hypo_mh2);
-          kinFitsraw.addHypo(hypo_mh1,hypo_mh2);
+          KinFitter fitter(tlv_firstBjet, tlv_secondBjet, tlv_firstLepton, tlv_secondLepton, ptmiss, stableMetCov, bjet1_JER, bjet2_JER);
 
-	  if(DEBUG)
-	  {
-	     cout<<"---Kinfit Input debug---"<<endl;
-	     cout<<"L1"<<endl;
-	     cout<<"(pt,eta,phi,e) "<<tlv_firstLepton.Pt()<<","<<tlv_firstLepton.Eta()<<","<<tlv_firstLepton.Phi()<<","<<tlv_firstLepton.E()<<endl;
-	     cout<<"L2"<<endl;
-	     cout<<"(pt,eta,phi,e) "<<tlv_secondLepton.Pt()<<","<<tlv_secondLepton.Eta()<<","<<tlv_secondLepton.Phi()<<","<<tlv_secondLepton.E()<<endl;
-	     cout<<"B1"<<endl;
-	     cout<<"(pt,eta,phi,e,res) "<<tlv_firstBjet.Pt()<<","<<tlv_firstBjet.Eta()<<","<<tlv_firstBjet.Phi()<<","<<tlv_firstBjet.E()<<","<<bjet1_JER<<endl;
-	     cout<<"B2"<<endl;
-	     cout<<"(pt,eta,phi,e,res) "<<tlv_secondBjet.Pt()<<","<<tlv_secondBjet.Eta()<<","<<tlv_secondBjet.Phi()<<","<<tlv_secondBjet.E()<<","<<bjet2_JER<<endl;
-	     cout<<"MET"<<endl;
-	     cout<<"(Px,Py) "<<","<<ptmiss.Px()<<","<<ptmiss.Py()<<endl;
-	     cout<<"METCOV "<<endl;
-	     cout<<metcov(0,0)<<"  "<<metcov(0,1)<<endl;
-	     cout<<metcov(1,0)<<"  "<<metcov(1,1)<<endl;
-	  }
-
-          try{ kinFits.fit();}
-          catch(HHKinFit2::HHInvMConstraintException &e)
-          {
-            cout<<"INVME THIS EVENT WAS WRONG, INV MASS CONSTRAIN EXCEPTION"<<endl;
-            cout<<"INVME masshypo1 = 125,    masshypo2 = 125"<<endl;
-            cout<<"INVME Tau1"<<endl;
-            cout<<"INVME (E,Px,Py,Pz,M) "<<tlv_firstLepton.E()<<","<<tlv_firstLepton.Px()<<","<<tlv_firstLepton.Py()<<","<<tlv_firstLepton.Pz()<<","<<tlv_firstLepton.M()<<endl;
-            cout<<"INVME Tau2"<<endl;
-            cout<<"INVME (E,Px,Py,Pz,M) "<<tlv_secondLepton.E()<<","<<tlv_secondLepton.Px()<<","<<tlv_secondLepton.Py()<<","<<tlv_secondLepton.Pz()<<","<<tlv_secondLepton.M()<<endl;
-            cout<<"INVME B1"<<endl;
-            cout<<"INVME (E,Px,Py,Pz,M) "<<tlv_firstBjet.E()<<","<<tlv_firstBjet.Px()<<","<<tlv_firstBjet.Py()<<","<<tlv_firstBjet.Pz()<<","<<tlv_firstBjet.M()<<endl;
-            cout<<"INVME B2"<<endl;
-            cout<<"INVME (E,Px,Py,Pz,M) "<<tlv_secondBjet.E()<<","<<tlv_secondBjet.Px()<<","<<tlv_secondBjet.Py()<<","<<tlv_secondBjet.Pz()<<","<<tlv_secondBjet.M()<<endl;
-            cout<<"INVME MET"<<endl;
-            cout<<"INVME (E,Px,Py,Pz,M) "<<","<<ptmiss.Px()<<","<<ptmiss.Py()<<endl;
-            cout<<"INVME METCOV "<<endl;
-            cout<<"INVME "<<metcov (0,0)<<"  "<<metcov (0,1)<<endl;// = theBigTree.MET_cov00->at (chosenTauPair) ;
-            cout<<"INVME "<<metcov (1,0)<<"  "<<metcov (1,1)<<endl;// = theBigTree.MET_cov10->at (chosenTauPair) ;
-            cout<<"INVME tau1, tau2, b1, b2"<<endl;
-            cout<<"INVME ";
-            tlv_firstLepton.Print();
-            cout<<"INVME ";
-            tlv_secondLepton.Print();
-            cout<<"INVME ";
-            tlv_firstBjet.Print();
-            cout<<"INVME ";
-            tlv_secondBjet.Print();
-            wrongHHK=true;
+          wrongHHK = fitter.fit(whichSgnHp);
+          if(!wrongHHK) {
+            HHKmass = fitter.getMH();
+            HHKChi2 = fitter.getChi2();
           }
-          catch (HHKinFit2::HHEnergyRangeException &e)
-          {
-            cout<<"ERANGE THIS EVENT WAS WRONG, ENERGY RANGE EXCEPTION"<<endl;
-            cout<<"ERANGE masshypo1 = 125,    masshypo2 = 125"<<endl;
-            cout<<"ERANGE Tau1"<<endl;
-            cout<<"ERANGE (E,Px,Py,Pz,M) "<<tlv_firstLepton.E()<<","<<tlv_firstLepton.Px()<<","<<tlv_firstLepton.Py()<<","<<tlv_firstLepton.Pz()<<","<<tlv_firstLepton.M()<<endl;
-            cout<<"ERANGE Tau2"<<endl;
-            cout<<"ERANGE (E,Px,Py,Pz,M) "<<tlv_secondLepton.E()<<","<<tlv_secondLepton.Px()<<","<<tlv_secondLepton.Py()<<","<<tlv_secondLepton.Pz()<<","<<tlv_secondLepton.M()<<endl;
-            cout<<"ERANGE B1"<<endl;
-            cout<<"ERANGE (E,Px,Py,Pz,M) "<<tlv_firstBjet.E()<<","<<tlv_firstBjet.Px()<<","<<tlv_firstBjet.Py()<<","<<tlv_firstBjet.Pz()<<","<<tlv_firstBjet.M()<<endl;
-            cout<<"ERANGE B2"<<endl;
-            cout<<"ERANGE (E,Px,Py,Pz,M) "<<tlv_secondBjet.E()<<","<<tlv_secondBjet.Px()<<","<<tlv_secondBjet.Py()<<","<<tlv_secondBjet.Pz()<<","<<tlv_secondBjet.M()<<endl;
-            cout<<"ERANGE MET"<<endl;
-            cout<<"ERANGE (E,Px,Py,Pz,M) "<<","<<ptmiss.Px()<<","<<ptmiss.Py()<<endl;
-            cout<<"ERANGE METCOV "<<endl;
-            cout<<"ERANGE "<<metcov (0,0)<<"  "<<metcov (0,1)<<endl;// = theBigTree.MET_cov00->at (chosenTauPair) ;
-            cout<<"ERANGE "<<metcov (1,0)<<"  "<<metcov (1,1)<<endl;// = theBigTree.MET_cov10->at (chosenTauPair) ;
-            cout<<"ERANGE tau1, tau2, b1, b2"<<endl;
-            cout<<"ERANGE ";
-            tlv_firstLepton.Print();
-            cout<<"ERANGE ";
-            tlv_secondLepton.Print();
-            cout<<"ERANGE ";
-            tlv_firstBjet.Print();
-            cout<<"ERANGE ";
-            tlv_secondBjet.Print();
-            wrongHHK=true;
-          }
-          catch(HHKinFit2::HHEnergyConstraintException &e)
-          {
-            cout<<"ECON THIS EVENT WAS WRONG, ENERGY CONSTRAIN EXCEPTION"<<endl;
-            cout<<"ECON masshypo1 = 125,    masshypo2 = 125"<<endl;
-            cout<<"ECON Tau1"<<endl;
-            cout<<"ECON (E,Px,Py,Pz,M) "<<tlv_firstLepton.E()<<","<<tlv_firstLepton.Px()<<","<<tlv_firstLepton.Py()<<","<<tlv_firstLepton.Pz()<<","<<tlv_firstLepton.M()<<endl;
-            cout<<"ECON Tau2"<<endl;
-            cout<<"ECON (E,Px,Py,Pz,M) "<<tlv_secondLepton.E()<<","<<tlv_secondLepton.Px()<<","<<tlv_secondLepton.Py()<<","<<tlv_secondLepton.Pz()<<","<<tlv_secondLepton.M()<<endl;
-            cout<<"ECON B1"<<endl;
-            cout<<"ECON (E,Px,Py,Pz,M) "<<tlv_firstBjet.E()<<","<<tlv_firstBjet.Px()<<","<<tlv_firstBjet.Py()<<","<<tlv_firstBjet.Pz()<<","<<tlv_firstBjet.M()<<endl;
-            cout<<"ECON B2"<<endl;
-            cout<<"ECON (E,Px,Py,Pz,M) "<<tlv_secondBjet.E()<<","<<tlv_secondBjet.Px()<<","<<tlv_secondBjet.Py()<<","<<tlv_secondBjet.Pz()<<","<<tlv_secondBjet.M()<<endl;
-            cout<<"ECON MET"<<endl;
-            cout<<"ECON (E,Px,Py,Pz,M) "<<","<<ptmiss.Px()<<","<<ptmiss.Py()<<endl;
-            cout<<"ECON METCOV "<<endl;
-            cout<<"ECON "<<metcov (0,0)<<"  "<<metcov (0,1)<<endl;// = theBigTree.MET_cov00->at (chosenTauPair) ;
-            cout<<"ECON "<<metcov (1,0)<<"  "<<metcov (1,1)<<endl;// = theBigTree.MET_cov10->at (chosenTauPair) ;
-            cout<<"ECON tau1, tau2, b1, b2"<<endl;
-            cout<<"ECON ";
-            tlv_firstLepton.Print();
-            cout<<"ECON ";
-            tlv_secondLepton.Print();
-            cout<<"ECON ";
-            tlv_firstBjet.Print();
-            cout<<"ECON ";
-            tlv_secondBjet.Print();
-            wrongHHK=true;
-          }
-          if(!wrongHHK)
-          {
-            HHKmass = kinFits.getMH () ;
-            HHKChi2 = kinFits.getChi2 () ;
-          }
-          else
-          {
-            if(isOS)HHKmass = -333;
+          else {
+            HHKmass = 0;
+            HHKChi2 = std::nanf("1");
           }
 
-          // nominal kinfit raw
-          bool wrongHHKraw =false;
-          try {kinFitsraw.fit();}
-          catch(HHKinFit2::HHInvMConstraintException   &e){wrongHHKraw=true;}
-          catch(HHKinFit2::HHEnergyConstraintException &e){wrongHHKraw=true;}
-          catch(HHKinFit2::HHEnergyRangeException      &e){wrongHHKraw=true;}
-          if(!wrongHHKraw)
-          {
-            theSmallTree.m_HHKin_mass_raw = kinFitsraw.getMH();
-            theSmallTree.m_HHKin_mass_raw_chi2        = kinFitsraw.getChi2();
-            theSmallTree.m_HHKin_mass_raw_convergence = kinFitsraw.getConvergence();
-            theSmallTree.m_HHKin_mass_raw_prob        = kinFitsraw.getFitProb();
-	    if(DEBUG)
-	    {
-	       cout<<"---Kinfit Output debug---"<<endl;
-	       cout<<"KinFit mass = " << kinFitsraw.getMH() << endl;
-	       cout<<"KinFit chi2 = " << kinFitsraw.getChi2()<< endl;
-	       cout<<"KinFit conv = " << kinFitsraw.getConvergence()<< endl;
-	    }
-          }
-          else theSmallTree.m_HHKin_mass_raw = -100 ;
           if ( (theBigTree.SVfitMass->at(chosenTauPair) > -900. || (doSmearing && theSmallTree.m_tauH_SVFIT_mass > 0)) && !wrongHHK)
           {
-            TLorentzVector b1 = kinFits.getFittedBJet1();
-            TLorentzVector b2 = kinFits.getFittedBJet2();
+            TLorentzVector b1 = fitter.getFittedBJet1();
+            TLorentzVector b2 = fitter.getFittedBJet2();
             TLorentzVector bH_HKin = b1 + b2;
             TLorentzVector tlv_HHsvfit = bH_HKin + tlv_tauH_SVFIT ;
 
@@ -4226,8 +4113,7 @@ int main (int argc, char** argv)
             theSmallTree.m_HHkinsvfit_e   = tlv_HHsvfit.E () ;
             theSmallTree.m_HHkinsvfit_m   = tlv_HHsvfit.M () ;
           } // in case the SVFIT mass is calculated
-
-        } // end if doing HHKinFit
+        } // end of HH KinFit
 
         theSmallTree.m_HHKin_mass_raw_copy = theSmallTree.m_HHKin_mass_raw ; // store twice if different binning needed
 

--- a/test/skimNtuple2017_HHbtag.cpp
+++ b/test/skimNtuple2017_HHbtag.cpp
@@ -6509,13 +6509,13 @@ int main (int argc, char** argv)
     const double MU_MASS = 0.1056583715; //GeV
 
     // Reaf from configs
-    std::string model_dir = gConfigParser->readStringOption ("DNN::weights");
+    std::string model_dir = gConfigParser->readStringOption ("DNN::"+whichSgnHp+"weights");
     std::cout << "DNN::weights   : " << model_dir << std::endl;
 
     vector<float> DNN_kl;
     DNN_kl = gConfigParser->readFloatListOption("DNN::kl");
 
-    std::string features_file = gConfigParser->readStringOption ("DNN::features");
+    std::string features_file = gConfigParser->readStringOption ("DNN::"+whichSgnHp+"features");
     std::cout << "DNN::features  : " << features_file << std::endl;
 
     // Read from file the requested features to be computed

--- a/test/skimNtuple2017_HHbtag.cpp
+++ b/test/skimNtuple2017_HHbtag.cpp
@@ -27,6 +27,7 @@
 #include "bTagSF.h"
 #include "HHReweight5D.h"
 #include "../../HHKinFit2/HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
+#include "kinfitter.h"
 #include "SFProvider.h"
 #include "BDTfunctionsUtils.h"
 #include "TauIDSFTool.h"
@@ -305,6 +306,11 @@ int main (int argc, char** argv)
   if (isHHNLOI == 1) isHHNLO = true;
   cout << "** INFO: isHHNLO: " << isHHNLO << endl;
 
+  string whichSgnHp = "HH";
+  string opt32 (argv[32]);
+  if (opt32 != "HH") whichSgnHp = opt32;
+  cout << "** INFO: signal hypothesis being used is " << whichSgnHp << endl;
+
   // ------------------  decide what to do for the reweight of HH samples
   enum HHrewTypeList {
     kNone    = 0, //no reweighting
@@ -448,10 +454,6 @@ int main (int argc, char** argv)
   TFile * smallFile = new TFile (outputFile, "recreate") ;
   smallFile->cd () ;
   smallTree theSmallTree ("HTauTauTree") ;
-
-  // for HHKinFit
-  int hypo_mh1 = 125;
-  int hypo_mh2 = 125;
 
   // for efficiencies
   float totalEvents = 0. ;
@@ -4396,155 +4398,40 @@ int main (int argc, char** argv)
         //if (runHHKinFit && pairType <= 2 && tlv_bH_raw.M() > 50 && tlv_bH_raw.M() < 200 && theBigTree.SVfitMass->at (chosenTauPair) > 50 && theBigTree.SVfitMass->at (chosenTauPair) < 200) // no kinfit for ee / mumu + very loose mass window
         if (runHHKinFit && pairType <= 3) // FIXME: temporary
         {
-          HHKinFit2::HHKinFitMasterHeavyHiggs kinFits = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_firstBjet, tlv_secondBjet, tlv_firstLepton, tlv_secondLepton, ptmiss, stableMetCov, bjet1_JER, bjet2_JER) ;
-          HHKinFit2::HHKinFitMasterHeavyHiggs kinFitsraw = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_firstBjet, tlv_secondBjet, tlv_firstLepton, tlv_secondLepton,  ptmiss, stableMetCov, bjet1_JER, bjet2_JER) ;
+          if(DEBUG)
+            {
+               cout<<"---Kinfit Input debug---"<<endl;
+               cout<<"L1"<<endl;
+               cout<<"(pt,eta,phi,e) "<<tlv_firstLepton.Pt()<<","<<tlv_firstLepton.Eta()<<","<<tlv_firstLepton.Phi()<<","<<tlv_firstLepton.E()<<endl;
+               cout<<"L2"<<endl;
+               cout<<"(pt,eta,phi,e) "<<tlv_secondLepton.Pt()<<","<<tlv_secondLepton.Eta()<<","<<tlv_secondLepton.Phi()<<","<<tlv_secondLepton.E()<<endl;
+               cout<<"B1"<<endl;
+               cout<<"(pt,eta,phi,e,res) "<<tlv_firstBjet.Pt()<<","<<tlv_firstBjet.Eta()<<","<<tlv_firstBjet.Phi()<<","<<tlv_firstBjet.E()<<","<<bjet1_JER<<endl;
+               cout<<"B2"<<endl;
+               cout<<"(pt,eta,phi,e,res) "<<tlv_secondBjet.Pt()<<","<<tlv_secondBjet.Eta()<<","<<tlv_secondBjet.Phi()<<","<<tlv_secondBjet.E()<<","<<bjet2_JER<<endl;
+               cout<<"MET"<<endl;
+               cout<<"(Px,Py) "<<","<<ptmiss.Px()<<","<<ptmiss.Py()<<endl;
+               cout<<"METCOV "<<endl;
+               cout<<metcov(0,0)<<"  "<<metcov(0,1)<<endl;
+               cout<<metcov(1,0)<<"  "<<metcov(1,1)<<endl;
+             }
 
-          //           kinFits.setAdvancedBalance (&ptmiss, metcov) ;
-          //           kinFits.setSimpleBalance (ptmiss.Pt (),10) ; //alternative which uses only the absolute value of ptmiss in the fit
-          //
-          //           kinFits.addMh1Hypothesis (hypo_mh1) ;
-          //           kinFits.addMh2Hypothesis (hypo_mh2) ;
-          kinFits.   addHypo(hypo_mh1,hypo_mh2);
-          kinFitsraw.addHypo(hypo_mh1,hypo_mh2);
+          KinFitter fitter(tlv_firstBjet, tlv_secondBjet, tlv_firstLepton, tlv_secondLepton, ptmiss, stableMetCov, bjet1_JER, bjet2_JER);
 
-	  if(DEBUG)
-	  {
-	     cout<<"---Kinfit Input debug---"<<endl;
-	     cout<<"L1"<<endl;
-	     cout<<"(pt,eta,phi,e) "<<tlv_firstLepton.Pt()<<","<<tlv_firstLepton.Eta()<<","<<tlv_firstLepton.Phi()<<","<<tlv_firstLepton.E()<<endl;
-	     cout<<"L2"<<endl;
-	     cout<<"(pt,eta,phi,e) "<<tlv_secondLepton.Pt()<<","<<tlv_secondLepton.Eta()<<","<<tlv_secondLepton.Phi()<<","<<tlv_secondLepton.E()<<endl;
-	     cout<<"B1"<<endl;
-	     cout<<"(pt,eta,phi,e,res) "<<tlv_firstBjet.Pt()<<","<<tlv_firstBjet.Eta()<<","<<tlv_firstBjet.Phi()<<","<<tlv_firstBjet.E()<<","<<bjet1_JER<<endl;
-	     cout<<"B2"<<endl;
-	     cout<<"(pt,eta,phi,e,res) "<<tlv_secondBjet.Pt()<<","<<tlv_secondBjet.Eta()<<","<<tlv_secondBjet.Phi()<<","<<tlv_secondBjet.E()<<","<<bjet2_JER<<endl;
-	     cout<<"MET"<<endl;
-	     cout<<"(Px,Py) "<<","<<ptmiss.Px()<<","<<ptmiss.Py()<<endl;
-	     cout<<"METCOV "<<endl;
-	     cout<<metcov(0,0)<<"  "<<metcov(0,1)<<endl;
-	     cout<<metcov(1,0)<<"  "<<metcov(1,1)<<endl;
-	  }
-
-          try{ kinFits.fit();}
-          catch(HHKinFit2::HHInvMConstraintException &e)
-          {
-            cout<<"INVME THIS EVENT WAS WRONG, INV MASS CONSTRAIN EXCEPTION"<<endl;
-            cout<<"INVME masshypo1 = 125,    masshypo2 = 125"<<endl;
-            cout<<"INVME Tau1"<<endl;
-            cout<<"INVME (E,Px,Py,Pz,M) "<<tlv_firstLepton.E()<<","<<tlv_firstLepton.Px()<<","<<tlv_firstLepton.Py()<<","<<tlv_firstLepton.Pz()<<","<<tlv_firstLepton.M()<<endl;
-            cout<<"INVME Tau2"<<endl;
-            cout<<"INVME (E,Px,Py,Pz,M) "<<tlv_secondLepton.E()<<","<<tlv_secondLepton.Px()<<","<<tlv_secondLepton.Py()<<","<<tlv_secondLepton.Pz()<<","<<tlv_secondLepton.M()<<endl;
-            cout<<"INVME B1"<<endl;
-            cout<<"INVME (E,Px,Py,Pz,M) "<<tlv_firstBjet.E()<<","<<tlv_firstBjet.Px()<<","<<tlv_firstBjet.Py()<<","<<tlv_firstBjet.Pz()<<","<<tlv_firstBjet.M()<<endl;
-            cout<<"INVME B2"<<endl;
-            cout<<"INVME (E,Px,Py,Pz,M) "<<tlv_secondBjet.E()<<","<<tlv_secondBjet.Px()<<","<<tlv_secondBjet.Py()<<","<<tlv_secondBjet.Pz()<<","<<tlv_secondBjet.M()<<endl;
-            cout<<"INVME MET"<<endl;
-            cout<<"INVME (E,Px,Py,Pz,M) "<<","<<ptmiss.Px()<<","<<ptmiss.Py()<<endl;
-            cout<<"INVME METCOV "<<endl;
-            cout<<"INVME "<<metcov (0,0)<<"  "<<metcov (0,1)<<endl;// = theBigTree.MET_cov00->at (chosenTauPair) ;
-            cout<<"INVME "<<metcov (1,0)<<"  "<<metcov (1,1)<<endl;// = theBigTree.MET_cov10->at (chosenTauPair) ;
-            cout<<"INVME tau1, tau2, b1, b2"<<endl;
-            cout<<"INVME ";
-            tlv_firstLepton.Print();
-            cout<<"INVME ";
-            tlv_secondLepton.Print();
-            cout<<"INVME ";
-            tlv_firstBjet.Print();
-            cout<<"INVME ";
-            tlv_secondBjet.Print();
-            wrongHHK=true;
+          wrongHHK = fitter.fit(whichSgnHp);
+          if(!wrongHHK) {
+            HHKmass = fitter.getMH();
+            HHKChi2 = fitter.getChi2();
           }
-          catch (HHKinFit2::HHEnergyRangeException &e)
-          {
-            cout<<"ERANGE THIS EVENT WAS WRONG, ENERGY RANGE EXCEPTION"<<endl;
-            cout<<"ERANGE masshypo1 = 125,    masshypo2 = 125"<<endl;
-            cout<<"ERANGE Tau1"<<endl;
-            cout<<"ERANGE (E,Px,Py,Pz,M) "<<tlv_firstLepton.E()<<","<<tlv_firstLepton.Px()<<","<<tlv_firstLepton.Py()<<","<<tlv_firstLepton.Pz()<<","<<tlv_firstLepton.M()<<endl;
-            cout<<"ERANGE Tau2"<<endl;
-            cout<<"ERANGE (E,Px,Py,Pz,M) "<<tlv_secondLepton.E()<<","<<tlv_secondLepton.Px()<<","<<tlv_secondLepton.Py()<<","<<tlv_secondLepton.Pz()<<","<<tlv_secondLepton.M()<<endl;
-            cout<<"ERANGE B1"<<endl;
-            cout<<"ERANGE (E,Px,Py,Pz,M) "<<tlv_firstBjet.E()<<","<<tlv_firstBjet.Px()<<","<<tlv_firstBjet.Py()<<","<<tlv_firstBjet.Pz()<<","<<tlv_firstBjet.M()<<endl;
-            cout<<"ERANGE B2"<<endl;
-            cout<<"ERANGE (E,Px,Py,Pz,M) "<<tlv_secondBjet.E()<<","<<tlv_secondBjet.Px()<<","<<tlv_secondBjet.Py()<<","<<tlv_secondBjet.Pz()<<","<<tlv_secondBjet.M()<<endl;
-            cout<<"ERANGE MET"<<endl;
-            cout<<"ERANGE (E,Px,Py,Pz,M) "<<","<<ptmiss.Px()<<","<<ptmiss.Py()<<endl;
-            cout<<"ERANGE METCOV "<<endl;
-            cout<<"ERANGE "<<metcov (0,0)<<"  "<<metcov (0,1)<<endl;// = theBigTree.MET_cov00->at (chosenTauPair) ;
-            cout<<"ERANGE "<<metcov (1,0)<<"  "<<metcov (1,1)<<endl;// = theBigTree.MET_cov10->at (chosenTauPair) ;
-            cout<<"ERANGE tau1, tau2, b1, b2"<<endl;
-            cout<<"ERANGE ";
-            tlv_firstLepton.Print();
-            cout<<"ERANGE ";
-            tlv_secondLepton.Print();
-            cout<<"ERANGE ";
-            tlv_firstBjet.Print();
-            cout<<"ERANGE ";
-            tlv_secondBjet.Print();
-            wrongHHK=true;
-          }
-          catch(HHKinFit2::HHEnergyConstraintException &e)
-          {
-            cout<<"ECON THIS EVENT WAS WRONG, ENERGY CONSTRAIN EXCEPTION"<<endl;
-            cout<<"ECON masshypo1 = 125,    masshypo2 = 125"<<endl;
-            cout<<"ECON Tau1"<<endl;
-            cout<<"ECON (E,Px,Py,Pz,M) "<<tlv_firstLepton.E()<<","<<tlv_firstLepton.Px()<<","<<tlv_firstLepton.Py()<<","<<tlv_firstLepton.Pz()<<","<<tlv_firstLepton.M()<<endl;
-            cout<<"ECON Tau2"<<endl;
-            cout<<"ECON (E,Px,Py,Pz,M) "<<tlv_secondLepton.E()<<","<<tlv_secondLepton.Px()<<","<<tlv_secondLepton.Py()<<","<<tlv_secondLepton.Pz()<<","<<tlv_secondLepton.M()<<endl;
-            cout<<"ECON B1"<<endl;
-            cout<<"ECON (E,Px,Py,Pz,M) "<<tlv_firstBjet.E()<<","<<tlv_firstBjet.Px()<<","<<tlv_firstBjet.Py()<<","<<tlv_firstBjet.Pz()<<","<<tlv_firstBjet.M()<<endl;
-            cout<<"ECON B2"<<endl;
-            cout<<"ECON (E,Px,Py,Pz,M) "<<tlv_secondBjet.E()<<","<<tlv_secondBjet.Px()<<","<<tlv_secondBjet.Py()<<","<<tlv_secondBjet.Pz()<<","<<tlv_secondBjet.M()<<endl;
-            cout<<"ECON MET"<<endl;
-            cout<<"ECON (E,Px,Py,Pz,M) "<<","<<ptmiss.Px()<<","<<ptmiss.Py()<<endl;
-            cout<<"ECON METCOV "<<endl;
-            cout<<"ECON "<<metcov (0,0)<<"  "<<metcov (0,1)<<endl;// = theBigTree.MET_cov00->at (chosenTauPair) ;
-            cout<<"ECON "<<metcov (1,0)<<"  "<<metcov (1,1)<<endl;// = theBigTree.MET_cov10->at (chosenTauPair) ;
-            cout<<"ECON tau1, tau2, b1, b2"<<endl;
-            cout<<"ECON ";
-            tlv_firstLepton.Print();
-            cout<<"ECON ";
-            tlv_secondLepton.Print();
-            cout<<"ECON ";
-            tlv_firstBjet.Print();
-            cout<<"ECON ";
-            tlv_secondBjet.Print();
-            wrongHHK=true;
-          }
-          if(!wrongHHK)
-          {
-            HHKmass = kinFits.getMH () ;
-            HHKChi2 = kinFits.getChi2 () ;
-          }
-          else
-          {
-            if(isOS)HHKmass = -333;
+          else {
+            HHKmass = 0;
+            HHKChi2 = std::nanf("1");
           }
 
-          // nominal kinfit raw
-          bool wrongHHKraw =false;
-          try {kinFitsraw.fit();}
-          catch(HHKinFit2::HHInvMConstraintException   &e){wrongHHKraw=true;}
-          catch(HHKinFit2::HHEnergyConstraintException &e){wrongHHKraw=true;}
-          catch(HHKinFit2::HHEnergyRangeException      &e){wrongHHKraw=true;}
-          if(!wrongHHKraw)
-          {
-            theSmallTree.m_HHKin_mass_raw = kinFitsraw.getMH();
-            theSmallTree.m_HHKin_mass_raw_chi2        = kinFitsraw.getChi2();
-            theSmallTree.m_HHKin_mass_raw_convergence = kinFitsraw.getConvergence();
-            theSmallTree.m_HHKin_mass_raw_prob        = kinFitsraw.getFitProb();
-	    if(DEBUG)
-	    {
-	       cout<<"---Kinfit Output debug---"<<endl;
-	       cout<<"KinFit mass = " << kinFitsraw.getMH() << endl;
-	       cout<<"KinFit chi2 = " << kinFitsraw.getChi2()<< endl;
-	       cout<<"KinFit conv = " << kinFitsraw.getConvergence()<< endl;
-	    }
-          }
-          else theSmallTree.m_HHKin_mass_raw = -100 ;
           if ( (theBigTree.SVfitMass->at(chosenTauPair) > -900. || (doSmearing && theSmallTree.m_tauH_SVFIT_mass > 0)) && !wrongHHK)
           {
-            TLorentzVector b1 = kinFits.getFittedBJet1();
-            TLorentzVector b2 = kinFits.getFittedBJet2();
+            TLorentzVector b1 = fitter.getFittedBJet1();
+            TLorentzVector b2 = fitter.getFittedBJet2();
             TLorentzVector bH_HKin = b1 + b2;
             TLorentzVector tlv_HHsvfit = bH_HKin + tlv_tauH_SVFIT ;
 
@@ -4555,8 +4442,7 @@ int main (int argc, char** argv)
             theSmallTree.m_HHkinsvfit_e   = tlv_HHsvfit.E () ;
             theSmallTree.m_HHkinsvfit_m   = tlv_HHsvfit.M () ;
           } // in case the SVFIT mass is calculated
-
-        } // end if doing HHKinFit
+        } // end of HH KinFit
 
         theSmallTree.m_HHKin_mass_raw_copy = theSmallTree.m_HHKin_mass_raw ; // store twice if different binning needed
 

--- a/test/skimNtuple2017_HHbtag.cpp
+++ b/test/skimNtuple2017_HHbtag.cpp
@@ -26,7 +26,7 @@
 #include "bJetRegrVars.h"
 #include "bTagSF.h"
 #include "HHReweight5D.h"
-#include "../../HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
+#include "../../HHKinFit2/HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
 #include "SFProvider.h"
 #include "BDTfunctionsUtils.h"
 #include "TauIDSFTool.h"

--- a/test/skimNtuple2017_HHbtag.cpp
+++ b/test/skimNtuple2017_HHbtag.cpp
@@ -306,7 +306,7 @@ int main (int argc, char** argv)
   if (isHHNLOI == 1) isHHNLO = true;
   cout << "** INFO: isHHNLO: " << isHHNLO << endl;
 
-  string whichSgnHp = "HH";
+  TString whichSgnHp = "HH";
   string opt32 (argv[32]);
   if (opt32 != "HH") whichSgnHp = opt32;
   cout << "** INFO: signal hypothesis being used is " << whichSgnHp << endl;

--- a/test/skimNtuple2018_HHbtag.cpp
+++ b/test/skimNtuple2018_HHbtag.cpp
@@ -297,7 +297,7 @@ int main (int argc, char** argv)
   if (isHHNLOI == 1) isHHNLO = true;
   cout << "** INFO: isHHNLO: " << isHHNLO << endl;
 
-  string whichSgnHp = "HH";
+  TString whichSgnHp = "HH";
   string opt32 (argv[32]);
   if (opt32 != "HH") whichSgnHp = opt32;
   cout << "** INFO: signal hypothesis being used is " << whichSgnHp << endl;

--- a/test/skimNtuple2018_HHbtag.cpp
+++ b/test/skimNtuple2018_HHbtag.cpp
@@ -4296,7 +4296,6 @@ int main (int argc, char** argv)
                }
 
             KinFitter fitter(tlv_firstBjet, tlv_secondBjet, tlv_firstLepton, tlv_secondLepton, ptmiss, stableMetCov, bjet1_JER, bjet2_JER);
-            KinFitter fitterRaw(tlv_firstBjet, tlv_secondBjet, tlv_firstLepton, tlv_secondLepton, ptmiss, stableMetCov, bjet1_JER, bjet2_JER);
 
             wrongHHK = fitter.fit(whichSgnHp);
             if(!wrongHHK) {
@@ -4304,27 +4303,9 @@ int main (int argc, char** argv)
               HHKChi2 = fitter.getChi2();
             }
             else {
-              if(isOS)HHKmass = -333;
+              HHKmass = 0;
+              HHKChi2 = std::nanf("1");
             }
-
-            // nominal kinfit raw
-            bool wrongHHKraw =false;
-            wrongHHKraw = fitterRaw.fit(whichSgnHp);
-            if(!wrongHHKraw)
-              {
-                theSmallTree.m_HHKin_mass_raw             = fitterRaw.getMH();
-                theSmallTree.m_HHKin_mass_raw_chi2        = fitterRaw.getChi2();
-                theSmallTree.m_HHKin_mass_raw_convergence = fitterRaw.getConvergence();
-                theSmallTree.m_HHKin_mass_raw_prob        = fitterRaw.getFitProb();
-                if(DEBUG)
-                  {
-                     cout<<"---Kinfit Output debug---"<<endl;
-                     cout<<"KinFit mass = " << fitterRaw.getMH() << endl;
-                     cout<<"KinFit chi2 = " << fitterRaw.getChi2()<< endl;
-                     cout<<"KinFit conv = " << fitterRaw.getConvergence()<< endl;
-                  }
-              }
-            else theSmallTree.m_HHKin_mass_raw = -100 ;
 
             if ( (theBigTree.SVfitMass->at(chosenTauPair) > -900. || (doSmearing && theSmallTree.m_tauH_SVFIT_mass > 0)) && !wrongHHK)
             {
@@ -4341,8 +4322,6 @@ int main (int argc, char** argv)
               theSmallTree.m_HHkinsvfit_m   = tlv_HHsvfit.M () ;
             } // in case the SVFIT mass is calculated
           } // end of HH KinFit
-
-          theSmallTree.m_HHKin_mass_raw_copy = theSmallTree.m_HHKin_mass_raw ; // store twice if different binning needed
 
           theSmallTree.m_HHKin_mass = HHKmass;//kinFits.getMH () ;
           theSmallTree.m_HHKin_chi2 = HHKChi2;//kinFits.getChi2 () ;

--- a/test/skimNtuple2018_HHbtag.cpp
+++ b/test/skimNtuple2018_HHbtag.cpp
@@ -6371,13 +6371,13 @@ int main (int argc, char** argv)
     const double MU_MASS = 0.1056583715; //GeV
 
     // Reaf from configs
-    std::string model_dir = gConfigParser->readStringOption ("DNN::weights");
+    std::string model_dir = gConfigParser->readStringOption ("DNN::"+whichSgnHp+"weights");
     std::cout << "DNN::weights   : " << model_dir << std::endl;
 
     vector<float> DNN_kl;
     DNN_kl = gConfigParser->readFloatListOption("DNN::kl");
 
-    std::string features_file = gConfigParser->readStringOption ("DNN::features");
+    std::string features_file = gConfigParser->readStringOption ("DNN::"+whichSgnHp+"features");
     std::cout << "DNN::features  : " << features_file << std::endl;
 
     // Read from file the requested features to be computed

--- a/test/skimOutputter.cpp
+++ b/test/skimOutputter.cpp
@@ -21,7 +21,7 @@
 // bigTree is produced on an existing ntuple as follows (see at the end of the file) 
 #include "smallTree.h"
 #include "OfflineProducerHelper.h"
-#include "../../HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
+#include "../../HHKinFit2/HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
 #include "BDTfunctionsUtils.h"
 #include "skimUtils.h"
 

--- a/test/skimOutputter_HHbtag.cpp
+++ b/test/skimOutputter_HHbtag.cpp
@@ -21,7 +21,7 @@
 // bigTree is produced on an existing ntuple as follows (see at the end of the file) 
 #include "smallTree.h"
 #include "OfflineProducerHelper.h"
-#include "../../HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
+#include "../../HHKinFit2/HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
 #include "BDTfunctionsUtils.h"
 #include "skimUtils.h"
 #include "SFProvider.h"


### PR DESCRIPTION
This PR implements the new KinFitter module.
This module is essentially a wrapper around HHKinFit2 and makes some more tricks possible while making the skimmers more readable. 
Mainly triggered by the request to do ZH/ZZ signal checks from the ARC, this module can supersede the approach we had toward HHKinFit also for the actual H analysis.

Some tests have already been run on this new module and some others are underway.
For the moment, the new module is at least able to reproduce the correct HHmass as it was calculated in the older version of the skimmer without this module.

NOTE: given the new positioning of HHKinFit2, after pulling the changes in this PR it is necessary for the user to:
```
cd CMSSW_11_1_0_pre6/src
rm HHKinFit2
mkdir HHKinFit2
cd HHKinFit2
git clone git@github.com:jonamotta/HHKinFit2.git -b bbtautau_Run2DNNtraining
cd ..

scram b -j 12

cd HHKinFit2/HHKinFit2/
ln -ns interface include
source setup.sh
./compile.sh
cd ../..

cd KLUBAnalysis
cd interface/exceptions
ln -ns ../../../HHKinFit2/HHKinFit2/interface/exceptions/HHInvMConstraintException.h
ln -ns ../../../HHKinFit2/HHKinFit2/interface/exceptions/HHEnergyRangeException.h
ln -ns ../../../HHKinFit2/HHKinFit2/interface/exceptions/HHEnergyConstraintException.h
cd -

source scripts/setup.sh
make -j 10
make exe -j 10
```