### PR TITLE
Update to latest CMSSW_11_1_X release, allow project to be symlinked

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,6 @@ git clone git@github.com:LLRCMS/KLUBAnalysis.git
 cd KLUBAnalysis
 git checkout VBF_UL
 
-cd interface/exceptions
-ln -ns ../../../HHKinFit2/interface/exceptions/HHInvMConstraintException.h
-ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyRangeException.h
-ln -ns ../../../HHKinFit2/interface/exceptions/HHEnergyConstraintException.h
-cd -
-
 source scripts/setup.sh
 make
 make exe

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Repo for the hh->bbtautau analysis within the LLR framework
 
-## Instructions for Run2 Legacy Analysis
+## Instructions for Run2 Ultra Legacy Analysis
+
 ```
 cmsrel CMSSW_11_1_0_pre6
 cd CMSSW_11_1_0_pre6/src
@@ -25,12 +26,14 @@ git clone https://gitlab.cern.ch/hh/bbtautau/MulticlassInference.git
 # HHbtag package
 git clone git@github.com:hh-italian-group/HHbtag.git HHTools/HHbtag
 
-# KinFit and Combine packages
+# KinFit package
 git clone git@github.com:LLRCMS/HHKinFit2.git -b bbtautau_LegacyRun2
-git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
-cd HiggsAnalysis/CombinedLimit
-git checkout v8.2.0
-cd -
+
+# Combine package (disabled since only recommended for 10_2_X releases)
+# git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
+# cd HiggsAnalysis/CombinedLimit
+# git checkout v8.2.0
+# cd -
 
 # SVfit packages
 git clone https://github.com/LLRCMS/ClassicSVfit.git TauAnalysis/ClassicSVfit -b bbtautau_LegacyRun2

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Repo for the hh->bbtautau analysis within the LLR framework
 ## Instructions for Run2 Ultra Legacy Analysis
 
 ```
-cmsrel CMSSW_11_1_0_pre6
-cd CMSSW_11_1_0_pre6/src
+cmsrel CMSSW_11_1_9
+cd CMSSW_11_1_9/src
 cmsenv
 
 # DNN packages

--- a/interface/DNNKLUBinterface.h
+++ b/interface/DNNKLUBinterface.h
@@ -32,9 +32,9 @@
 #include "TLorentzVector.h"
 
 // DNN
-#include "../../cms_hh_tf_inference/inference/interface/inf_wrapper.hh"
-#include "../../cms_hh_proc_interface/processing/interface/feat_comp.hh"
-#include "../../cms_hh_proc_interface/processing/interface/evt_proc.hh"
+#include "cms_hh_tf_inference/inference/interface/inf_wrapper.hh"
+#include "cms_hh_proc_interface/processing/interface/feat_comp.hh"
+#include "cms_hh_proc_interface/processing/interface/evt_proc.hh"
 
 // Using names
 using DNNVector = ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<float>>;

--- a/interface/HHbtagKLUBinterface.h
+++ b/interface/HHbtagKLUBinterface.h
@@ -27,7 +27,7 @@
 #include <Math/VectorUtil.h>
 
 // HHbtag libraries
-#include "../../HHTools/HHbtag/interface/HH_BTag.h"
+#include "HHTools/HHbtag/interface/HH_BTag.h"
 
 
 // HHbtagKLUBinterface class

--- a/interface/SVfitKLUBinterface.h
+++ b/interface/SVfitKLUBinterface.h
@@ -26,10 +26,10 @@
 #include "TMatrixD.h"
 
 // ClassicSVfit libraries
-#include "../../TauAnalysis/ClassicSVfit/interface/ClassicSVfit.h"
-#include "../../TauAnalysis/ClassicSVfit/interface/ClassicSVfitIntegrand.h"
-#include "../../TauAnalysis/ClassicSVfit/interface/MeasuredTauLepton.h"
-#include "../../TauAnalysis/ClassicSVfit/interface/svFitHistogramAdapter.h"
+#include "TauAnalysis/ClassicSVfit/interface/ClassicSVfit.h"
+#include "TauAnalysis/ClassicSVfit/interface/ClassicSVfitIntegrand.h"
+#include "TauAnalysis/ClassicSVfit/interface/MeasuredTauLepton.h"
+#include "TauAnalysis/ClassicSVfit/interface/svFitHistogramAdapter.h"
 
 using namespace classic_svFit;
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -15,22 +15,26 @@ paths=$(echo $PATH | tr ":" "\n") # split on :
 pathunset=true
 for pp in $paths
 do
