### PR TITLE
Added lxplus submit and plotting scripts

### DIFF
--- a/config/mainCfg_TauTau_UL18.cfg
+++ b/config/mainCfg_TauTau_UL18.cfg
@@ -1,0 +1,117 @@
+
+[general]
+
+lumi = 59970 # pb^-1 CMS2018LUMI PASSING ANALYSIS QUALITY REQUIREMENT
+# the lumi in fb^-1 is used only by the plotting program
+# approximate to only one decimal digit
+lumi_fb = 60.0 # fb^-1
+
+outputFolder = /eos/user/j/jowulff/res_HH/CMSSW_11_1_9/src/KLUBAnalysis/TauTau_UL18_mv
+
+data = DTauA, DTauB, DTauC, DTauD
+
+signals = ggF_BulkGraviton_m250, ggF_BulkGraviton_m260
+
+
+backgrounds = DY_NLO, EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, ST_tW_antitop, ST_tW_top, ST_tchannel_antitop, ST_tchannel_top, TTWJetsToLNu, TTWJetsToQQ, TTWW, TTWZ, TTZToLLNuNu, TTZZ, TTfullyHad, TTfullyLep, TTsemiLep, VBFHTauTau, ggHTauTau, ttHToBB, ttHToNonBB, ttHToTauTau, WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf, WW, WZ, WminusHTauTau, WplusHTauTau, ZH_HTauTau
+# TOGETHER WITH THE TARGET VARIABLES YOU NEED ALWAYS PLOT LOWER LEVEL VARIABLES TO CHECK THAT EVERYTHING IS OK
+variables = dau1_pt, dau2_pt, dau1_eta, dau2_eta, ditau_deltaR, bjet1_pt, bjet1_bID_deepFlavor, bjet2_pt, bjet2_bID_deepFlavor, tauH_mass, tauH_SVFIT_mass, tauH_pt, bH_mass, bH_pt, HH_mass_raw, HH_pt
+#variables = tauH_pt, tauH_mass, dau1_pt, dau2_pt, dau1_eta, dau2_eta, ditau_deltaR, bjet1_pt, bjet2_pt, bH_mass, bH_pt, HH_pt
+#variables = tauH_pt
+
+# SELECTIONS W/O MASS CUT
+#selections = baseline, s1b1jresolved, s2b0jresolved, sboostedLL, s0b2j, VBFloose, VBFtight
+
+# SELECTIONS W/ MASS CUT
+#selections = baselineMcut, s1b1jresolvedMcut, s2b0jresolvedMcut, sboostedLLMcut, s0b2j, VBFlooseMcut, VBFtightMcut
+
+selections = baseline
+
+regions    = SR
+#regions    = SR, SStight, OSrlx, SSrlx, OSinviso, SSinviso
+
+
+[configs]
+
+sampleCfg = config/sampleCfg_TauTau_UL18.cfg
+cutCfg    = config/selectionCfg_TauTau_Legacy2018.cfg
+
+
+[merge]
+# HERE THE MERGING OF THE BKGs IS DONE SO THAT WE CAN COMPUTE DURING THE PLOTTING ALSO THE YIELDS OF THE SIGLE PROCESSES INVOLVED
+# IN ORDER TO HAVE THE SAME FINAL PLOTS AS FOR THE OTHER YEARS, WHEN PLOTTING THE MERGING IS FURTHER CARRIED OUT AS FOLLOWS:
+# others = EWK + singleT + VH + singleT + VH + ttH + doubleTsingleV + doubleTVV + doubleV + tripleV + VBFHTauTau + ggHTauTau
+
+
+TT	= TTfullyHad, TTfullyLep, TTsemiLep
+EWK = EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL
+singleT =  ST_tW_antitop, ST_tW_top, ST_tchannel_antitop, ST_tchannel_top
+TTV = TTWJetsToLNu, TTWJetsToQQ, TTZToLLNuNu
+TTVV = TTWW, TTWZ, TTZZ
+H = VBFHTauTau, ggHTauTau, ttHToBB, ttHToNonBB, ttHToTauTau, WminusHTauTau, WplusHTauTau, ZH_HTauTau
+W =  WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
+VV = WW, WZ
+
+data_obs  = DTauA, DTauB, DTauC, DTauD
+
+############################################################################################
+############################################################################################
+# the following lines are used for postprocessing (pp_), i.e. not read from AnalysisHelper
+# but used in subsequent steps of the analysis to combine histos, compute QCD etc..
+# we keep them here to have everything at hand
+
+[pp_merge]
+
+
+## in case some histos must be rebinned. Pass as
+## uniqueid = varToRebin , condition, newBinning
+# [pp_rebin]
+# r1 = HHKin_mass_raw         , sboostedLLMcut , 250, 1000 # a unique, big bin
+# r2 = HHKin_mass_raw_tauup   , sboostedLLMcut , 250, 1000 # a unique, big bin
+# r3 = HHKin_mass_raw_taudown , sboostedLLMcut , 250, 1000 # a unique, big bin
+# r4 = HHKin_mass_raw_jetup   , sboostedLLMcut , 250, 1000 # a unique, big bin
+# r5 = HHKin_mass_raw_jetdown , sboostedLLMcut , 250, 1000 # a unique, big bin
+#
+# r6  = MT2         , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+# r7  = MT2_tauup   , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+# r8  = MT2_taudown , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+# r9  = MT2_jetup   , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+# r10 = MT2_jetdown , sboostedLLMcut , 0, 150, 500 # two bins - the lowest one has small signal
+
+## parameters for QCD evaluation
+## doFitIf : condition to be respected to make rlx-to-tight QCD fit. It is used as eval(doFitIf). Use names sel, var
+
+
+[pp_QCD]
+#QCDname      = QCD
+#SR           = SR
+#yieldSB      = SStight
+#shapeSB      = SSrlx
+#SBtoSRfactor = 1
+#regionD = SSinviso
+#regionC = OSinviso
+#doFitIf      = False
+#fitFunc      = [0] + [1]*x
+
+
+#for inverted QCD
+QCDname      = QCD
+SR           = SR
+yieldSB      = OSinviso
+shapeSB      = OSinviso
+SBtoSRfactor = 1
+doFitIf      = False
+fitFunc      = [0] + [1]*x
+regionC      = SStight
+regionD      = SSinviso
+
+
+[VBF_rew]
+# !WARNING! The input samples MUST be in the order: node1, node2, node3, node4, node5, node19 !
+# See the list 'inputSignals' to understand the link node<->couplings
+doReweighting = False
+inputSignals = VBFHH_CV_1_C2V_1_C3_1, VBFHH_CV_1_C2V_1_C3_0, VBFHH_CV_1_C2V_1_C3_2, VBFHH_CV_1_C2V_2_C3_1, VBFHH_CV_1_5_C2V_1_C3_1, VBFHH_CV_1_C2V_0_C3_2
+target_kl  = 1
+target_cv  = 0, 1
+target_c2v = 1
+target_xs = 1 #[pb]