-    if [[ $pp == *"KLUBAnalysis/bin"* ]] ; then
+    if [[ $pp == *KLUBAnalysis/bin ]] ; then
         echo "Warning: path to KLUB binaries already set to: $pp"
         echo "         ... Ignoring this setup command"
         pathunset=false
+        break
     fi
 done
 
-if [ "$pathunset" = true ] ; then
-    export THISDIR=`pwd`
-    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${THISDIR}/lib
-    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${THISDIR}/../HHKinFit2
+if $pathunset; then
+    THISFILE="$( [ ! -z "$ZSH_VERSION" ] && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
+    KLUBDIR="$( cd "$( dirname "$THISFILE" )/.." && pwd )"
+    CMSSWDIR="$( cd "$( dirname "$THISFILE" )/../.." && pwd )"
 
-    if [ -n "${DYLD_LIBRARY_PATH}" ] ; then
-    export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:${THISDIR}/lib
-    export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:${THISDIR}/../HHKinFit2
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${KLUBDIR}/lib"
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${CMSSWDIR}/HHKinFit2"
+
+    if [ -n "${DYLD_LIBRARY_PATH}" ]; then
+        export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${KLUBDIR}/lib"
+        export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${CMSSWDIR}/HHKinFit2"
     fi
 
-    export PATH=${PATH}:${THISDIR}/bin
+    export PATH="${PATH}:${KLUBDIR}/bin"
 fi

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,88 +1,84 @@
-HDR   = ../interface/
-OBJ   = ../obj/
-LIB   = ../lib/
-BIN   = ../bin/
-PRG   = ../test/
+HDR = ../interface/
+OBJ = ../obj/
+LIB = ../lib/
+BIN = ../bin/
+PRG = ../test/
 
-HdrSuf  =  .h
-SrcSuf  =  .cc
-ObjSuf  =  .o
-PrgSuf  =  .cpp
-BinSuf  =  .exe
-LibSuf  =  .so
+HdrSuf = .h
+SrcSuf = .cc
+ObjSuf = .o
+PrgSuf = .cpp
+BinSuf = .exe
+LibSuf = .so
 
-HDRS  =  $(wildcard $(HDR)*$(HdrSuf))
-SRCS  =  $(wildcard *$(SrcSuf))
-_OBJS =  $(patsubst %$(SrcSuf), %$(ObjSuf), $(SRCS))
-OBJS  =  $(addprefix $(OBJ),$(_OBJS))
-PRGS  =  $(wildcard $(PRG)*$(PrgSuf))
+HDRS  = $(wildcard $(HDR)*$(HdrSuf))
+SRCS  = $(wildcard *$(SrcSuf))
+_OBJS = $(patsubst %$(SrcSuf), %$(ObjSuf), $(SRCS))
+OBJS  = $(addprefix $(OBJ),$(_OBJS))
+PRGS  = $(wildcard $(PRG)*$(PrgSuf))
 
-_BINS    =  $(wildcard $(PRG)*$(PrgSuf))
-__BINS   =  $(_BINS:$(PrgSuf)=$(BinSuf))
-___BINS  =  $(notdir $(__BINS))
-BINS	 =  $(addprefix $(BIN),${___BINS})
+_BINS   = $(wildcard $(PRG)*$(PrgSuf))
+__BINS  = $(_BINS:$(PrgSuf)=$(BinSuf))
+___BINS = $(notdir $(__BINS))
+BINS    = $(addprefix $(BIN),${___BINS})
 
-LINKDEF   =  $(wildcard ${HDR}*LinkDef.h)
-DICTHDRS  =  $(patsubst $(LINKDEF),,$(HDRS)) $(LINKDEF)
+LINKDEF  = $(wildcard ${HDR}*LinkDef.h)
+DICTHDRS = $(patsubst $(LINKDEF),,$(HDRS)) $(LINKDEF)
 
 PROJDIR = $(shell ( cd $$CMSSW_BASE/src && /bin/pwd ))
 
-ROOTCFLAGS    = $(shell root-config --cflags)
-ROOTGLIBS     = $(shell root-config --glibs)
+ROOTCFLAGS = $(shell root-config --cflags)
+ROOTGLIBS  = $(shell root-config --glibs)
 
-BOOSTFLAGS      = $(shell ( cd $(PROJDIR) && scram tool info boost ) | grep -e '^LIBDIR' | sed -e 's/LIBDIR=/-L/')
-BOOSTLIB    = $(shell ( cd $(PROJDIR) && scram tool info boost ) | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
+BOOSTFLAGS = $(shell ( cd $(PROJDIR) && scram tool info boost ) | grep -e '^LIBDIR' | sed -e 's/LIBDIR=/-L/')
+BOOSTLIB   = $(shell ( cd $(PROJDIR) && scram tool info boost ) | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
 
 TensFLowFLAGS = $(shell ( cd $(PROJDIR) && scram tool info tensorflow ) | grep -e '^LIBDIR' | sed -e 's/LIBDIR=/-L/')
 TensFLowLIB   = $(shell ( cd $(PROJDIR) && scram tool info tensorflow ) | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
 
-PROTOBUFLIB   = $(shell ( cd $(PROJDIR) && scram tool info protobuf ) | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
-EIGENLIB   = $(shell ( cd $(PROJDIR) && scram tool info eigen ) | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
-TBBLIB = $(shell ( cd $(PROJDIR) && scram tool info tbb ) | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
-BASELIBS = -I$(shell echo $$CMSSW_RELEASE_BASE | sed -e 's/$$/\/src/')
-CMSSWLIBS = -I$(shell echo $$CMSSW_BASE | sed -e 's/$$/\/src/')
-HHKINFITLIB  = -I$(PROJDIR)/HHKinFit2/interface
+PROTOBUFLIB = $(shell ( cd $(PROJDIR) && scram tool info protobuf ) | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
+EIGENLIB    = $(shell ( cd $(PROJDIR) && scram tool info eigen ) | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
+TBBLIB      = $(shell ( cd $(PROJDIR) && scram tool info tbb ) | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
+BASELIBS    = -I$(shell echo $$CMSSW_RELEASE_BASE | sed -e 's/$$/\/src/')
+CMSSWLIBS   = -I$(shell echo $$CMSSW_BASE | sed -e 's/$$/\/src/')
+HHKINFITLIB = -I$(PROJDIR)/HHKinFit2/interface
 
-ARCHL = -m64
-CXX  =  g++
-CXXFLAGS  =  -Wall -O -fPIC -I$(HDR) $(ROOTCFLAGS) $(BOOSTFLAGS) $(BOOSTLIB) $(BASELIBS) $(CMSSWLIBS) $(TensFLowLIB) $(PROTOBUFLIB) $(EIGENLIB) $(TBBLIB) $(HHKINFITLIB)
-CPP  =  g++
-CPPFLAGS  = -Wall  $(ARCHL) -I$(HDR) $(ROOTCFLAGS) $(BOOSTFLAGS) $(BOOSTLIB) $(BASELIBS) $(CMSSWLIBS) $(TensFLowLIB) $(PROTOBUFLIB) $(EIGENLIB) $(TBBLIB) $(HHKINFITLIB)
+ARCHL    = -m64
+CXX      = g++
+CXXFLAGS = -Wall -O -fPIC -I$(HDR) $(ROOTCFLAGS) $(BOOSTFLAGS) $(BOOSTLIB) $(BASELIBS) $(CMSSWLIBS) $(TensFLowLIB) $(PROTOBUFLIB) $(EIGENLIB) $(TBBLIB) $(HHKINFITLIB)
+CPP      = g++
+CPPFLAGS = -Wall  $(ARCHL) -I$(HDR) $(ROOTCFLAGS) $(BOOSTFLAGS) $(BOOSTLIB) $(BASELIBS) $(CMSSWLIBS) $(TensFLowLIB) $(PROTOBUFLIB) $(EIGENLIB) $(TBBLIB) $(HHKINFITLIB)
 
-F    = gfortran
+F      = gfortran
 FFLAGS = -c
 
-LD       =  g++
-LDFLAGS  =  -rdynamic -shared -O3 $(ARCHL)
-SONAME	 =  libDoubleHiggs.so
-SONAME2  =  DoubleHiggs
-SOFLAGS  =  -Wl,-soname,$(SONAME)
+LD      = g++
+LDFLAGS = -rdynamic -shared -O3 $(ARCHL)
+SONAME  = libDoubleHiggs.so
+SONAME2 = DoubleHiggs
+SOFLAGS = -Wl,-soname,$(SONAME)
 
-GLIBS   =  -lm -ldl -rdynamic $(ROOTGLIBS) -lGenVector -lFoam -lMinuit -lTMVA -lMLP -lXMLIO -lGpad  -lTreePlayer -lRooFit -lRooFitCore -lRooStats -L$(PROJDIR)/HHKinFit2 -lHHKinFit2 -lboost_regex -lboost_system -lboost_filesystem -ltensorflow_cc -ltensorflow_framework $(TensFLowFLAGS)
+GLIBS = -lm -ldl -rdynamic $(ROOTGLIBS) -lGenVector -lFoam -lMinuit -lTMVA -lMLP -lXMLIO -lGpad  -lTreePlayer -lRooFit -lRooFitCore -lRooStats -L$(PROJDIR)/HHKinFit2 -lHHKinFit2 -lboost_regex -lboost_system -lboost_filesystem -ltensorflow_cc -ltensorflow_framework $(TensFLowFLAGS)
 
-DNNARCH = $(shell scram arch)
-DNNPATH = $(shell echo $$CMSSW_BASE | grep "CMSSW" | sed -e 's/$$/\/lib/')/$(DNNARCH)/
-DNNLIBS = -lcms_hh_proc_interfaceprocessing -lcms_hh_tf_inferenceinference -lMulticlassInferenceMulticlassInference -L$(DNNPATH)
+DNNARCH    = $(shell scram arch)
+DNNPATH    = $(shell echo $$CMSSW_BASE | grep "CMSSW" | sed -e 's/$$/\/lib/')/$(DNNARCH)/
+DNNLIBS    = -lcms_hh_proc_interfaceprocessing -lcms_hh_tf_inferenceinference -lMulticlassInferenceMulticlassInference -L$(DNNPATH)
 FWCOREPATH = $(shell echo $$CMSSW_RELEASE_BASE | sed -e 's/$$/\/lib/')/$(DNNARCH)/
 FWCORELIBS = -lFWCoreMessageLogger -lCondFormatsJetMETObjects -lJetMETCorrectionsModules -L$(FWCOREPATH)
 
-SVfitLIBS = -lTauAnalysisClassicSVfit -lTauAnalysisSVfitTF -L$(DNNPATH)
+SVfitLIBS  = -lTauAnalysisClassicSVfit -lTauAnalysisSVfitTF -L$(DNNPATH)
 HHbtagLIBS = -lHHToolsHHbtag -L${DNNPATH}
 
 #################################################
 #if mac 64
-ARCH  =  $(shell root-config --arch)
+ARCH =  $(shell root-config --arch)
 ifeq ($(ARCH),macosx64)
-LibSuf  =  .dylib
-
-ARCHL = -m64
-
-CPPFLAGS  =  -Wall -W -Woverloaded-virtual -O2 $(ARCHL) -pipe -I$(HDR) $(ROOTCFLAGS)
-
-CXXFLAGS  = -fPIC  -Wall -W -Woverloaded-virtual -O2 $(ARCHL) -pipe -I$(HDR) $(ROOTCFLAGS) 
-
-LDFLAGS  =  -dynamiclib -shared -03 -single_module -undefined dynamic_lookup $(ARCHL)
-SONAME	 =  libPlotter.dylib
+LibSuf   = .dylib
+ARCHL    = -m64
+CPPFLAGS = -Wall -W -Woverloaded-virtual -O2 $(ARCHL) -pipe -I$(HDR) $(ROOTCFLAGS)
+CXXFLAGS = -fPIC  -Wall -W -Woverloaded-virtual -O2 $(ARCHL) -pipe -I$(HDR) $(ROOTCFLAGS) 
+LDFLAGS  = -dynamiclib -shared -03 -single_module -undefined dynamic_lookup $(ARCHL)
+SONAME   = libPlotter.dylib
 SOFLAGS  =
 endif
 #################################################
@@ -92,7 +88,6 @@ endif
 all: $(LIB)$(SONAME)
 
 exe: $(BINS) 
-
 
 test:
 	@echo "HDRS = $(HDRS)"
@@ -104,10 +99,8 @@ test:
 	@echo "DNNLIBS   = $(DNNLIBS)"
 	@echo "CMSSWPATH = $(CMSSWPATH)"
 
-
 $(OBJ)%$(ObjSuf): %$(SrcSuf) $(HDRS)
 	$(CXX) $< -c $(CXXFLAGS) -o $@  
-
 
 $(OBJ)mydict.cc: $(DICTHDRS)
 	@echo "Generating dictionary for  ..."
@@ -119,7 +112,6 @@ $(LIB)$(SONAME): $(OBJS) $(OBJ)mydict.o
 
 $(BIN)%$(BinSuf): $(PRG)%$(PrgSuf) $(HDRS) $(LIB)$(SONAME)
 	$(CPP) $<  -l$(SONAME2) $(CPPFLAGS) -L$(LIB) $(GLIBS) $(DNNLIBS) $(SVfitLIBS) $(HHbtagLIBS) $(FWCORELIBS) -o $@
-
 
 clean:
 	rm -f $(OBJ)*$(ObjSuf)  $(OBJ)mydict* $(BIN)*$(BinSuf) $(LIB)*$(LibSuf) 

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,26 +25,29 @@ BINS	 =  $(addprefix $(BIN),${___BINS})
 LINKDEF   =  $(wildcard ${HDR}*LinkDef.h)
 DICTHDRS  =  $(patsubst $(LINKDEF),,$(HDRS)) $(LINKDEF)
 
+PROJDIR = $(shell ( cd $$CMSSW_BASE/src && /bin/pwd ))
+
 ROOTCFLAGS    = $(shell root-config --cflags)
 ROOTGLIBS     = $(shell root-config --glibs)
 
-BOOSTFLAGS      = $(shell scram tool info boost | grep -e '^LIBDIR' | sed -e 's/LIBDIR=/-L/')
-BOOSTLIB    = $(shell scram tool info boost | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
+BOOSTFLAGS      = $(shell ( cd $(PROJDIR) && scram tool info boost ) | grep -e '^LIBDIR' | sed -e 's/LIBDIR=/-L/')
+BOOSTLIB    = $(shell ( cd $(PROJDIR) && scram tool info boost ) | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
 
-TensFLowFLAGS = $(shell scram tool info tensorflow | grep -e '^LIBDIR' | sed -e 's/LIBDIR=/-L/')
-TensFLowLIB   = $(shell scram tool info tensorflow | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
+TensFLowFLAGS = $(shell ( cd $(PROJDIR) && scram tool info tensorflow ) | grep -e '^LIBDIR' | sed -e 's/LIBDIR=/-L/')
+TensFLowLIB   = $(shell ( cd $(PROJDIR) && scram tool info tensorflow ) | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
 
-PROTOBUFLIB   = $(shell scram tool info protobuf | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
-EIGENLIB   = $(shell scram tool info eigen | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
-TBBLIB = $(shell scram tool info tbb | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
+PROTOBUFLIB   = $(shell ( cd $(PROJDIR) && scram tool info protobuf ) | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
+EIGENLIB   = $(shell ( cd $(PROJDIR) && scram tool info eigen ) | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
+TBBLIB = $(shell ( cd $(PROJDIR) && scram tool info tbb ) | grep -e '^INCLUDE' | sed -e 's/INCLUDE=/-I/')
 BASELIBS = -I$(shell echo $$CMSSW_RELEASE_BASE | sed -e 's/$$/\/src/')
 CMSSWLIBS = -I$(shell echo $$CMSSW_BASE | sed -e 's/$$/\/src/')
+HHKINFITLIB  = -I$(PROJDIR)/HHKinFit2/interface
 
 ARCHL = -m64
 CXX  =  g++
-CXXFLAGS  =  -Wall -O -fPIC -I$(HDR) $(ROOTCFLAGS) $(BOOSTFLAGS) $(BOOSTLIB) $(BASELIBS) $(CMSSWLIBS) $(TensFLowLIB) $(PROTOBUFLIB) $(EIGENLIB) $(TBBLIB)
+CXXFLAGS  =  -Wall -O -fPIC -I$(HDR) $(ROOTCFLAGS) $(BOOSTFLAGS) $(BOOSTLIB) $(BASELIBS) $(CMSSWLIBS) $(TensFLowLIB) $(PROTOBUFLIB) $(EIGENLIB) $(TBBLIB) $(HHKINFITLIB)
 CPP  =  g++
-CPPFLAGS  = -Wall  $(ARCHL) -I$(HDR) $(ROOTCFLAGS) $(BOOSTFLAGS) $(BOOSTLIB) $(BASELIBS) $(CMSSWLIBS) $(TensFLowLIB) $(PROTOBUFLIB) $(EIGENLIB) $(TBBLIB)
+CPPFLAGS  = -Wall  $(ARCHL) -I$(HDR) $(ROOTCFLAGS) $(BOOSTFLAGS) $(BOOSTLIB) $(BASELIBS) $(CMSSWLIBS) $(TensFLowLIB) $(PROTOBUFLIB) $(EIGENLIB) $(TBBLIB) $(HHKINFITLIB)
 
 F    = gfortran
 FFLAGS = -c
@@ -55,7 +58,7 @@ SONAME	 =  libDoubleHiggs.so
 SONAME2  =  DoubleHiggs
 SOFLAGS  =  -Wl,-soname,$(SONAME)
 
-GLIBS   =  -lm -ldl -rdynamic $(ROOTGLIBS) -lGenVector -lFoam -lMinuit -lTMVA -lMLP -lXMLIO -lGpad  -lTreePlayer -lRooFit -lRooFitCore -lRooStats -lHHKinFit2 -L../../HHKinFit2 -lboost_regex -lboost_system -lboost_filesystem -ltensorflow_cc -ltensorflow_framework $(TensFLowFLAGS)
+GLIBS   =  -lm -ldl -rdynamic $(ROOTGLIBS) -lGenVector -lFoam -lMinuit -lTMVA -lMLP -lXMLIO -lGpad  -lTreePlayer -lRooFit -lRooFitCore -lRooStats -L$(PROJDIR)/HHKinFit2 -lHHKinFit2 -lboost_regex -lboost_system -lboost_filesystem -ltensorflow_cc -ltensorflow_framework $(TensFLowFLAGS)
 
 DNNARCH = $(shell scram arch)
 DNNPATH = $(shell echo $$CMSSW_BASE | grep "CMSSW" | sed -e 's/$$/\/lib/')/$(DNNARCH)/

--- a/test/skimNtuple2016_HHbtag.cpp
+++ b/test/skimNtuple2016_HHbtag.cpp
@@ -25,7 +25,7 @@
 #include "bJetRegrVars.h"
 #include "bTagSF.h"
 #include "HHReweight5D.h"
-#include "../../HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
+#include "HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
 #include "SFProvider.h"
 #include "BDTfunctionsUtils.h"
 #include "TauIDSFTool.h"
@@ -57,9 +57,9 @@
 #include <Math/PxPyPzM4D.h>
 
 // DNN
-#include "../../cms_hh_tf_inference/inference/interface/inf_wrapper.hh"
-#include "../../cms_hh_proc_interface/processing/interface/feat_comp.hh"
-#include "../../cms_hh_proc_interface/processing/interface/evt_proc.hh"
+#include "cms_hh_tf_inference/inference/interface/inf_wrapper.hh"
+#include "cms_hh_proc_interface/processing/interface/feat_comp.hh"
+#include "cms_hh_proc_interface/processing/interface/evt_proc.hh"
 
 // HHbtag
 #include "HHbtagKLUBinterface.h"

--- a/test/skimNtuple2017_HHbtag.cpp
+++ b/test/skimNtuple2017_HHbtag.cpp
@@ -26,7 +26,7 @@
 #include "bJetRegrVars.h"
 #include "bTagSF.h"
 #include "HHReweight5D.h"
-#include "../../HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
+#include "HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
 #include "SFProvider.h"
 #include "BDTfunctionsUtils.h"
 #include "TauIDSFTool.h"
@@ -58,9 +58,9 @@
 #include <Math/PxPyPzM4D.h>
 
 // DNN
-#include "../../cms_hh_tf_inference/inference/interface/inf_wrapper.hh"
-#include "../../cms_hh_proc_interface/processing/interface/feat_comp.hh"
-#include "../../cms_hh_proc_interface/processing/interface/evt_proc.hh"
+#include "cms_hh_tf_inference/inference/interface/inf_wrapper.hh"
+#include "cms_hh_proc_interface/processing/interface/feat_comp.hh"
+#include "cms_hh_proc_interface/processing/interface/evt_proc.hh"
 
 // HHbtag
 #include "HHbtagKLUBinterface.h"

--- a/test/skimNtuple2018_HHbtag.cpp
+++ b/test/skimNtuple2018_HHbtag.cpp
@@ -26,7 +26,7 @@
 #include "bJetRegrVars.h"
 #include "bTagSF.h"
 #include "HHReweight5D.h"
-#include "../../HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
+#include "HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
 #include "SFProvider.h"
 #include "BDTfunctionsUtils.h"
 #include "TauIDSFTool.h"
@@ -58,9 +58,9 @@
 #include <Math/PxPyPzM4D.h>
 
 // DNN
-#include "../../cms_hh_tf_inference/inference/interface/inf_wrapper.hh"
-#include "../../cms_hh_proc_interface/processing/interface/feat_comp.hh"
-#include "../../cms_hh_proc_interface/processing/interface/evt_proc.hh"
+#include "cms_hh_tf_inference/inference/interface/inf_wrapper.hh"
+#include "cms_hh_proc_interface/processing/interface/feat_comp.hh"
+#include "cms_hh_proc_interface/processing/interface/evt_proc.hh"
 
 // HHbtag
 #include "HHbtagKLUBinterface.h"

--- a/test/skimNtuple_oldOrdering.cpp_x
+++ b/test/skimNtuple_oldOrdering.cpp_x
@@ -25,7 +25,7 @@
 #include "bTagSF.h"
 // #include "HHReweight.h"
 #include "HHReweight5D.h"
-#include "../../HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
+#include "HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
 
 // for minuit-based minimization
 // #include "mt2.h"
@@ -34,7 +34,7 @@
 // #include "Math/Functor.h"
 #include "lester_mt2_bisect.h"
 
-//#include "../../HTT-utilities/LepEffInterface/interface/ScaleFactor.h"
+//#include "HTT-utilities/LepEffInterface/interface/ScaleFactor.h"
 #include "ScaleFactor.h"
 #include "ConfigParser.h"
 #include "EffCounter.h"

--- a/test/skimOutputter.cpp
+++ b/test/skimOutputter.cpp
@@ -21,7 +21,7 @@
 // bigTree is produced on an existing ntuple as follows (see at the end of the file)
 #include "smallTree.h"
 #include "OfflineProducerHelper.h"
-#include "../../HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
+#include "HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
 #include "BDTfunctionsUtils.h"
 #include "skimUtils.h"
 

--- a/test/skimOutputter_HHbtag.cpp
+++ b/test/skimOutputter_HHbtag.cpp
@@ -21,7 +21,7 @@
 // bigTree is produced on an existing ntuple as follows (see at the end of the file)
 #include "smallTree.h"
 #include "OfflineProducerHelper.h"
-#include "../../HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
+#include "HHKinFit2/include/HHKinFitMasterHeavyHiggs.h"
 #include "BDTfunctionsUtils.h"
 #include "skimUtils.h"
 #include "SFProvider.h"


### PR DESCRIPTION
Hi!

This PR updates the UL instructions to the latest CMSSW_11_1_X release.

Also (and sorry for piggybacking on this PR), it contains a few smaller changes related to the setup. We tend to have the KLUBAnalysis repo separate from the CMSSW checkout and just add a symlink to `$CMSSW_BASE/src` (mostly to have the repo itself in a directory which we can sync (rsync/afs) to local directories for developing). However, I noticed that there are some assumptions about the project structure in the include statements (e.g. `#include "../../HHKinFit2/XYZ`) which prevent using symlinks.

I made these statements absolute and rather adjusted the `Makefile` slightly to properly find all includes and to link libraries after compilation. I took the liberty and cleaned the file a bit, which causes git to report many line changes, but actually nothing happened there. This streamlines the setup a bit and also allows symlinking :)