--- a/config/sampleCfg_TauTau_UL18.cfg
+++ b/config/sampleCfg_TauTau_UL18.cfg
@@ -1,0 +1,185 @@
+[samples]
+
+# Data
+DEGamma_Run2018A = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_EGamma_Run2018A
+DEGamma_Run2018B = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_EGamma_Run2018B
+DEGamma_Run2018C = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_EGamma_Run2018C
+DEGamma_Run2018D = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_EGamma_Run2018D
+
+DMET_Run2018A = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_MET_Run2018A
+DMET_Run2018B = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_MET_Run2018B
+DMET_Run2018C = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_MET_Run2018C
+DMET_Run2018D = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_MET_Run2018D
+
+DSingleMuon_Run2018A = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_SingleMuon_Run2018A
+DSingleMuon_Run2018B = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_SingleMuon_Run2018B
+DSingleMuon_Run2018C = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_SingleMuon_Run2018C
+DSingleMuon_Run2018D = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_SingleMuon_Run2018D
+
+DTauA = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_Tau_Run2018A
+DTauB = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_Tau_Run2018B
+DTauC = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_Tau_Run2018C
+DTauD = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_Tau_Run2018D
+# Bkgd 
+DY_NLO = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_DY_NLO
+DY_NLO_0j = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_DY_NLO_0j
+DY_NLO_1j = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_DY_NLO_1j
+DY_NLO_2j = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_DY_NLO_2j
+DY_NLO_PT100To250 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_DY_NLO_PT100To250
+DY_NLO_PT250To400 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_DY_NLO_PT250To400
+DY_NLO_PT400To650 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_DY_NLO_PT400To650
+DY_NLO_PT50To100 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_DY_NLO_PT50To100
+DY_NLO_PT650ToInf = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_DY_NLO_PT650ToInf
+DYmerged = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_DYmerged
+
+EWKWMinus2Jets_WToLNu = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_EWKWMinus2Jets_WToLNu
+EWKWPlus2Jets_WToLNu = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_EWKWPlus2Jets_WToLNu
+EWKZ2Jets_ZToLL = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_EWKZ2Jets_ZToLL
+
+ST_tW_antitop = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ST_tW_antitop
+ST_tW_top = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ST_tW_top
+ST_tchannel_antitop = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ST_tchannel_antitop
+ST_tchannel_top = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ST_tchannel_top
+
+TTWJetsToLNu = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_TTWJetsToLNu
+TTWJetsToQQ = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_TTWJetsToQQ
+TTZToLLNuNu = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_TTZToLLNuNu
+
+TTWW = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_TTWW
+TTWZ = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_TTWZ
+TTZZ = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_TTZZ
+
+TTfullyHad = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_TT_fullyHad
+TTfullyLep = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_TT_fullyLep
+TTsemiLep = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_TT_semiLep
+
+VBFHTauTau = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBFHTauTau
+
+ggHTauTau = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggHTauTau
+
+ttHToBB = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ttHToBB
+ttHToNonBB = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ttHToNonBB
+ttHToTauTau = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ttHToTauTau
+
+WJets_HT_0_70 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_WJets_HT_0_70
+WJets_HT_70_100 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_WJets_HT_70_100
+WJets_HT_100_200 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_WJets_HT_100_200
+WJets_HT_200_400 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_WJets_HT_200_400
+WJets_HT_400_600 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_WJets_HT_400_600
+WJets_HT_600_800 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_WJets_HT_600_800
+WJets_HT_800_1200 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_WJets_HT_800_1200
+WJets_HT_1200_2500 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_WJets_HT_1200_2500
+WJets_HT_2500_Inf = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_WJets_HT_2500_Inf
+
+WW = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_WW
+WZ = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_WZ
+
+WminusHTauTau = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_WminusHTauTau
+WplusHTauTau = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_WplusHTauTau
+
+ZH_HTauTau = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ZH_HTauTau
+#ZZ = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ZZ
+
+ggF_BulkGraviton_m250 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m250
+ggF_BulkGraviton_m260 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m260
+ggF_BulkGraviton_m270 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m270
+ggF_BulkGraviton_m280 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m280
+ggF_BulkGraviton_m300 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m300
+ggF_BulkGraviton_m320 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m320
+ggF_BulkGraviton_m350 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m350
+ggF_BulkGraviton_m400 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m400
+ggF_BulkGraviton_m450 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m450
+ggF_BulkGraviton_m500 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m500
+ggF_BulkGraviton_m550 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m550
+ggF_BulkGraviton_m600 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m600
+ggF_BulkGraviton_m650 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m650
+ggF_BulkGraviton_m700 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m700
+ggF_BulkGraviton_m750 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m750
+ggF_BulkGraviton_m800 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m800
+ggF_BulkGraviton_m850 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m850
+ggF_BulkGraviton_m900 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m900
+ggF_BulkGraviton_m1000 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m1000
+ggF_BulkGraviton_m1250 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m1250
+ggF_BulkGraviton_m1500 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m1500
+ggF_BulkGraviton_m1750 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m1750
+ggF_BulkGraviton_m2000 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m2000
+ggF_BulkGraviton_m2500 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m2500
+ggF_BulkGraviton_m3000 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_BulkGraviton_m3000
+
+ggF_Radion_m250 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m250
+ggF_Radion_m260 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m260
+ggF_Radion_m270 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m270
+ggF_Radion_m280 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m280
+ggF_Radion_m300 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m300
+ggF_Radion_m320 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m320
+ggF_Radion_m350 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m350
+ggF_Radion_m400 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m400
+ggF_Radion_m450 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m450
+ggF_Radion_m500 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m500
+ggF_Radion_m550 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m550
+ggF_Radion_m600 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m600
+ggF_Radion_m650 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m650
+ggF_Radion_m700 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m700
+ggF_Radion_m750 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m750
+ggF_Radion_m800 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m800
+ggF_Radion_m850 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m850
+ggF_Radion_m900 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m900
+ggF_Radion_m1000 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m1000
+ggF_Radion_m1250 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m1250
+ggF_Radion_m1500 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m1500
+ggF_Radion_m1750 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m1750
+ggF_Radion_m2000 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m2000
+ggF_Radion_m2500 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m2500
+ggF_Radion_m3000 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_ggF_Radion_m3000
+
+VBF_BulkGraviton_m250 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m250
+VBF_BulkGraviton_m260 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m260
+VBF_BulkGraviton_m270 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m270
+VBF_BulkGraviton_m280 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m280
+VBF_BulkGraviton_m300 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m300
+VBF_BulkGraviton_m320 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m320
+VBF_BulkGraviton_m350 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m350
+VBF_BulkGraviton_m400 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m400
+VBF_BulkGraviton_m450 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m450
+VBF_BulkGraviton_m500 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m500
+VBF_BulkGraviton_m550 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m550
+VBF_BulkGraviton_m600 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m600
+VBF_BulkGraviton_m650 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m650
+VBF_BulkGraviton_m700 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m700
+VBF_BulkGraviton_m750 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m750
+VBF_BulkGraviton_m800 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m800
+VBF_BulkGraviton_m850 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m850
+VBF_BulkGraviton_m900 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m900
+VBF_BulkGraviton_m1000 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m1000
+VBF_BulkGraviton_m1250 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m1250
+VBF_BulkGraviton_m1500 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m1500
+VBF_BulkGraviton_m1750 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m1750
+VBF_BulkGraviton_m2000 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m2000
+VBF_BulkGraviton_m2500 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m2500
+VBF_BulkGraviton_m3000 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_BulkGraviton_m3000
+
+VBF_Radion_m250 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m250
+VBF_Radion_m260 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m260
+VBF_Radion_m270 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m270
+VBF_Radion_m280 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m280
+VBF_Radion_m300 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m300
+VBF_Radion_m320 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m320
+VBF_Radion_m350 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m350
+VBF_Radion_m400 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m400
+VBF_Radion_m450 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m450
+VBF_Radion_m500 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m500
+VBF_Radion_m550 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m550
+VBF_Radion_m600 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m600
+VBF_Radion_m650 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m650
+VBF_Radion_m700 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m700
+VBF_Radion_m750 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m750
+VBF_Radion_m800 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m800
+VBF_Radion_m850 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m850
+VBF_Radion_m900 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m900
+VBF_Radion_m1000 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m1000
+VBF_Radion_m1250 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m1250
+VBF_Radion_m1500 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m1500
+VBF_Radion_m1750 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m1750
+VBF_Radion_m2000 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m2000
+VBF_Radion_m2500 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m2500
+VBF_Radion_m3000 = /eos/user/l/lportale/hhbbtautau/skims/SKIMS_UL18_220610/SKIM_VBF_Radion_m3000

--- a/scripts/makeFinalPlots_lxplus.py
+++ b/scripts/makeFinalPlots_lxplus.py
@@ -1,0 +1,1003 @@
+from ROOT import *
+import re
+import os
+import sys
+import argparse
+import fnmatch
+import math
+from array import array
+import modules.ConfigReader as cfgr
+import modules.OutputManager as omng
+
+def findInFolder (folder, pattern):
+        ll = []
+        for ff in os.listdir(folder):
+            if fnmatch.fnmatch(ff, pattern): ll.append(ff)
+        if len (ll) == 0:
+            print "*** WARNING: No valid" , pattern , "found in " , folder
+            return None
+        if len (ll) > 1:
+            print "*** WARNING: Too many files found in " , folder , ", using first one : " , ll
+        return ll[0]
+
+
+
+def flatBinning(rootFile,namelist, var,sel,reg):
+    for name in namelist:
+        fullName = name + "_" + sel + "_" + reg + "_" + var
+        if not rootFile.GetListOfKeys().Contains(fullName):
+            print "*** WARNING: histo " , fullName , " not available"
+            continue
+        
+        if 'VBFC2V1' in name:
+            h = rootFile.Get(fullName)
+
+            nq = h.GetNbinsX()/2
+            xq = array('d', [0.] * nq)  
+            yq = array('d', [0.] * nq)  
+
+            for i in xrange(nq):
+                        xq[i] = float(i + 1) / nq
+                        
+            h.GetQuantiles(nq, yq, xq)
+            print yq
+            return yq
+
+def retrieveHistos (rootFile, namelist, var, sel, reg,flat,binning):
+    res = {}
+    for name in namelist:
+        fullName = name + "_" + sel + "_" + reg + "_" + var
+
+        if not rootFile.GetListOfKeys().Contains(fullName):
+            print "*** WARNING: histo " , fullName , " not available"
+            continue
+        h = rootFile.Get(fullName)
+    
+        if not args.flat:
+                res[name] = h
+        else:
+                hreb = h.Rebin(len(binning)-1,"hreb",binning) 
+                res[name] = hreb
+                        
+    return res
+                        
+def getHisto (histoName,inputList,doOverflow):
+        for idx, name in enumerate(inputList):
+                if (name.startswith(histoName) and name.endswith(histoName)):
+                        h = inputList[name].Clone (histoName)
+                        if doOverflow: h = addOverFlow(h)
+                        break
+
+        return h
+
+### QCD is special and has a strange name, need data to recontruct it
+### CORR_DDQCD_SS_DATA_HHKin_mass_SS_defaultBtagMMNoIsoBBTTCut_DsingleMuRunD
+#def retrieveQCD (rootFile, var, sel, dataNameList):
+#    name = "CORR_DDQCD_SS_DATA_" + var + "_SS_" + sel + "_" + dataNameList[-1]
+#    if not rootFile.GetListOfKeys().Contains(name):
+#        print "*** WARNING: QCD histo " , name , " not available"
+#        return None
+#    hQCD = rootFile.Get(name)
+#    return hQCD
+
+# makes an histogram by adding together all those in the input list ; inputList: names, histoList: histograms
+def makeStack (stackName, histoList):
+    s = THStack (stackName, stackName)
+    for h in histoList:
+        s.Add(h)
+    return s
+
+def makeSum (sumName, histoList):
+    for i,h in enumerate(histoList):
+        if i == 0: hsum = h.Clone(sumName)
+        else: hsum.Add(h)
+    return hsum
+
+def setPlotStyle ():
+    #Styles are: Plain Bold Video Pub Classic Default Modern
+    #Modern is the default one
+    #ss = gROOT.GetListOfStyles()
+    #for s in ss: sys.stdout.write(s.GetName() + " ")
+    
+    gROOT.SetStyle("Modern")
+    #LucaStyle = TStyle ("LucaStyle", "LucaStyle")
+    #LucaStyle
+
+# tranform an histo into a TGraphAsymmErrors, with 
+def makeTGraphFromHist (histo, newName):
+    nPoints  = hData.GetNbinsX()
+    fX       = []
+    fY       = []
+    feYUp    = []
+    feYDown  = []
+    feXRight = []
+    feXLeft  = []
+
+    for ibin in range (1, nPoints+1):
+        x = hData.GetBinCenter(ibin);
+        y = hData.GetBinContent(ibin);
+        dxRight = hData.GetBinLowEdge(ibin+1) - hData.GetBinCenter(ibin);
+        dxLeft  = hData.GetBinCenter(ibin) - hData.GetBinLowEdge(ibin);
+        dyUp    = hData.GetBinErrorUp(ibin);
+        dyLow   = hData.GetBinErrorLow(ibin);
+
+        #if (!drawGrass && (int) y == 0) continue;
+        fY.append(y)
+        fX.append(x)
+        feYUp.append(dyUp)
+        feYDown.append(dyLow)
+        feXRight.append(dxRight)
+        feXLeft.append(dxLeft)
+
+    afX       = array ("d", fX      )
+    afY       = array ("d", fY      )
+    afeYUp    = array ("d", feYUp   )
+    afeYDown  = array ("d", feYDown )
+    afeXRight = array ("d", feXRight)
+    afeXLeft  = array ("d", feXLeft )
+
+    gData = TGraphAsymmErrors (len(afX), afX, afY, afeXLeft, afeXRight, afeYDown, afeYUp);
+    gData.SetMarkerStyle(8);
+    gData.SetMarkerSize(1.);
+    gData.SetMarkerColor(kBlack);
+    gData.SetLineColor(kBlack);
+    gData.SetName(newName)
+    return gData;
+
+# set all horizontal bar errors to 0
+def removeHErrors (graph):
+    for ipt in range (0, graph.GetN()):
+        graph.SetPointEXlow(ipt, 0)
+        graph.SetPointEXhigh(ipt, 0)
+
+# remove all points with content = 0
+def removeEmptyPoints (graph):
+    zeroes = []
+    for ipt in range (0, graph.GetN()):
+        x = Double(0.0)
+        y = Double(0.0)
+        graph.GetPoint(ipt,x,y)
+        if y == 0:
+            zeroes.append(ipt)
+    for i in reversed (zeroes):
+        graph.RemovePoint(i)
+
+
+        
+def addOverFlow (histo):
+    dummy = TH1F ("tempo",histo.GetTitle (),histo.GetNbinsX () + 1, histo.GetXaxis ().GetXmin (),histo.GetXaxis ().GetXmax () + histo.GetBinWidth (1)) 
+
+    for iBin in range(1,histo.GetNbinsX () + 2):
+            dummy.SetBinContent (iBin, histo.GetBinContent (iBin)) 
+            dummy.SetBinError (iBin, histo.GetBinError (iBin)) 
+  
+
+    if(histo.GetDefaultSumw2()):
+           dummy.Sumw2 () 
+
+    name = histo.GetName () 
+    histo.SetName ("trash") 
+    if args.label:
+            dummy.GetXaxis().SetTitle(args.label)
+    else:
+            dummy.GetXaxis().SetTitle(args.var)
+    dummy.SetName (name) 
+    histo, dummy = dummy, histo
+    return histo
+
+
+
+
+
+
+def addOverAndUnderFlow ( histo):
+
+
+  histo.SetBinContent(histo.GetNbinsX(),histo.GetBinContent(histo.GetNbinsX())+histo.GetBinContent(histo.GetNbinsX()+1)); 
+  histo.SetBinContent(1,histo.GetBinContent(1)+histo.GetBinContent(0))
+  
+  if (histo.GetBinErrorOption() != TH1.kPoisson):
+    histo.SetBinError(histo.GetNbinsX(),sqrt(pow(histo.GetBinError(histo.GetNbinsX()),2)+pow(histo.GetBinError(histo.GetNbinsX()+1),2)))
+    histo.SetBinError(1,sqrt(pow(histo.GetBinError(1),2)+pow(histo.GetBinError(0),2)))  
+  
+
+  histo.SetBinContent(0,0)
+  histo.SetBinContent(histo.GetNbinsX()+1,0)
+  if (histo.GetBinErrorOption() != TH1.kPoisson):
+      histo.SetBinError(0,0)
+      histo.SetBinError(histo.GetNbinsX()+1,0)
+  
+
+        
+# NB!! need to be called BEFORE removeHErrors or cannot know bin width
+def scaleGraphByBinWidth (graph):
+    for ipt in range (0, graph.GetN()):
+        bwh = graph.GetErrorXhigh(ipt)
+        bwl = graph.GetErrorXlow(ipt)
+        bw = bwl + bwh
+
+        eyh = graph.GetErrorYhigh(ipt)
+        eyl = graph.GetErrorYlow(ipt)
+        x = Double(0.0)
+        y = Double(0.0)
+        graph.GetPoint (ipt, x, y)
+        graph.SetPoint (ipt, x, y/bw)
+        graph.SetPointEYlow(ipt, eyl/bw)
+        graph.SetPointEYhigh(ipt, eyh/bw)
+
+
+# Get the uncertainty band from BKG to be plotted in the ratio plot
+def makeMCUncertaintyBand (bkgSum):
+    nPoints = bkgSum.GetNbinsX()
+    fX       = []
+    fY       = []
+    feYUp    = []
+    feYDown  = []
+    feXRight = []
+    feXLeft  = []
+
+    for ibin in range (1, nPoints+1):
+        central = bkgSum.GetBinContent(ibin)
+        if central > 0:
+            fX.append      (bkgSum.GetBinCenter(ibin))
+            fY.append      (1.0)
+            feYUp.append   (bkgSum.GetBinErrorUp(ibin)  / central)
+            feYDown.append (bkgSum.GetBinErrorLow(ibin) / central)
+            feXRight.append(bkgSum.GetBinLowEdge(ibin+1) - bkgSum.GetBinCenter(ibin))
+            feXLeft.append (bkgSum.GetBinCenter(ibin) - bkgSum.GetBinLowEdge(ibin))
+
+    afX       = array ("d", fX      )
+    afY       = array ("d", fY      )
+    afeYUp    = array ("d", feYUp   )
+    afeYDown  = array ("d", feYDown )
+    afeXRight = array ("d", feXRight)
+    afeXLeft  = array ("d", feXLeft )
+    gBand = TGraphAsymmErrors (len(afX), afX, afY, afeXLeft, afeXRight, afeYDown, afeYUp);
+    return gBand;
+
+
+## do ratio of Data/MC
+# horErrs : do horizonta errors
+def makeDataOverMCRatioPlot (hData, hMC, newName, horErrs=False):
+    nPoints = hData.GetNbinsX()
+    fX       = []
+    fY       = []
+    feYUp    = []
+    feYDown  = []
+    feXRight = []
+    feXLeft  = []
+
+    for ibin in range (1, nPoints+1):
+        num = hData.GetBinContent(ibin)
+        den = hMC.GetBinContent(ibin)
+        if den > 0:
+            # Y
+            fY.append(num/den)
+            feYUp.append(hData.GetBinErrorUp(ibin) / den)
+            feYDown.append(hData.GetBinErrorLow(ibin) / den)
+
+            # X
+            fX.append (hData.GetBinCenter(ibin))
+            if horErrs:
+                feXRight.append(hData.GetBinLowEdge(ibin+1) - hData.GetBinCenter(ibin))
+                feXLeft.append(hData.GetBinCenter(ibin) - hData.GetBinLowEdge(ibin))
+            else:
+                feXLeft.append(0.0)
+                feXRight.append(0.0)
+
+    afX       = array ("d", fX      )
+    afY       = array ("d", fY      )
+    afeYUp    = array ("d", feYUp   )
+    afeYDown  = array ("d", feYDown )
+    afeXRight = array ("d", feXRight)
+    afeXLeft  = array ("d", feXLeft )
+    gRatio = TGraphAsymmErrors (len(afX), afX, afY, afeXLeft, afeXRight, afeYDown, afeYUp);
+    
+    gRatio.SetMarkerStyle(8);
+    gRatio.SetMarkerSize(1.);
+    gRatio.SetMarkerColor(kBlack);
+    gRatio.SetLineColor(kBlack);
+    gRatio.SetName(newName)
+
+    return gRatio;
+
+## find maximum of tgraph, including error
+def findMaxOfGraph (graph):
+    uppers = []
+    for i in range (0, graph.GetN()):
+        x = Double(0.0)
+        y = Double(0.0)
+        graph.GetPoint(i, x, y)
+        uppers.append (y + graph.GetErrorYhigh(i))
+    return max(uppers)
+
+# def makeSystUpDownStack (bkgList, systList, newNamePart):
+#     for i, name in bkgList:
+#         scale = systList[i] # error on nominal histo
+#         hUp = None   # the histograms with up/down syst
+#         hDown = None #
+#         if i == 0:
+#             hUp = bkgList[i].Clone (newNamePart + "_up")
+#             hDown = bkgList[i].Clone (newNamePart + "_up")
+#             hUp.Scale (1.0 + scale)
+#             hDown.Scale (1.0 - scale)
+#         else:
+#             hTempUp   = bkgList[i].Clone (newNamePart + "_tmp_up" + i)
+#             hTempDown = bkgList[i].Clone (newNamePart + "_tmp_up" + i)
+#             hTempUp.Scale (1.0 + scale)
+#             hTempDown.Scale (1.0 - scale)
+
+## remove negative bins and reset yield accordingly
+## NB: must be done BEFORE bin width division
+def makeNonNegativeHistos (hList):
+    for h in hList:
+        integral = h.Integral()
+        for b in range (1, h.GetNbinsX()+1):
+            if (h.GetBinContent(b) < 0):
+               h.SetBinContent (b, 0)
+        integralNew = h.Integral()        
+        if (integralNew != integral):
+            print "** INFO: removed neg bins from histo " , h.GetName() 
+        
+        # print h.GetName() , integral , integralNew
+        if integralNew == 0:
+            h.Scale(0)
+        else:
+            h.Scale(integral/integralNew) 
+
+
+### script body ###
+
+if __name__ == "__main__" :
+    TH1.AddDirectory(0)
+
+    titleSize = 24
+    labelSize = 22
+    # gStyle.SetLabelFont(43)
+    # gStyle.SetTitleFont(43)
+
+    parser = argparse.ArgumentParser(description='Command line parser of plotting options')
+    
+    #string opts
+    parser.add_argument('--var', dest='var', help='variable name', default=None)
+    parser.add_argument('--sel', dest='sel', help='selection name', default=None)
+    parser.add_argument('--name', dest='name', help='selection name for plot', default=None)
+    parser.add_argument('--dir', dest='dir', help='analysis output folder name', default="./")
+    parser.add_argument('--tag', dest='tag', help='plots output folder name', default="./")
+    parser.add_argument('--reg', dest='reg', help='region name', default=None)
+    parser.add_argument('--title', dest='title', help='plot title', default=None)
+    parser.add_argument('--label', dest='label', help='x label', default=None)
+    parser.add_argument('--channel', dest='channel', help='channel = (MuTau, ETau, TauTau)', default=None)
+    parser.add_argument('--siglegextratext', dest='siglegextratext', help='additional optional text to be plotted in legend after signal block', default=None)
+    
+    #bool opts
+    parser.add_argument('--log',     dest='log', help='use log scale',  action='store_true', default=False)
+    parser.add_argument('--no-data', dest='dodata', help='disable plotting data',  action='store_false', default=True)
+    parser.add_argument('--no-sig',  dest='dosig',  help='disable plotting signal',  action='store_false', default=True)
+    parser.add_argument('--no-legend',   dest='legend',   help = 'disable drawing legend',       action='store_false', default=True)
+    parser.add_argument('--no-binwidth', dest='binwidth', help = 'disable scaling by bin width', action='store_false', default=True)
+    parser.add_argument('--ratio',    dest='ratio', help = 'do ratio plot at the botton', action='store_true', default=False)
+    parser.add_argument('--no-print', dest='printplot', help = 'no pdf output', action='store_false', default=True)
+    parser.add_argument('--quit',    dest='quit', help = 'quit at the end of the script, no interactive window', action='store_true', default=False)
+    parser.add_argument('--overflow',    dest='overflow', help = 'add overflow bin', action='store_true', default=False)
+    parser.add_argument('--flat',    dest='flat', help = 'rebin getting flat signal', action='store_true', default=False)
+
+    # par list opt
+    parser.add_argument('--blind-range',   dest='blindrange', nargs=2, help='start and end of blinding range', default=None)
+
+    #float opt
+    parser.add_argument('--lymin', dest='lymin', type=float, help='legend min y position in pad fraction', default=None)
+    parser.add_argument('--ymin', dest='ymin', type=float, help='min y range of plots', default=None)
+    parser.add_argument('--ymax', dest='ymax', type=float, help='max y range of plots', default=None)
+    parser.add_argument('--sigscale', dest='sigscale', type=float, help='scale to apply to all signals', default=None)
+    parser.add_argument('--lumi', dest='lumi_num', type=float, help='lumi in fb-1', default=None)
+
+    
+    args = parser.parse_args()
+
+    if args.quit : gROOT.SetBatch(True)
+    
+    ######################### CANVASES #################################
+
+    c1 = TCanvas ("c1", "c1", 600, 600)
+    # c1.SetLeftMargin(0.15);
+    # c1.SetBottomMargin(0.12);
+    # c1.SetTopMargin(0.055);
+
+    pad1 = None
+    pad2 = None
+
+    if args.ratio:
+        pad1 = TPad ("pad1", "pad1", 0, 0.25, 1, 1.0)
+        pad1.SetFrameLineWidth(3)
+        pad1.SetLeftMargin(0.12);
+        pad1.SetBottomMargin(0.02);
+        pad1.SetTopMargin(0.055);
+        
+        pad1.Draw()
+    else:
+        pad1 = TPad ("pad1", "pad1", 0, 0.0, 1.0, 1.0)
+        pad1.SetFrameLineWidth(3)
+        pad1.SetLeftMargin(0.12);
+        pad1.SetBottomMargin(0.12);
+        pad1.SetTopMargin(0.055);
+        pad1.Draw()
+
+
+    pad1.cd()
+
+
+
+    ######################### PUT USER CONFIGURATION HERE ####################
+    cfgName  =  args.dir + "/mainCfg_"+args.channel+"_UL18.cfg"
+    cfg        = cfgr.ConfigReader (cfgName)
+    bkgList    = cfg.readListOption("general::backgrounds")
+
+    doQCD = True
+    if not "SR" in args.reg: doQCD = False
+    if not "Tau" in args.channel: doQCD = False
+    
+    if doQCD:
+        bkgList.append('QCD')
+    sigList = cfg.readListOption("general::signals")
+
+    #sigList = ["VBFC2V1","ggHH"]
+    #sigList = ["VBFRadion600","VBFRadion900","VBFRadion2000"]
+
+    sigNameList = []
+    if args.log:
+            #sigNameList = ["VBFC2V1","ggHH"]
+            #sigNameList = ["VBFRadion600","VBFRadion900","VBFRadion2000"]
+            sigNameList = ["VBF HH SM (x10)"]
+    else:
+           #sigNameList = ["VBFC2V1","ggHH (#times 0.1)"]
+           #sigNameList = ["VBFRadion600","VBFRadion900","VBFRadion2000"]
+           sigNameList = ["VBF HH SM (x10)"]
+
+    sigColors = {}
+    #sigColors["VBFC2V1"] = 2
+    #sigColors["ggHH"] = kCyan
+    #sigColors["VBFRadion600"]  = kBlack
+    #sigColors["VBFRadion900"]  = kBlue
+    #sigColors["VBFRadion2000"] = kCyan
+    sigColors["VBFSM"] = kBlack
+
+    bkgColors = {}
+    bkgLineColors = {}
+
+    #bkgColors["singleT"] = kOrange+10
+    #bkgColors["EWKW"] = kGreen+3
+    #bkgColors["VV"] = kViolet
+    #bkgColors["SM"] = kBlue+1
+    #bkgColors["DY"] = kGreen+1
+    #bkgColors["TT"] =  kOrange+1
+    #bkgColors["WJets"] = kAzure-2
+    #bkgColors["other"] = kCyan+1
+
+    # RGB/HEX colors
+    col = TColor()
+    hex_color_strings = ["#d08770", "#a3be8c",
+                         "#b48ead", "#ebcb8b",
+                         "#2e3440", "#5e81ac", "#FF731D",
+                         "#BB6464", "#bf616a","#11324D"]
+    #bkgColors["DY"] = col.GetColor("#A3BE8C") #(TColor(68 ,186,104)).GetNumber() #gROOT.GetColor("#44BA68")
+    #bkgColors["TT"]    = col.GetColor("#F4B642") #(TColor(244,182,66 )).GetNumber() #gROOT.GetColor("#F4B642")
+    #bkgColors["TTV"]    = col.GetColor("#BF616A") #(TColor(244,182,66 )).GetNumber() #gROOT.GetColor("#F4B642")
+    #bkgColors["TTVV"]    = col.GetColor("#D08770") #(TColor(244,182,66 )).GetNumber() #gROOT.GetColor("#F4B642")
+    #bkgColors["VV"]    = col.GetColor("#b48ead") #(TColor(244,182,66 )).GetNumber() #gROOT.GetColor("#F4B642")
+    #bkgColors["W"] = col.GetColor("#B1AFFF") #(TColor(65 ,180,219)).GetNumber() #gROOT.GetColor("#41B4DB")
+    #bkgColors["EWK"] = col.GetColor("#EBCB8B") #(TColor(65 ,180,219)).GetNumber() #gROOT.GetColor("#41B4DB")
+    #bkgColors["single top"] = col.GetColor("#000000") #(TColor(65 ,180,219)).GetNumber() #gROOT.GetColor("#41B4DB")
+    ##bkgColors["other"] = col.GetColor("#ED635E") #(TColor(237,99 ,94 )).GetNumber() #gROOT.GetColor("#ED635E")
+
+    #bkgLineColors["DY"] = col.GetColor("#A3BE8C") #(TColor(68 ,186,104)).GetNumber() #gROOT.GetColor("#44BA68")
+    #bkgLineColors["TT"]    = col.GetColor("#F4B642") #(TColor(244,182,66 )).GetNumber() #gROOT.GetColor("#F4B642")
+    #bkgLineColors["TTV"]    = col.GetColor("#BF616A") #(TColor(244,182,66 )).GetNumber() #gROOT.GetColor("#F4B642")
+    #bkgLineColors["TTVV"]    = col.GetColor("#D08770") #(TColor(244,182,66 )).GetNumber() #gROOT.GetColor("#F4B642")
+    #bkgLineColors["VV"]    = col.GetColor("#b48ead") #(TColor(244,182,66 )).GetNumber() #gROOT.GetColor("#F4B642")
+    #bkgLineColors["W"] = col.GetColor("#B1AFFF") #EBCB8B") #(TColor(65 ,180,219)).GetNumber() #gROOT.GetColor("#41B4DB")
+    #bkgColors["EWK"] = col.GetColor("#EBCB8B") #(TColor(65 ,180,219)).GetNumber() #gROOT.GetColor("#41B4DB")
+    #bkgColors["single top"] = col.GetColor("#000000") #(TColor(65 ,180,219)).GetNumber() #gROOT.GetColor("#41B4DB")
+    #bkgLineColors["other"] = col.GetColor("#d85a56")
+
+
+    #if args.sigscale:
+    #     for i in range(0,len(sigScale)): sigScale[i] = args.sigscale
+    sigScale = [10]
+
+    plotTitle = ""
+
+    if args.title:
+        plotTitle = args.title
+    dataList = ["data_obs"]
+
+
+    if cfg.hasSection("merge"): 
+        for i, groupname in enumerate(cfg.config['merge']):
+            if "data" in groupname: continue
+            mergelist = cfg.readListOption('merge::'+groupname)
+            for x in mergelist:
+                bkgList.remove(x)
+            bkgList.append(groupname)
+
+
+   
+
+
+    ###########################################################################
+    #setPlotStyle()
+
+
+    outplotterName = findInFolder  (args.dir+"/", 'analyzedOutPlotter.root')
+    
+
+    #    if not "Tau" in args.channel:
+    #           outplotterName = findInFolder  (args.dir+"/", 'outPlotter.root')            
+ 
+    rootFile = TFile.Open (args.dir+"/"+outplotterName)
+
+    binning = None
+    if (args.flat): binning = flatBinning(rootFile, sigList, args.var, args.sel,args.reg)
+
+    
+    hSigs = retrieveHistos (rootFile, sigList, args.var, args.sel,args.reg,args.flat,binning)
+    hBkgs = retrieveHistos  (rootFile, bkgList, args.var, args.sel,args.reg,args.flat,binning)
+
+    hDatas = retrieveHistos  (rootFile, dataList, args.var, args.sel,args.reg,args.flat,binning)
+
+
+    
+    xsecRatio = 19.56
+    if not args.log: xsecRatio = xsecRatio/float(10)
+    #sigScale = [1. , xsecRatio*hSigs["ggHH"].GetEntries()/float(hSigs["VBFC2V1"].GetEntries())]
+
+            
+    doOverflow = args.overflow
+    
+
+    hBkgList = []
+    hBkgNameList = []
+    for idx, bkgd in enumerate(bkgList):
+        #if not "QCD" in bkgd:
+        hBkgList.append(getHisto(bkgd, hBkgs, doOverflow))
+        if 'TT' in bkgd:
+            name = bkgd.replace('TT', 't#bar{t}')
+            hBkgNameList.append(name)
+        else:
+            hBkgNameList.append(bkgd)
+        bkgColors[bkgd] = col.GetColor(hex_color_strings[idx])
+        bkgLineColors[bkgd] = col.GetColor(hex_color_strings[idx])
+
+
+    #hDY = getHisto("DY_NLO", hBkgs,doOverflow)
+    #hTT = getHisto("TT", hBkgs,doOverflow)
+    #hTTV = getHisto("TTV", hBkgs,doOverflow)
+    #hTTVV = getHisto("TTVV", hBkgs,doOverflow)
+    #hW = getHisto("W", hBkgs,doOverflow)
+    #hsingleT = getHisto("singleT", hBkgs,doOverflow)
+    #hEWKW = getHisto("EWK", hBkgs,doOverflow)
+    #hVV = getHisto("VV", hBkgs,doOverflow)
+    #hSM = getHisto("SM", hBkgs,doOverflow)
+
+    #hBkgList = [hothers, hSM, hVV, hEWKW, hsingleT, hWJets, hTT, hDY] ## full list for stack
+    #hBkgList = [hW, hTT, hDY, hTTV, hTTVV, hsingleT,hEWKW,hVV ] ## full list for stack
+    #hBkgList = [hVV, hEWKW, hsingleT, hWJets, hTT, hDY] ## full list for stack
+    #hBkgList = [hsingleT, hTT, hDY]
+
+    #hBkgNameList = ["Others","SM Higgs", "VV", "EWK", "Single top", "W + jets", "t#bar{t}","DY + jets"] # list for legend
+    #hBkgNameList = ["W","t#bar{t}", "DY + jets", "t#bar{t} V", "t#bar{t} VV", "single top", "EWK", "VV"] # list for legend
+    #hBkgNameList = ["VV", "EWK", "single top", "W + jets", "t#bar{t}","DY + jets"] # list for legend
+    #hBkgNameList = ["Single top", "t#bar{t}", "DY + jets"]
+
+    #if cfg.hasSection('pp_QCD'):
+    #if doQCD:
+    #    hQCD    = getHisto ("QCD", hBkgs,doOverflow)
+    #    hQCD.SetName("QCD")
+    #    hBkgList.append(hQCD)
+    #    hBkgNameList.append("QCD")
+    #    #bkgColors["QCD"] = kPink+5
+    #    bkgColors["QCD"] = col.GetColor("#5e81ac") #(TColor(65 ,180,219)).GetNumber() #gROOT.GetColor("#41B4DB")
+    #    bkgLineColors["QCD"] = col.GetColor("#5e81ac") #DC885A")
+
+
+    hData = getHisto("data_obs", hDatas , doOverflow).Clone("hData")
+
+    # remove all data from blinding region before creating tgraph etc...
+    if args.blindrange:
+        blow = float (args.blindrange[0]) 
+        bup = float (args.blindrange[1]) 
+        for ibin in range (1, hData.GetNbinsX()+1):
+            center = hData.GetBinCenter(ibin)
+            if center > blow and center < bup:
+                hData.SetBinContent(ibin, 0)
+
+
+    hDataNonScaled = hData.Clone("hDataNonScaled")
+    gData = makeTGraphFromHist (hData, "grData")
+
+
+
+
+    # apply sig color if available
+    for key in hSigs:
+        hSigs[key].SetLineWidth(2)
+        if doOverflow: hSigs[key] = addOverFlow(hSigs[key])
+        if key in sigColors:
+            thecolor = int(sigColors[key])
+            hSigs[key].SetLineColor(thecolor)
+
+
+    # apply bkg color if available
+    for h in hBkgList:
+            histoname =h.GetName()
+            for key,value in bkgColors.items():
+                if key == histoname:    
+                        thecolor = int(bkgColors[key])
+                        h.SetFillColor(thecolor)
+                        h.SetFillStyle(1001)
+
+    # apply bkg lines colors if available
+    for h in hBkgList:
+        histoname = h.GetName()
+        for key,value in bkgLineColors.items():
+            if key == histoname:
+                thecolor = int(bkgLineColors[key])
+                h.SetLineColor(thecolor)
+                h.SetLineWidth(1)
+
+            
+    #################### REMOVE NEGARIVE BINS #######################
+    print "** INFO: removing all negative bins from bkg histos"
+    makeNonNegativeHistos (hBkgList)
+
+    for h in hBkgList: print "Integral ", h.GetName(), " : ", h.Integral(), " - ", h.Integral(-1,-1)
+    for n in hDatas: print "Integral ", hDatas[n].GetName(), " : ", hDatas[n].Integral(), " - ", hDatas[n].Integral(-1,-1)
+    #################### PERFORM DIVISION BY BIN WIDTH #######################
+    #clones non scaled (else problems with graph ratio because I pass data evt hist)
+    bkgStackNS = makeStack ("bkgStackNS", hBkgList)
+    hBkgEnvelopeNS = bkgStackNS.GetStack().Last().Clone("hBkgEnvelopeNS")
+
+    if args.binwidth:
+        scaleGraphByBinWidth (gData)
+        for h in hBkgList:
+            h.Scale(1., "width")
+        for i, name in enumerate (sigNameList):
+            histo = hSigs[sigList[i]]
+            histo.Scale(1., "width")
+
+
+    #################### DO STACK AND PLOT #######################
+
+    bkgStack = makeStack ("bkgStack", hBkgList)
+    bkgSum = makeSum ("bkgSum", hBkgList)
+    
+    
+    if args.log: pad1.SetLogy()
+
+
+    ################## TITLE AND AESTETICS ############################
+    bkgStack.Draw("HIST")
+
+    bkgStack.GetXaxis().SetTitleFont(43)
+    bkgStack.GetYaxis().SetTitleFont(43)
+    bkgStack.GetXaxis().SetLabelFont(43)
+    bkgStack.GetYaxis().SetLabelFont(43)
+
+    bkgStack.GetXaxis().SetTitleOffset(1.0)
+    bkgStack.GetYaxis().SetTitleOffset(1.4)
+
+    bkgStack.GetXaxis().SetTitleSize(titleSize)
+    bkgStack.GetYaxis().SetTitleSize(titleSize)
+
+    bkgStack.GetXaxis().SetLabelSize(labelSize)
+    bkgStack.GetYaxis().SetLabelSize(labelSize)
+
+    if args.label: bkgStack.GetXaxis().SetTitle (args.label)
+    else: bkgStack.GetXaxis().SetTitle (args.var)
+
+    width = ((bkgStack.GetXaxis().GetXmax() - bkgStack.GetXaxis().GetXmin())/bkgStack.GetStack().Last().GetNbinsX())
+    ylabel = "Events/%.1f" % width
+    if args.label:
+        if "GeV" in args.label: ylabel +=" GeV"
+    bkgStack.GetYaxis().SetTitle(ylabel)
+    
+    #intBkg = bkgStack.GetHistogram().Integral()
+    intBkg = bkgStack.GetStack().Last().Integral()
+    bkgStack.SetTitle(plotTitle)
+
+
+    for key in hSigs:
+        intSig = hSigs[key].Integral()
+        if intSig > 0:
+                hSigs[key].Scale(intBkg/intSig)
+
+    # apply sig scale
+    for i, scale in enumerate (sigScale):
+        histo = hSigs[sigList[i]]
+        histo.Scale(scale)
+                
+    ################## LEGEND ######################################
+
+    legmin = 0.45
+    if args.lymin: legmin = args.lymin
+    legminx = 0.50
+    if (len(hBkgNameList) +len(hSigs)>6): legminx = 0.4
+    leg = TLegend (legminx, legmin, 0.85, 0.93)
+    if (len(hBkgNameList) +len(hSigs)> 6): leg.SetNColumns(2)
+    leg.SetFillStyle(0)
+    leg.SetBorderSize(0)
+    leg.SetTextFont(43)
+    leg.SetTextSize(20)
+
+    # add element in same order as stack --> top-bottom
+    for i, name in reversed(list(enumerate(hBkgNameList))):
+        leg.AddEntry(hBkgList[i], name, "f")
+
+    if args.dosig:
+        #for i, name in enumerate (sigNameList):
+        for i, name in reversed(list(enumerate (sigNameList))):
+            histo = hSigs[sigList[i]]
+            leg.AddEntry (histo, name, "l")
+        # null entry to complete signal Xsection
+        if args.siglegextratext:
+            leg.AddEntry(None, args.siglegextratext, "")
+
+    if args.dodata:
+        leg.AddEntry(gData, "Data", "pe")
+
+
+    ################## Y RANGE SETTINGS ############################
+    ymin = 0
+    if args.log: ymin = 0.1
+
+    maxs = []
+    
+    # bkgmax = 0
+    # for h in hBkgList: bkgmax+= h.GetMaximum()
+    # maxs.append(bkgmax)
+    maxs.append(bkgStack.GetStack().Last().GetMaximum())
+
+    if args.dodata:
+        maxs.append(findMaxOfGraph(gData))
+        #if not args.binwidth:
+        #    maxs.append(hData.GetMaximum() + math.sqrt(hData.GetMaximum()))
+        
+    if args.dosig :
+        for key in hSigs: maxs.append(hSigs[key].GetMaximum())
+
+    ymax = max(maxs)
+
+    # scale max to leave some space (~10%)
+    extraspace = 0.3
+
+    if not args.log:
+        ymax += extraspace* (ymax-ymin)
+    
+    else:
+        new = extraspace * (math.log(ymax, 10) - math.log(ymin, 10)) + math.log(ymax, 10)
+        ymax = math.pow(10, new)
+
+
+    #print "limits: " , ymin, ymax
+
+    ## override form args
+    if args.ymin: ymin = args.ymin
+    if args.ymax: ymax = args.ymax
+
+    bkgStack.SetMinimum(ymin)
+    bkgStack.SetMaximum(ymax)
+
+    # interactive display
+    bkgStack.Draw("HIST")
+    bkgSum.SetFillColor(kGray+2);
+    bkgSum.SetFillStyle(3002);
+    bkgSum.Draw("e2 same")
+    if args.dosig:
+        for key in hSigs: hSigs[key].Draw("hist same")
+    if args.dodata:
+        removeHErrors(gData)
+        removeEmptyPoints(gData)
+        gData.Draw("P Z same") # Z: no small line at the end of error bar
+
+    ###################### OTHER TEXT ON PLOT #########################
+
+    # extraText = "preliminary"
+    # CMStext = "CMS"
+
+    cmsTextFont     = 61  # font of the "CMS" label
+    cmsTextSize   = 0.05  # font size of the "CMS" label
+    extraTextFont   = 52     # for the "preliminary"
+    extraTextSize   = 0.76 * cmsTextSize # for the "preliminary"
+
+
+    
+    t = gPad.GetTopMargin()
+    b = gPad.GetBottomMargin()
+    l = gPad.GetLeftMargin()
+    r = gPad.GetRightMargin()       
+    #yoffset = 0.05 # fractional shift   
+
+    CMSbox       = TLatex  (l , 1 - t + 0.02, "CMS")       
+    extraTextBox = TLatex  (l + 0.1 , 1 - t + 0.02,"Preliminary")
+    CMSbox.SetNDC()
+    extraTextBox.SetNDC()
+    CMSbox.SetTextSize(cmsTextSize)
+    CMSbox.SetTextFont(cmsTextFont)
+    CMSbox.SetTextColor(kBlack)
+    CMSbox.SetTextAlign(11)
+    extraTextBox.SetTextSize(extraTextSize)
+    extraTextBox.SetTextFont(extraTextFont)
+    extraTextBox.SetTextColor(kBlack)
+    extraTextBox.SetTextAlign(11)
+
+    x = 0
+    y = 0
+    #    histoWidth = histo.GetXaxis().GetBinWidth(1)*histo.GetXaxis().GetNbins()
+    #    histoHeight = histo.GetMaximum()-histo.GetMinimum()
+ 
+
+    lumi = "%.1f fb^{-1} (13 TeV)" % args.lumi_num
+    lumibox = TLatex  (1-r, 1 - t + 0.02 , lumi)       
+    lumibox.SetNDC()
+    lumibox.SetTextAlign(31)
+    lumibox.SetTextSize(extraTextSize)
+    lumibox.SetTextFont(42)
+    lumibox.SetTextColor(kBlack)
+
+    if args.channel:
+        if args.channel == "MuTau":
+            chName = "bb #mu#tau_{h}"
+        elif args.channel == "ETau":
+            chName = "bb e#tau_{h}"
+        elif args.channel == "TauTau":
+            chName = "bb #tau_{h}#tau_{h}"
+        elif args.channel == "MuMu":
+            chName = "bb #mu#mu"
+        else:
+            print "*** Warning: channel name must be MuTau, ETau, TauTau, you wrote: " , args.channel
+
+        if chName:
+            chBox = TLatex  (l + 0.04 , 1 - t - 0.02, chName)
+            chBox.SetNDC()
+            chBox.SetTextSize(cmsTextSize+20)
+            chBox.SetTextFont(43)
+            chBox.SetTextColor(kBlack)
+            chBox.SetTextAlign(13)
+            
+    CMSbox.Draw()
+    extraTextBox.Draw()
+    lumibox.Draw()
+    
+    if args.legend: leg.Draw()
+    if chBox: chBox.Draw()
+
+
+    if not args.name:
+            if "baseline" in args.sel:  
+                    selName = "baseline"
+            if "1b1j" in args.sel:  
+                    selName = "1b1j"
+            if "2b0j" in args.sel:  
+                    selName = "2b0j"
+            if "VBFloose" in args.sel:
+                    selName = "VBF loose"
+            if "GGFclass" in args.sel:
+                    selName = "VBF - GGF mpp"
+            if "VBFclass" in args.sel:
+                    selName = "VBF - VBF mpp"
+            if "TTlepclass" in args.sel:
+                    selName = "VBF - TTlep mpp"
+            if "TThadclass" in args.sel:
+                    selName = "VBF - TThad mpp"
+            if "ttHclass" in args.sel:
+                    selName = "VBF - ttH mpp"
+            if "DYclass" in args.sel:
+                    selName = "VBF - DY mpp"
+    else:
+            selName = args.name
+
+    selBox = TLatex  (l + 0.04 , 1 - t - 0.02 - 0.06, selName)
+    selBox.SetNDC()
+    selBox.SetTextSize(cmsTextSize+20)
+    selBox.SetTextFont(43)
+    selBox.SetTextColor(kBlack)
+    selBox.SetTextAlign(13)
+    selBox.Draw()
+    
+    ###################### BLINDING BOX ###############################
+    if args.blindrange:
+        blow = float(args.blindrange[0])
+        bup = float(args.blindrange[1])
+        bBox = TBox (blow, ymin, bup, 0.93*ymax)
+        bBox.SetFillStyle(3002) # NB: does not appear the same in displayed box and printed pdf!!
+        bBox.SetFillColor(kGray+2) # NB: does not appear the same in displayed box and printed pdf!!
+        bBox.Draw()
+
+
+    ###################### RATIO PLOT #################################
+    if args.ratio:
+        bkgStack.GetXaxis().SetTitleSize(0.00);
+        bkgStack.GetXaxis().SetLabelSize(0.00);
+
+        c1.cd()
+        pad2 = TPad ("pad2", "pad2", 0, 0.0, 1, 0.2496)
+        pad2.SetLeftMargin(0.12);
+        pad2.SetTopMargin(0.02);
+        pad2.SetBottomMargin(0.4);
+        pad2.SetGridy(True);
+        pad2.SetFrameLineWidth(3)
+        #pad2.SetGridx(True);
+        pad2.Draw()
+        pad2.cd()
+
+        grRatio = makeDataOverMCRatioPlot (hDataNonScaled, hBkgEnvelopeNS, "grRatio")
+        hRatio = hDataNonScaled.Clone("hRatioAxis") # for ranges only
+        grUncert = makeMCUncertaintyBand (bkgSum) # uncertainty band from MC, always centered at 1.0
+
+        hRatio.GetXaxis().SetTitleFont(43) # so that size is in pixels
+        hRatio.GetYaxis().SetTitleFont(43) # so that size is in pixels
+        hRatio.GetXaxis().SetLabelFont(43) # so that size is in pixels
+        hRatio.GetYaxis().SetLabelFont(43) # so that size is in pixels
+        hRatio.GetYaxis().SetNdivisions(505)
+
+        #hRatio.GetXaxis().SetTitle(bkgStack.GetXaxis().GetName())
+        hRatio.SetTitle(plotTitle)
+        hRatio.GetYaxis().SetTitle ("Data/Bkg.") #("Data/MC")
+        if args.label: hRatio.GetXaxis().SetTitle (args.label)
+        else: hRatio.GetXaxis().SetTitle (args.var)
+        hRatio.GetXaxis().SetTitleOffset(3.9)
+        hRatio.GetYaxis().SetTitleOffset(1.2)
+
+        hRatio.GetXaxis().SetTitleSize(titleSize);
+        hRatio.GetXaxis().SetLabelSize(labelSize);
+        hRatio.GetYaxis().SetTitleSize(titleSize);
+        hRatio.GetYaxis().SetLabelSize(labelSize);
+
+        hRatio.GetXaxis().SetTickSize(0.10)
+        hRatio.GetYaxis().SetTickSize(0.05)
+
+        hRatio.SetStats(0)
+        # hRatio.SetMinimum(0.5)
+        # hRatio.SetMaximum(1.5)
+        hRatio.SetMinimum(0.1)
+        hRatio.SetMaximum(1.9)
+
+        removeEmptyPoints (grRatio)
+        hRatio.Draw("axis")
+        
+        grRatio.Draw("P Z same") # Z : no small limes at the end of points
+        xmin =hRatio.GetXaxis().GetXmin()
+        xmax = hRatio.GetXaxis().GetXmax()
+        l1 = TLine(xmin, 1, xmax, 1)
+        l1.SetLineColor(kRed)
+        l1.SetLineStyle(4)
+        l1.SetLineWidth(1)
+        l1.Draw("same")
+
+        grUncert.SetFillColor(kGray+2)
+        grUncert.SetFillStyle(3002)
+        grUncert.Draw("e2")
+
+        pad2.RedrawAxis();
+        pad2.RedrawAxis("g"); #otherwise no grid..
+    ###################### DISPLAY ###################################
+    if not args.quit:
+        # pad1.Update() # necessary to show plot
+        # pad2.Update() # necessary to show plot
+        c1.Update()
+        pad1.Update()
+        if pad2: pad2.Update()
+        raw_input() # to prevent script from closing
+
+    if args.printplot:
+        tagch = ""
+        if args.channel:
+            tagch = "_" + args.channel
+        saveName = "./"+args.tag+"/"+args.sel+"_"+args.reg+"/plot_" + args.var + "_" + args.sel +"_" + args.reg+ tagch
+
+        if args.log:
+            saveName = saveName+"_log"
+        if args.flat:
+            saveName = saveName+"_flat"    
+        c1.SaveAs (saveName+".pdf")
+        c1.SaveAs (saveName+".png")

--- a/scripts/makePlots_lxplus.py
+++ b/scripts/makePlots_lxplus.py
@@ -1,0 +1,105 @@
+from argparse import ArgumentParser
+import os
+import sys
+from subprocess import Popen, PIPE
+
+import modules.ConfigReader as cfgr
+
+def make_parser():
+    parser = ArgumentParser(
+        description="Run the plotter for all variables.")
+    parser.add_argument("-t", "--tag", type=str, 
+    help="Tag used in main_cfg") 
+    parser.add_argument("-c", "--channel", type=str, 
+    help="TauTau or MuTau or ETau")
+    parser.add_argument("-l", "--lumi", type=float, 
+    help="Lumi. Should match the one from main cfg.")
+    parser.add_argument("-r", "--region", type=str,
+    help="for example: SR")
+    parser.add_argument("-s", "--selection", type=str,
+    default="baseline", help="Selection.")
+    parser.add_argument("-o", "--others", type=str, 
+    default="--quit --ratio --no-sig",
+    help="Plotting Arguments provided at the end of the plotter call.")
+    return parser
+
+
+def main(tag, channel, lumi, region, selection, others):
+    cfgName = tag + "/mainCfg_"+ channel+"_UL18.cfg"
+    cfg = cfgr.ConfigReader (cfgName)
+    variables = cfg.readListOption("general::variables")
+    outdir = "./"+tag+"/"+selection+"_"+region
+    if not os.path.exists("./"+tag):
+        raise ValueError("{} does not exist. \
+Make sure you pass the tag that was also used \
+in submitHistoFiller.py --tag <tag>".format("./"+tag))
+    if not os.path.exists(outdir):
+        print("{} does not exist.".format(outdir))
+        print("Creating it now.")
+        os.makedirs(outdir)
+    # defing what the daughter particles are
+    daughter_dict = {"tautau": ('#tau_{h1}','#tau_{h2}'),
+                     "mutau": ("#mu", "#tau_{h}"),
+                     "etau": ("e", "#tau_{h}")}
+    obj1, obj2 = daughter_dict[channel.lower()] 
+    label_suffixes = {
+        'pt': " p_{T} [GeV]",
+        'mass': " M [GeV]",
+        'eta': " #eta",
+        'deltaR': " #DeltaR"
+    }
+    label_prefixes = {
+        "dau1": obj1, 
+        "dau2": obj2,
+        "tauH": "H_{#tau#tau}",
+        "bH": "H_{bb}",
+        "ditau": "#tau#tau",
+        "bjet1": "b_{1}",
+        "bjet2": "b_{2}",
+        "HH": "HH"
+    } 
+    for var in variables:
+        cmd = "python scripts/makeFinalPlots_lxplus.py --dir "+tag
+        cmd += " --var "+var+" --reg "+region+" --sel "+selection
+        cmd += " --channel "+channel+" --lymin 0.7 --lumi "+str(lumi)
+        cmd += " --tag "+tag
+        try:
+            label = label_prefixes[var.split('_')[0]]
+            label += label_suffixes[var.split('_')[-1]]
+        except KeyError:
+            label = var
+        cmd += " --label \"{}\"".format(label)
+        cmd += " "+others
+        cmd_log = cmd + " --log"
+        print("Now running: {}".format(cmd_log))
+        prcs = Popen(cmd_log, 
+                    stderr=PIPE, stdout=PIPE, shell=True,)
+        out, err = prcs.communicate()
+        print("Now running: {}".format(cmd))
+        prcs = Popen(cmd, 
+                        stderr=PIPE, stdout=PIPE, shell=True,)
+        out, err = prcs.communicate()
+        #if err:
+        #    print("There were the following errors:")
+        #    print(err)
+        #    print("Stdout:")
+        #    print(out)
+        #else:
+        #    print(out)
+
+
+if __name__ == "__main__":
+    parser = make_parser()
+    args = parser.parse_args()
+    main(tag=args.tag,
+         channel=args.channel,
+         lumi=args.lumi,
+         region=args.region,
+         selection=args.selection,
+         others=args.others)
+        
+        
+
+
+
+#python scripts/$plotter --dir /data_CMS/cms/amendola/analysisLegacy2018/analysis_$channel\_$tag --var dau1_pt         --reg $reg --sel $baseline --channel $channel --lymin 0.7 --lumi $lumi    --tag $tag --label "${obj1} p_{T} [GeV]"  $others 

--- a/scripts/submitHistoFiller_lxplus.py
+++ b/scripts/submitHistoFiller_lxplus.py
@@ -1,0 +1,147 @@
+import os
+import sys
+import argparse
+
+
+write = lambda stream, text: stream.write(text + '\n')
+
+
+def make_parser():
+    parser = argparse.ArgumentParser(description='Command line parser of plotting options')
+    parser.add_argument('--outdir', type=str, dest="outdir", required=True,
+                        help='/afs/directory/to/submit/from. Must be afs\
+    because condor submission is only allowed from /afs on lxplus.')
+    parser.add_argument('--cfg', dest='cfg', required=True,
+                        help='name of the main cfg to run', default=None)
+    parser.add_argument('--tag', dest='tag', required=True, default=None,
+                        help='name of working space')
+    parser.add_argument('--njobs', dest='njobs', required=False, type=int,
+                        help='number of jobs for parallelization', default=10)
+    return parser
+
+
+def create_dir(d):
+    if not os.path.exists(d):
+        print("{} does not exist. Creating now".format(d))
+        os.makedirs(d)
+
+
+def write_filler_executable(scriptpath, exe, cfg, njobs):
+    with open(scriptpath, 'w') as s:
+        write(s,'#!/bin/bash')
+        write(s,'export X509_USER_PROXY=~/Condor/x509up_u149480')
+        write(s,'source /cvmfs/cms.cern.ch/cmsset_default.sh')
+        write(s,'cd {} || exit 1'.format(os.getcwd()))
+        write(s,'export SCRAM_ARCH=slc6_amd64_gcc491')
+        write(s,'eval `scram r -sh`')
+        write(s,'source scripts/setup.sh')
+        command = (exe + ' ' + cfg + ' ${1}' + ' ' + str(njobs))
+        write(s,command)
+        os.system('chmod u+rwx {}'.format(scriptpath))
+    
+
+def write_submit_file(submit_file, executable, out_dir, err_dir):
+    with open(submit_file, 'w') as s:
+        write(s,'Universe = vanilla')
+        write(s,'Executable = {}'.format(executable))
+        write(s,'input = /dev/null')
+        write(s,'output = {}/$(ClusterId)$(ProcId).out'.format(out_dir))
+        write(s,'error  = {}/$(ClusterId)$(ProcId).err'.format(err_dir))
+        write(s,'getenv = true')
+        write(s,'+JobFlavour = \"longlunch\"')
+        write(s,'+SingularityCmd = ""')
+        write(s,'Arguments = $(NAME) ')
+        write(s,'queue') 
+
+
+def write_postscript(postscript, tag,):
+    with open(postscript, 'w') as ps:
+        write(ps,'#!/bin/bash')
+        write(ps,'export X509_USER_PROXY=~/Condor/x509up_u149480')
+        write(ps,'source /cvmfs/cms.cern.ch/cmsset_default.sh')
+        write(ps,'cd {} || exit 1'.format(os.getcwd()))
+        write(ps,'export SCRAM_ARCH=slc6_amd64_gcc491')
+        write(ps,'eval `scram r -sh`')
+        write(ps,'source scripts/setup.sh')
+        write(ps,'cd {} || exit 1'.format(tag))
+        write(ps,'hadd outPlotter.root *.root')
+        write(ps,'cd - || exit 1')
+        write(ps,'python scripts/combineFillerOutputs.py --dir {}'.format(tag))
+        os.system('chmod u+rwx ' + postscript)
+
+
+def write_postscript_submit(submit_file, executable, out_dir, err_dir):
+    with open(submit_file, 'w') as s:
+        write(s,'Universe = vanilla')
+        write(s,'Executable = {}'.format(executable))
+        write(s,'input = /dev/null')
+        write(s,'output = {}/post.out'.format(out_dir))
+        write(s,'error  = {}/post.err'.format(err_dir))
+        write(s,'getenv = true')
+        write(s,'queue') 
+
+def write_dagfile(dagfile, njobs, submit_file, postscript_submit):
+    with open(dagfile, 'w') as dag:
+        for job in range(njobs):
+            write(dag, 'JOB {} {}'.format(job, submit_file))
+            write(dag, 'VARS {} NAME=\"{}\"'.format(job, job))
+        write(dag, 'JOB Cleanup {}'.format(postscript_submit))
+        children = ' '.join([str(i) for i in range(njobs)])
+        write(dag, 'PARENT {} CHILD Cleanup'.format(children))
+
+#hourdate = datetime.datetime.now().strftime('%Y.%m.%d_%H.%M.%S').replace('.','-')
+
+def main():
+    parser = make_parser()
+    args = parser.parse_args()
+    outdir = args.outdir
+    exe = 'testAnalysisHelper.exe'
+    condor_executable = 'filler.sh'
+
+    # check if outdir exists
+    if os.path.exists(outdir):
+        print("{} already exists. Checking if it's empty.".format(outdir))
+        contents = os.listdir(outdir)
+        if len(contents) > 0:
+            print("{} contains the following :".format(outdir))
+            for i in contents:
+                print(i)
+            print("Please remove these or use a different tag!")
+            sys.exit(1)
+        
+    create_dir(outdir)
+    condor_out = os.path.join(outdir, 'out')
+    create_dir(condor_out)
+    condor_err = os.path.join(outdir, 'err')
+    create_dir(condor_err)
+
+    scriptpath = os.path.join(outdir, condor_executable)
+    write_filler_executable(scriptpath=scriptpath,
+                            exe=exe,
+                            cfg=args.cfg,
+                            njobs=args.njobs)
+    submit_file_path = os.path.join(outdir, 'filler.submit')
+    write_submit_file(submit_file=submit_file_path,
+                      executable=scriptpath,
+                      out_dir=condor_out,
+                      err_dir=condor_err)
+    postscript_path = os.path.join(outdir, 'postscript.sh')
+    write_postscript(postscript=postscript_path, tag=args.tag)
+    postscript_submit_path = os.path.join(outdir, 'postscript.submit')
+    write_postscript_submit(submit_file=postscript_submit_path,
+                            executable=postscript_path,
+                            out_dir=condor_out,
+                            err_dir=condor_err)
+    dagfile = os.path.join(outdir, 'filler.dag')
+    write_dagfile(dagfile=dagfile,
+                  njobs=args.njobs,
+                  submit_file=submit_file_path,
+                  postscript_submit=postscript_submit_path)
+
+
+if __name__ == "__main__":
+    main()
+    #os.chdir(condor_dir)
+    #launch_command = 'condor_submit {}'.format(scriptpath_condor)
+    #print('The following command was run: {}'.format(launch_command))
+    #os.system(launch_command)


### PR DESCRIPTION
The relevant added scripts are:

1. ./scripts/makeFinalPlots_lxplus.py
2. ./scripts/makePlots_lxplus.py
3. ./scripts/submitHistoFiller_lxplus.py

## ./scripts/makeFinalPlots_lxplus.py

./scripts/makeFinalPlots_lxplus.py is very close to ./scripts/makeFinalPlots.py. Only a few arguments are changed and the color scheme is adapted. The backgrounds are now added directly from the provided main.cfg: ([link](https://github.com/JohanWulff/KLUBAnalysis/blob/a0dd4e9a04ac0363d850eccdcc26572ff9f4f726/scripts/makeFinalPlots_lxplus.py#L434))
```
    ######################### PUT USER CONFIGURATION HERE ####################
    cfgName  =  args.dir + "/mainCfg_"+args.channel+"_UL18.cfg"
    cfg        = cfgr.ConfigReader (cfgName)
    bkgList    = cfg.readListOption("general::backgrounds")
```
and the backgrounds don't have to be added to the hist by hand: ([link](https://github.com/JohanWulff/KLUBAnalysis/blob/a0dd4e9a04ac0363d850eccdcc26572ff9f4f726/scripts/makeFinalPlots_lxplus.py#L558))
```
    hBkgList = []
    hBkgNameList = []
    for idx, bkgd in enumerate(bkgList):
        #if not "QCD" in bkgd:
        hBkgList.append(getHisto(bkgd, hBkgs, doOverflow))
        if 'TT' in bkgd:
            name = bkgd.replace('TT', 't#bar{t}')
            hBkgNameList.append(name)
        else:
            hBkgNameList.append(bkgd)
        bkgColors[bkgd] = col.GetColor(hex_color_strings[idx])
        bkgLineColors[bkgd] = col.GetColor(hex_color_strings[idx])
```

## ./scripts/makePlots_lxplus.py

instead of makeFinalPlots.sh the plotting is handled by makePlots_lxplus.py

It takes the tag, channel, lumi, region (for example: SR), selection (baseline) as arguments.
Instead of having to comment out a bunch of pre-existing plotting commands, the script constructs the commands from the arguments and the main.cfg.
The cfg could also be added to the arguments. Right now it's hard-coded to work with ./configs/mainCfg_<channel>_UL18.cfg.

## ./scripts/submitHistoFiller_lxplus.py

This script prepares the submission of the histogram filling. It's adopted from submitHistoFiller.py. The fact that on lxplus one can only submit from /afs is handled by taking the directory to submit from as an argument (--outdir). Jobs are now created in a [filller.dag](https://github.com/JohanWulff/KLUBAnalysis/blob/a0dd4e9a04ac0363d850eccdcc26572ff9f4f726/scripts/submitHistoFiller_lxplus.py#L83) file that submits #n_jobs jobs. These jobs are parents of a [postscript.sh](https://github.com/JohanWulff/KLUBAnalysis/blob/a0dd4e9a04ac0363d850eccdcc26572ff9f4f726/scripts/submitHistoFiller_lxplus.py#L57) that takes care of 
`hadd outPlotter.root outPlotter*.root`
and runs `python scripts/combineFillerOutputs.py --dir {}'.format(tag)`

@portalesHEP 