### PR TITLE
Remove problematic source ➕ Add user option

### DIFF
--- a/scripts/makeListOnStorage.py
+++ b/scripts/makeListOnStorage.py
@@ -19,7 +19,7 @@ def make_input_lists(args):
                 'uhh': 'root://dcache-cms-xrootd.desy.de:1094/',
                 'mib': '???'}[args.institute]
 
-    store = {'llr': 'store/user/lportale/HHNtuples_res',
+    store = {'llr': 'store/user/' + args.user + '/HHNtuples_res',
              'uhh': '???',
              'mib': '???'}[args.institute]
     store    = op.join(store, args.data_period)
@@ -37,9 +37,8 @@ def make_input_lists(args):
     awk    = "| awk '{{print $9}}'"
     rfcomm = lambda s : rfdir + ' {} '.format(s) + awk
     pipe   = Popen(rfcomm(path), shell=True, stdout=PIPE)
-
     all_lists = {}
-     
+
     for smpl_name in pipe.stdout:
         smpl_path = op.join(path, smpl_name).strip()    
         if args.sample not in smpl_name and args.sample != 'all':
@@ -66,7 +65,6 @@ def make_input_lists(args):
             final_dir = op.join(smpl_path, subfold.strip())
             str_comm = '{} | grep HTauTauAnalysis'
             file_comm = rfcomm( str_comm.format(final_dir.strip()) )
-
             out = Popen(file_comm, shell=True, stdout=PIPE).stdout.readlines()
             for filename in out:
                 name = xrd_door + op.join(final_dir, filename.strip())
@@ -94,6 +92,8 @@ if __name__ == "__main__":
                         help='Tag used for the input big ntuples')
     parser.add_argument('-d', '--data_period', dest='data_period', required=True, type=str,
                         help='Which data period to choose: Legacy2018, UL18, ...')
+    parser.add_argument('-u', '--user', dest='user', required=True, type=str,
+                        help='User who produced the input data')
     parser.add_argument('-x', '--institute', dest='institute', default='llr',
                         choices=('llr', 'uhh', 'mib'),
                         required=False, type=str, help='Which set of machines to use: LLR, Hamburg or Milano.')

--- a/scripts/skimNtuple.py
+++ b/scripts/skimNtuple.py
@@ -52,21 +52,20 @@ def parse_input_file_list(indir, insample):
                 filelist.append(line)
     return filelist
 
-def write_condor_file(d, shell_exec, c_exec, py_exec, queue, var='Process'):
+def write_condor_file(d, condor_name, shell_exec, c_exec, py_exec, queue, qvars):
         condouts = os.path.join(d, 'logs')
         create_dir(condouts)
-        paths = {'out': '{}/{{}}.out'.format(condouts),
-                 'err': '{}/{{}}.err'.format(condouts),
-                 'log': '{}/{{}}.log'.format(condouts)}
-        proc = '$(Process)'
-        condor_name = shell_exec.replace('.sh','.condor')
+        paths = {'out': '{}/$({{}}){{}}.out'.format(condouts),
+                 'err': '{}/$({{}}){{}}.err'.format(condouts),
+                 'log': '{}/$({{}}){{}}.log'.format(condouts)}
+
         with open(condor_name, 'w') as s:
             s.write( '\n'.join(('Universe = vanilla',
                                 'Executable = {}'.format(shell_exec),
                                 'input = {}'.format(c_exec),
-                                'output = ' + paths['out'].format(proc),
-                                'error = ' + paths['err'].format(proc),
-                                'log = ' + paths['log'].format(proc),
+                                'output = ' + paths['out'].format(qvars[0],qvars[1]),
+                                'error = ' + paths['err'].format(qvars[0],qvars[1]),
+                                'log = ' + paths['log'].format(qvars[0],qvars[1]),
                                 'getenv = true',
                                 '+JobBatchName="{}"'.format(FLAGS.sample),
                                 'should_transfer_files = YES',
@@ -78,15 +77,17 @@ def write_condor_file(d, shell_exec, c_exec, py_exec, queue, var='Process'):
                                 '',
                                 'include : /opt/exp_soft/cms/t3/t3queue |',
                                 '',
-                                'Arguments = $({})'.format(var),
-                                'queue {}'.format(queue))) + '\n' )
-        return paths, condor_name
+                                'Arguments = $({}) {}'.format(qvars[0], qvars[1]))) + '\n' )
+            s.write(queue + '\n')
+
+        return condouts
 
 def skim_ntuple(FLAGS, curr_folder):
-    arg1 = '${1}'
+    arg1, arg2 = '${1}', '${2}'
     io_names = ( '{}.txt'.format(arg1),
                  'output_{}.root'.format(arg1),
-                 '{}.log'.format(arg1) )
+                 '{}{}.log'.format(arg1,arg2) )
+    py_exec = 'scripts/check_outputs.py'
 
     if FLAGS.config == 'none':
         print('Config file missing, exiting')
@@ -116,43 +117,52 @@ def skim_ntuple(FLAGS, curr_folder):
 
     create_dir(jobs_dir)
     job_name_shell = os.path.join(jobs_dir, 'job.sh')
-    remove_file(job_name_shell)
+    if not FLAGS.resub:
+        remove_file(job_name_shell)
+    condor_name = job_name_shell.replace('.sh', '.condor')
 
-    # verify the result of the process
-    if (FLAGS.resub != 'none'):
-        if (FLAGS.input_folder == 'none'):
-            print('Input folder to be checked missing')
-            print('(this is the folder that contains the jobs to be submitted)')
-            sys.exit(1)
+    if FLAGS.resub:
+        rcount = 0
+        nsplit = condor_name.split('.')
+        while os.path.exists(condor_name):
+            rcount += 1
+            condor_name = nsplit[0] + '_resub' + str(rcount) + '.' + nsplit[1]
 
-        if FLAGS.input_folder[-1] == '/' :
-            FLAGS.input_folder = FLAGS.input_folder[:-1]
-        tagname = FLAGS.tag + "/" if FLAGS.tag else ''
-        FLAGS.input_folder = tagname + 'SKIM_' + os.path.basename(FLAGS.input_folder)
+        regex = re.compile('.*output_(.+)\.root')
+        failed = []
 
-        # check the log file
-        missing = []
-        for num in jobs:
-            rootfile = os.path.join(jobs_dir, io_names[1].replace(arg1, num))
-            logfile = os.path.join(jobs_dir, io_names[2].replace(arg1, num))
-            if not is_job_sucessful(rootfile, logfile):
-                missing.append(num)
+        badfiles_folder = os.path.join(FLAGS.output, FLAGS.sample)
+        glob_badfiles = glob.glob(os.path.join(badfiles_folder, 'bad*.txt'))
+        if len(glob_badfiles)==0:
+            sys.exit(0)
 
-        print('The following jobs did not end successfully:')
-        print(missing)
+        badfiles_recent = max(glob_badfiles, key=os.path.getctime)
+        badfiles = os.path.join(FLAGS.output, FLAGS.sample, badfiles_recent)
 
-        str_queue = 'afile from (\n'
-        for mis in missing:
-            str_queue += '  {}\n'.format(str(mis))
-        str_queue += '\n'
-        _, condor_name = write_condor_file(d=jobs_dir, shell_exec=job_name_shell,
-                                           queue=str_queue, var='afile')
+        with open(badfiles, 'r') as badf:
+            for line in badf.readlines():
+                fail = line
+                finded = regex.findall(line)
+                assert len(finded)==1
+                failed.append(finded[0])
+
+        queue_vars = 'Item', '_resub' + str(rcount)
+        queue = 'queue {} from (\n'.format(queue_vars[0])
+        queue += '\n'.join(failed)
+        queue += '\n)'
+        
+        write_condor_file(d=jobs_dir, condor_name=condor_name,
+                          shell_exec=job_name_shell,
+                          c_exec=FLAGS.exec_file,
+                          py_exec=py_exec,
+                          queue=queue, qvars=queue_vars)
             
         launch_command = 'condor_submit {}'.format(condor_name)
         if FLAGS.verb:
             print('Resubmission with: {}'.format(launch_command))
+        print('Resubmission with: {}'.format(launch_command))
+        os.system(launch_command)
         time.sleep(0.5)
-        #os.system(launch_command)
         sys.exit(0)
 
     # submit the jobs
@@ -168,7 +178,7 @@ def skim_ntuple(FLAGS, curr_folder):
         raise ValueError(mes)
     nfiles_per_job = [ div if i >= mod else div+1 for i in range(njobs)]
     assert sum(nfiles_per_job) == nfiles
-
+ 
     accumulate = lambda l : [sum(l[:y]) for y in range(1, len(l)+1)]
     inputlists = [ inputfiles[x-y:x] for x,y in zip(accumulate(nfiles_per_job), nfiles_per_job) ]
     assert len(inputlists) == njobs
@@ -177,7 +187,7 @@ def skim_ntuple(FLAGS, curr_folder):
     mes = ( '{} jobs will be scheduled for {} files.'
             .format(njobs,len(inputfiles),nfiles_per_job) )
     print(mes)
-
+ 
     lists_dir = os.path.join(jobs_dir, 'filelists')
     create_dir(lists_dir)
     for ij,listname in enumerate(inputlists):
@@ -185,13 +195,11 @@ def skim_ntuple(FLAGS, curr_folder):
         with open(os.path.join(lists_dir, list_file_name), 'w') as input_list_file:
             for line in listname:
                 input_list_file.write(line + '\n')
-
-    py_exec = 'scripts/check_outputs.py'
-    cpaths, cname = write_condor_file(d=jobs_dir,
-                                      shell_exec=job_name_shell,
-                                      c_exec=FLAGS.exec_file,
-                                      py_exec=py_exec,
-                                      queue=str(njobs))
+ 
+    clog = write_condor_file(d=jobs_dir, condor_name=condor_name,
+                             shell_exec=job_name_shell, c_exec=FLAGS.exec_file,
+                             py_exec=py_exec,
+                             queue='queue ' + str(njobs), qvars=('Process',''))
 
     with open(job_name_shell, 'w') as s:
         s.write( '\n'.join(('#!/usr/bin/env bash',
@@ -203,7 +211,7 @@ def skim_ntuple(FLAGS, curr_folder):
                             'source scripts/setup.sh')) + '\n' )
                 
         yes_or_no = lambda s : '1' if bool(s) else '0'
-        
+
         command, comment = double_join(FLAGS.exec_file,
                                        os.path.join(lists_dir, io_names[0]),
                                        os.path.join(jobs_dir, io_names[1]),
@@ -244,15 +252,15 @@ def skim_ntuple(FLAGS, curr_folder):
         # we need to check them 'live', i.e., while the job is running
         livedir = os.path.join(jobs_dir, 'live_logs')
         create_dir(livedir)
-        local_out = os.path.join(livedir, '{}.out'.format(arg1))
-        local_err = os.path.join(livedir, '{}.err'.format(arg1))
+        local_out = os.path.join(livedir, '{}{}.out'.format(arg1,arg2))
+        local_err = os.path.join(livedir, '{}{}.err'.format(arg1,arg2))
         s.write(command + ' 1>{} 2>{}\n'.format(local_out, local_err))
         
-        command, comment = double_join('python {}'.format(py_exec),
+        command, comment = double_join('python3 {}'.format(py_exec),
                                        '-r ' + os.path.join(jobs_dir, io_names[1]),
                                        '-o ' + local_out,
                                        '-e ' + local_err,
-                                       '-l ' + cpaths['log'].format(arg1),
+                                       '-l ' + os.path.join(clog, '{}{}.log'.format(arg1,arg2)),
                                        '-v ')
 
         s.write(comment + '\n')
@@ -278,7 +286,7 @@ def skim_ntuple(FLAGS, curr_folder):
         s.write('echo "Job with id '+arg1+' completed."\n')
         os.system('chmod u+rwx {}'.format(job_name_shell))
  
-    launch_command = 'condor_submit {}'.format(cname)
+    launch_command = 'condor_submit {}'.format(condor_name)
 
     time.sleep(0.1)
     print('The following command was run: \n  {}'.format(launch_command))
@@ -291,19 +299,19 @@ if __name__ == "__main__":
     parser.add_argument('--exec_file', dest='exec_file', required=True, help='folder where the C++ skimmer executable is stored')
     parser.add_argument('--sample', dest='sample', default='none', help='input sample')
     parser.add_argument('-Y', '--year', dest='year', default='2018', help='year', choices=['2016', '2017', '2018'])
-    parser.add_argument('-A', '--APV', dest='isAPV', default=False, help='isAPV')
+    parser.add_argument('-A', '--APV', dest='isAPV', default=0, type=int, help='isAPV')
     parser.add_argument('-x', '--xs', dest='xs', help='sample xs', default='1.')
     parser.add_argument('-o', '--output', dest='output', default='none', help='output folder')
     parser.add_argument('-q', '--queue', dest='queue', default='short', help='batch queue')
-    parser.add_argument('-r', '--resub', dest='resub', default='none', help='resubmit failed jobs')
-    parser.add_argument('-v', '--verb', dest='verb', default=False, help='verbose')
-    parser.add_argument('-d', '--isdata', dest='isdata', default=False, help='data flag')
+    parser.add_argument('-r', '--resub', dest='resub', action='store_true', help='resubmit failed jobs')
+    parser.add_argument('-v', '--verb', dest='verb', default=0, type=int, help='verbose')
+    parser.add_argument('-d', '--isdata', dest='isdata', default=0, type=int, help='data flag')
     parser.add_argument('-T', '--tag', dest='tag', default='', help='folder tag name')
     parser.add_argument('-H', '--hadd', dest='hadd', default='none', help='hadd the resulting ntuples')
     parser.add_argument('-c', '--config', dest='config', default='none', help='skim config file')
     parser.add_argument('-n', '--njobs', dest='njobs', default=100, type=int, help='number of skim jobs')
-    parser.add_argument('-k', '--kinfit', dest='dokinfit', default='True', help='run HH kin fitter')
-    parser.add_argument('-m', '--mt2', dest='domt2', default=True, help='run stransverse mass calculation')
+    parser.add_argument('-k', '--kinfit', dest='dokinfit', default=1, type=int, help='run HH kin fitter')
+    parser.add_argument('-m', '--mt2', dest='domt2', default=1, type=int, help='run stransverse mass calculation')
     parser.add_argument('-y', '--xsscale', dest='xsscale', default='1.0',
                         help='scale to apply on XS for stitching')
     parser.add_argument('-Z', '--htcutlow', dest='htcutlow', default='-999.0',
@@ -312,13 +320,13 @@ if __name__ == "__main__":
                         help='HT cut for stitching on inclusive')
     parser.add_argument('-e', '--njets', dest='njets', default='-999',
                         help='njets required for stitching on inclusive')
-    parser.add_argument('-t', '--toprew', dest='toprew', default=False,
+    parser.add_argument('-t', '--toprew', dest='toprew', default=0, type=int,
                         help='is TT bar sample to compute reweight?')
     parser.add_argument('-b', '--topstitch' , dest='topstitch' , default='0',
                         help='type of TT gen level decay pruning for stitch')
-    parser.add_argument('-g', '--genjets', dest='genjets', default=False,
+    parser.add_argument('-g', '--genjets', dest='genjets', default=0, type=int,
                         help='loop on genjets to determine the number of b hadrons')
-    parser.add_argument('-a', '--ishhsignal', dest='ishhsignal', default=False, help='isHHsignal')
+    parser.add_argument('-a', '--ishhsignal', dest='ishhsignal', default=0, type=int, help='isHHsignal')
     parser.add_argument('--BSMname', dest='BSMname', default='none', help='additional name for EFT benchmarks')
     parser.add_argument('--EFTbm', dest='EFTrew', default='none',
                         help='EFT benchmarks [SM, 1..12, 1b..7b, 8a, c2scan, manual]')
@@ -334,13 +342,14 @@ if __name__ == "__main__":
     parser.add_argument('--pu', dest='PUweights', default='none', help='name of susy model to select')
     parser.add_argument('--nj', dest='DY_nJets', default='-1', help='number of gen Jets for DY bins')
     parser.add_argument('--nb', dest='DY_nBJets', default='-1', help='number of gen BJets for DY bins')
-    parser.add_argument('--DY', dest='DY', default=False, help='if it is a DY sample')
-    parser.add_argument('--ttHToNonBB', dest='ttHToNonBB', default=False,
+    parser.add_argument('--DY', dest='DY', default=0, type=int, help='if it is a DY sample')
+    parser.add_argument('--ttHToNonBB', dest='ttHToNonBB', default=0, type=int,
                         help='if it is a ttHToNonBB sample')
     parser.add_argument('--hhNLO', dest='hhNLO', default=False, action='store_true',
                         help='if it is an HH NLO sample')
     parser.add_argument('--doSyst', dest='doSyst', default=False, action='store_true',
                         help='compute up/down values of outputs')
+
 
     FLAGS = parser.parse_args()
     curr_folder = os.getcwd()

--- a/scripts/submit_skims_UL18.sh
+++ b/scripts/submit_skims_UL18.sh
@@ -7,7 +7,7 @@ STITCHING_ON="0"
 DRYRUN="0"
 RESUBMIT="0"
 OUT_TAG=""
-KLUB_TAG="Jan2023"
+IN_TAG="Jan2023"
 DATA_PERIOD="UL18"
 DATA_USER="${USER}"
 DATA_PERIOD_CHOICES=( "UL16" "UL17" "UL18" )
@@ -17,25 +17,25 @@ HELP_STR="Prints this help message."
 DRYRUN_STR="(Boolean) Prints all the commands to be launched but does not launch them. Defaults to ${DRYRUN}."
 RESUBMIT_STR="(Boolean) Resubmits failed jobs listed in 'badfiles.txt'"
 OUT_TAG_STR="(String) Defines tag for the output. Defaults to '${OUT_TAG}'."
-KLUB_TAG_STR="(String) Chooses tag for the klub input. Defaults to '${KLUB_TAG}'."
+IN_TAG_STR="(String) Chooses tag for the input (big ntuples). Defaults to '${IN_TAG}'."
 STITCHING_ON_STR="(Boolean) Drell-Yan stitching weights will be used. Defaults to ${STITCHING_ON}."
 NO_LISTS_STR="(Boolean) Whether to run the list production script before each submission. Defaults to ${NO_LISTS}."
 DATAPERIOD_STR="(String) Which data period to consider: Legacy18, UL18, ... Defaults to '${DATA_PERIOD}'."
 DATAUSER_STR="(String) Which user produced the data. Defaults to '${DATA_USER}'."
 function print_usage_submit_skims {
-    USAGE=" $(basename "$0") [-H] [--dry-run --resubmit -t -d -n -u --klub_tag --stitching_on]
+    USAGE=" $(basename "$0") [-H] [--dry-run --resubmit -t -d -n -u --in_tag --stitching_on]
 
 	-h / --help			[ ${HELP_STR} ]
 	--dry-run			[ ${DRYRUN_STR} ]
 	--resubmit			[ ${RESUBMIT_STR} ]
 	-t / --tag			[ ${OUT_TAG_STR} ]
-	--klub_tag			[ ${KLUB_TAG_STR} ]
+	--in_tag			[ ${IN_TAG_STR} ]
 	-s / --stitching_on [ ${STITCHING_ON_STR} ]
 	-n / --no_lists     [ ${NO_LISTS_STR} ]
 	-d / --data_period  [ ${DATAPERIOD_STR} ]
 	-u / --user         [ ${DATAUSER_STR} ]
 
-    Run example: bash $(basename "$0") -t <some_tag> --klub_tag <input_tag>
+    Run example: bash $(basename "$0") -t <some_tag> --in_tag <input_tag>
 "
     printf "${USAGE}"
 }
@@ -59,8 +59,8 @@ while [[ $# -gt 0 ]]; do
 	    OUT_TAG=${2}
 	    shift; shift;
 	    ;;
-	--klub_tag)
-	    KLUB_TAG=${2}
+	--in_tag)
+	    IN_TAG=${2}
 	    shift; shift;
 	    ;;
 	-s|--stitching)
@@ -119,8 +119,8 @@ if [ ${#VOMS_CHECK[@]} -eq 0 ]; then
 fi
 
 LIST_DIR=${LIST_DIR}"HHNtuples_res/"${DATA_PERIOD}"/"
-LIST_DATA_DIR=${LIST_DIR}"Data_"${KLUB_TAG}
-LIST_MC_DIR=${LIST_DIR}"MC_"${KLUB_TAG}
+LIST_DATA_DIR=${LIST_DIR}"Data_"${IN_TAG}
+LIST_MC_DIR=${LIST_DIR}"MC_"${IN_TAG}
 #declare -a LISTS_DATA=( $(/usr/bin/rfdir ${LIST_DATA_DIR} | awk '{{printf $9" "}}') )
 declare -a LISTS_MC=(   $(/usr/bin/rfdir ${LIST_MC_DIR}   | awk '{{printf $9" "}}') )
 
@@ -181,7 +181,7 @@ printf "DRYRUN\t\t\t= ${DRYRUN}\n"
 printf "RESUBMIT\t\t= ${RESUBMIT}\n"
 printf "NO_LISTS\t\t= ${NO_LISTS}\n"
 printf "OUT_TAG\t\t\t= ${OUT_TAG}\n"
-printf "KLUB_TAG\t\t= ${KLUB_TAG}\n"
+printf "IN_TAG\t\t= ${IN_TAG}\n"
 printf "STITCHING_ON\t\t= ${STITCHING_ON}\n"
 printf "DATA_PERIOD\t\t= ${DATA_PERIOD}\n"
 printf "DATA_USER\t\t= ${DATA_USER}\n"
@@ -205,7 +205,7 @@ function run_skim() {
 
 ### Input file list production command
 function produce_list() {
-	comm="python ${KLUB_DIR}/${LIST_SCRIPT} -t ${KLUB_TAG} --data_period ${DATA_PERIOD} --user ${DATA_USER} $@"
+	comm="python ${KLUB_DIR}/${LIST_SCRIPT} -t ${IN_TAG} --data_period ${DATA_PERIOD} --user ${DATA_USER} $@"
 	if [[ ${RESUBMIT} -eq 0 ]]; then
 		[[ ${DRYRUN} -eq 1 ]] && echo ${comm} || ${comm}
 	fi

--- a/scripts/submit_skims_UL18.sh
+++ b/scripts/submit_skims_UL18.sh
@@ -162,15 +162,15 @@ fi
 
 mkdir -p ${SKIM_DIR}
 OUTSKIM_DIR=${SKIM_DIR}/${TAG_DIR}/
-# if [ -d ${OUTSKIM_DIR} ] && [[ ${RESUBMIT} -eq 0 ]]; then
-# 	echo "Directory ${OUTSKIM_DIR} already exists."
-# 	echo "If you want to resubmit some jobs, add the '--resubmit' flag."
-# 	echo "If not, you might want to remove the directory with: 'rm -r ${OUTSKIM_DIR}'."
-# 	echo "Exiting."
-# 	exit 1
-# else
-# 	mkdir -p ${OUTSKIM_DIR}
-# fi
+if [ -d ${OUTSKIM_DIR} ] && [[ ${RESUBMIT} -eq 0 ]]; then
+	echo "Directory ${OUTSKIM_DIR} already exists."
+	echo "If you want to resubmit some jobs, add the '--resubmit' flag."
+	echo "If not, you might want to remove the directory with: 'rm -r ${OUTSKIM_DIR}'."
+	echo "Exiting."
+	exit 1
+else
+	mkdir -p ${OUTSKIM_DIR}
+fi
 ERR_FILE=${OUTSKIM_DIR}"/bad_patterns.o"
 
 
@@ -238,6 +238,7 @@ function find_sample() {
 		echo ${mes}
 		return 1
 	fi
+	echo ${sample}
 }
 
 ### Run on data samples

--- a/scripts/submit_skims_UL18.sh
+++ b/scripts/submit_skims_UL18.sh
@@ -1,34 +1,41 @@
 #!/usr/bin/env bash
+(return 0 2>/dev/null) && echo "This script must be run, not sourced. Try './' or 'bash'" && return 1
 
 ### Defaults
 NO_LISTS="0"
 STITCHING_ON="0"
 DRYRUN="0"
+RESUBMIT="0"
 OUT_TAG=""
-KLUB_TAG="Jul2022"
+KLUB_TAG="Jan2023"
 DATA_PERIOD="UL18"
+DATA_USER="${USER}"
 DATA_PERIOD_CHOICES=( "UL16" "UL17" "UL18" )
 
 ### Argument parsing
 HELP_STR="Prints this help message."
 DRYRUN_STR="(Boolean) Prints all the commands to be launched but does not launch them. Defaults to ${DRYRUN}."
+RESUBMIT_STR="(Boolean) Resubmits failed jobs listed in 'badfiles.txt'"
 OUT_TAG_STR="(String) Defines tag for the output. Defaults to '${OUT_TAG}'."
 KLUB_TAG_STR="(String) Chooses tag for the klub input. Defaults to '${KLUB_TAG}'."
 STITCHING_ON_STR="(Boolean) Drell-Yan stitching weights will be used. Defaults to ${STITCHING_ON}."
 NO_LISTS_STR="(Boolean) Whether to run the list production script before each submission. Defaults to ${NO_LISTS}."
 DATAPERIOD_STR="(String) Which data period to consider: Legacy18, UL18, ... Defaults to '${DATA_PERIOD}'."
+DATAUSER_STR="(String) Which user produced the data. Defaults to '${DATA_USER}'."
 function print_usage_submit_skims {
-    USAGE=" $(basename "$0") [-H] [--dry-run -t -d -n --klub_tag --stitching_on]
+    USAGE=" $(basename "$0") [-H] [--dry-run --resubmit -t -d -n -u --klub_tag --stitching_on]
 
 	-h / --help			[ ${HELP_STR} ]
 	--dry-run			[ ${DRYRUN_STR} ]
+	--resubmit			[ ${RESUBMIT_STR} ]
 	-t / --tag			[ ${OUT_TAG_STR} ]
 	--klub_tag			[ ${KLUB_TAG_STR} ]
-    -s / --stitching_on [ ${STITCHING_ON_STR} ]
-    -n / --no_lists     [ ${NO_LISTS_STR} ]
-    -d / --data_period  [ ${DATAPERIOD_STR} ]
+	-s / --stitching_on [ ${STITCHING_ON_STR} ]
+	-n / --no_lists     [ ${NO_LISTS_STR} ]
+	-d / --data_period  [ ${DATAPERIOD_STR} ]
+	-u / --user         [ ${DATAUSER_STR} ]
 
-    Run example: bash $(basename "$0") -t <some_tag>
+    Run example: bash $(basename "$0") -t <some_tag> --klub_tag <input_tag>
 "
     printf "${USAGE}"
 }
@@ -42,6 +49,10 @@ while [[ $# -gt 0 ]]; do
 	    ;;
 	--dry-run)
 	    DRYRUN="1"
+	    shift;
+	    ;;
+	--resubmit)
+	    RESUBMIT="1"
 	    shift;
 	    ;;
 	-t|--tag)
@@ -71,6 +82,10 @@ while [[ $# -gt 0 ]]; do
 		fi
 	    shift; shift;
 	    ;;
+	-u|--user)
+	    DATA_USER=${2}
+	    shift; shift;
+	    ;;
 	*)  # unknown option
 	    echo "Wrong parameter ${1}."
 	    exit 1
@@ -86,7 +101,7 @@ KLUB_DIR="$( cd "$( dirname ${THIS_DIR} )" && pwd )"
 EXEC_FILE="${KLUB_DIR}/bin"
 SUBMIT_SCRIPT="scripts/skimNtuple.py"
 LIST_SCRIPT="scripts/makeListOnStorage.py"
-LIST_DIR="/dpm/in2p3.fr/home/cms/trivcat/store/user/lportale/"
+LIST_DIR="/dpm/in2p3.fr/home/cms/trivcat/store/user/bfontana/"
 
 if [ ${DATA_PERIOD} == "UL16" ]; then
 	EXEC_FILE="${EXEC_FILE}/skimNtuple2016_HHbtag.exe"
@@ -96,16 +111,17 @@ elif [ ${DATA_PERIOD} == "UL18" ]; then
 	EXEC_FILE="${EXEC_FILE}/skimNtuple2018_HHbtag.exe"
 fi
 
-### Check if the voms command was run
-declare -a VOMS_CHECK=( $(/usr/bin/rfdir ${LIST_DIR} | awk '{{printf $9" "}}') )
+### Check if the voms command was runs
+declare -a VOMS_CHECK=( $(/usr/bin/rfdir ${LIST_DIR} 2>/dev/null | awk '{{printf $9" "}}') )
 if [ ${#VOMS_CHECK[@]} -eq 0 ]; then
 	echo "Folder ${LIST_DIR} seems empty. Are you sure you run 'voms-proxy-init -voms cms'?"
+	exit 1
 fi
 
 LIST_DIR=${LIST_DIR}"HHNtuples_res/"${DATA_PERIOD}"/"
 LIST_DATA_DIR=${LIST_DIR}"Data_"${KLUB_TAG}
 LIST_MC_DIR=${LIST_DIR}"MC_"${KLUB_TAG}
-declare -a LISTS_DATA=( $(/usr/bin/rfdir ${LIST_DATA_DIR} | awk '{{printf $9" "}}') )
+#declare -a LISTS_DATA=( $(/usr/bin/rfdir ${LIST_DATA_DIR} | awk '{{printf $9" "}}') )
 declare -a LISTS_MC=(   $(/usr/bin/rfdir ${LIST_MC_DIR}   | awk '{{printf $9" "}}') )
 
 SKIM_DIR="/data_CMS/cms/${USER}/HHresonant_SKIMS"
@@ -137,7 +153,7 @@ if [[ -z ${OUT_TAG} ]]; then
     else
 		echo "No tags are currently available. Everything looks clean!"
     fi
-    exit 1;
+    return 1;
 fi
 if [[ -z ${DATA_PERIOD} ]]; then
 	echo "Select the data period via the '--d / --data_period' option."
@@ -146,14 +162,15 @@ fi
 
 mkdir -p ${SKIM_DIR}
 OUTSKIM_DIR=${SKIM_DIR}/${TAG_DIR}/
-if [ -d ${OUTSKIM_DIR} ]; then
-	echo "Directory ${OUTSKIM_DIR} already exists."
-	echo "You might want to remove it with: 'rm -r ${OUTSKIM_DIR}'."
-	echo "Exiting."
-	exit 1
-else
-	mkdir -p ${OUTSKIM_DIR}
-fi
+# if [ -d ${OUTSKIM_DIR} ] && [[ ${RESUBMIT} -eq 0 ]]; then
+# 	echo "Directory ${OUTSKIM_DIR} already exists."
+# 	echo "If you want to resubmit some jobs, add the '--resubmit' flag."
+# 	echo "If not, you might want to remove the directory with: 'rm -r ${OUTSKIM_DIR}'."
+# 	echo "Exiting."
+# 	exit 1
+# else
+# 	mkdir -p ${OUTSKIM_DIR}
+# fi
 ERR_FILE=${OUTSKIM_DIR}"/bad_patterns.o"
 
 
@@ -161,11 +178,13 @@ ERR_FILE=${OUTSKIM_DIR}"/bad_patterns.o"
 echo "------ Arguments --------------"
 echo " Passed by the user:"
 printf "DRYRUN\t\t\t= ${DRYRUN}\n"
+printf "RESUBMIT\t\t= ${RESUBMIT}\n"
 printf "NO_LISTS\t\t= ${NO_LISTS}\n"
 printf "OUT_TAG\t\t\t= ${OUT_TAG}\n"
 printf "KLUB_TAG\t\t= ${KLUB_TAG}\n"
-printf "STITCHING_ON\t= ${STITCHING_ON}\n"
+printf "STITCHING_ON\t\t= ${STITCHING_ON}\n"
 printf "DATA_PERIOD\t\t= ${DATA_PERIOD}\n"
+printf "DATA_USER\t\t= ${DATA_USER}\n"
 echo " Others:"
 printf "OUTSKIM_DIR\t\t= ${OUTSKIM_DIR}\n"
 echo "-------------------------------"
@@ -173,20 +192,23 @@ echo "-------------------------------"
 #### Source additional setup
 make -j10 && make exe -j10
 source scripts/setup.sh
-source /opt/exp_soft/cms/t3/t3setup
+#source /opt/exp_soft/cms/t3/t3setup
 echo "-------- Run: $(date) ---------------" >> ${ERR_FILE}
 
 ### Submission command
 function run_skim() {
 	comm="python ${KLUB_DIR}/${SUBMIT_SCRIPT} --tag ${TAG_DIR} -o ${OUTSKIM_DIR} -c ${KLUB_DIR}/${CFG} "
-	comm+="--exec_file ${EXEC_FILE} -q long -Y 2018 -k True --pu ${PU_DIR} $@"
+	[[ ${RESUBMIT} -eq 1 ]] && comm+="--resub "
+	comm+="--exec_file ${EXEC_FILE} -q long -Y 2018 -k 1 --pu ${PU_DIR} $@"
 	[[ ${DRYRUN} -eq 1 ]] && echo ${comm} || ${comm}
 }
 
 ### Input file list production command
 function produce_list() {
-	comm="python ${KLUB_DIR}/${LIST_SCRIPT} -t ${KLUB_TAG} --data_period ${DATA_PERIOD} $@"
-	[[ ${DRYRUN} -eq 1 ]] && echo ${comm} || ${comm}
+	comm="python ${KLUB_DIR}/${LIST_SCRIPT} -t ${KLUB_TAG} --data_period ${DATA_PERIOD} --user ${DATA_USER} $@"
+	if [[ ${RESUBMIT} -eq 0 ]]; then
+		[[ ${DRYRUN} -eq 1 ]] && echo ${comm} || ${comm}
+	fi
 }
 
 ### Extract sample full name
@@ -216,7 +238,6 @@ function find_sample() {
 		echo ${mes}
 		return 1
 	fi
-	echo ${sample}
 }
 
 ### Run on data samples
@@ -230,98 +251,104 @@ for ds in ${DATA_LIST[@]}; do
 			ERRORS+=( ${sample} )
 		else
 			[[ ${NO_LISTS} -eq 0 ]] && produce_list --kind Data --sample ${sample}
-		 	run_skim -n 90 --isdata True -i ${DATA_DIR} --sample ${sample}			
+		 	run_skim -n 1000 --isdata 1 -i ${DATA_DIR} --sample ${sample}			
 		fi
 	done
 done
 
 ### Run on HH resonant signal samples
-# DATA_LIST=( "GluGluToRad" "GluGluToBulkGrav" "VBFToRad" "VBFToBulkGrav" )
-# MASSES=("250" "260" "270" "280" "300" "320" "350" "400" "450" "500" "550" "600" "650" "700" "750" "800" "850" "900" "1000" "1250" "1500" "1750" "2000" "2500" "3000")
-# for ds in ${DATA_LIST[@]}; do
-# 	for mass in ${MASSES[@]}; do
-# 		pattern="${ds}.+_M-${mass}_";
-# 		sample=$(find_sample ${pattern} ${LIST_MC_DIR} ${#LISTS_MC[@]} ${LISTS_MC[@]})
-# 		if [[ ${sample} =~ ${SEARCH_SPACE} ]]; then
-# 			ERRORS+=( ${sample} )
-# 		else
-# 			[[ ${NO_LISTS} -eq 0 ]] && produce_list --kind Signals --sample ${sample}
-# 			run_skim -n 20 -i ${SIG_DIR} --sample ${sample} -x 1.
-# 		fi
-# 	done
-# done
+DATA_LIST=( "GluGluToRad" "GluGluToBulkGrav" "VBFToRad" "VBFToBulkGrav" )
+MASSES=("250" "260" "270" "280" "300" "320" "350" "400" "450" "500" "550" "600" "650" "700" "750" "800" "850" "900" "1000" "1250" "1500" "1750" "2000" "2500" "3000")
+for ds in ${DATA_LIST[@]}; do
+	for mass in ${MASSES[@]}; do
+		pattern="${ds}.+_M-${mass}_";
+		sample=$(find_sample ${pattern} ${LIST_MC_DIR} ${#LISTS_MC[@]} ${LISTS_MC[@]})
+		if [[ ${sample} =~ ${SEARCH_SPACE} ]]; then
+			ERRORS+=( ${sample} )
+		else
+			[[ ${NO_LISTS} -eq 0 ]] && produce_list --kind Signals --sample ${sample}
+			run_skim -n 5 -i ${SIG_DIR} --sample ${sample} -x 1.
+		fi
+	done
+done
 
 ### Run on backgrounds samples
-stitch_opt="False"
-[[ ${STITCHING_ON} -eq 1 ]] && stitch_opt="True"
-
+DYXSEC="1.0"
+#DYXSEC="6077.22"
 DATA_MAP=(
-	["TTToHadronic"]="-n 100 -x 377.96"
-	["TTTo2L2Nu"]="-n 100 -x 88.29"
-	["TTToSemiLeptonic"]="-n 100 -x 365.34"
-
-	# ["DYJets.+_M-50_T.+amc"]=" -n 400 -x 6077.22 -g ${stitch_opt} --DY False" # inclusive NLO
-	#### ["DYJetsToLL_Pt-50To100"]="-n 150 -x 1.      -g ${stitch_opt} --DY False"
-	#### ["DYJetsToLL_Pt-100To250"]="-n 150 -x 1.     -g ${stitch_opt} --DY False"
-	#### ["DYJetsToLL_Pt-250To400"]="-n 150 -x 1.	 -g ${stitch_opt} --DY False"
-	#### ["DYJetsToLL_Pt-400To650"]="-n 150 -x 1.	 -g ${stitch_opt} --DY False"
-	#### ["DYJetsToLL_Pt-650ToInf"]="-n 150 -x 1.	 -g ${stitch_opt} --DY False"
+    ["TTToHadronic"]="-n 1000 -x 377.96"
+    ["TTTo2L2Nu"]="-n 1000 -x 88.29"
+    ["TTToSemiLeptonic"]="-n 1000 -x 365.34"
+	#
+	#    ["DYJets.+_M-50_T.+amc"]="-n 600            -x 6077.22 -g ${STITCHING_ON} --DY 0" # inclusive NLO
+	##    ["DYJets.+_M-50_T.+amc"]="-n 600            -x 6077.22 -g 0 --DY 0" # inclusive NLO
+	###    ["DYJetToLL_merged_noPtZ0-50"]="-n 450            -x 6077.22 -g ${STITCHING_ON} --DY 0" # merged
+	###    ["DYJetsToLL_LHEFilterPtZ-0To50"]="-n 100   -x ${DYXSEC} -g ${STITCHING_ON} --DY 0"
+	#    ["DYJetsToLL_LHEFilterPtZ-50To100"]="-n 600 -x 397.4     -g ${STITCHING_ON} --DY 0"
+	#    ["DYJetsToLL_LHEFilterPtZ-100To250"]="-n 600 -x  97.2     -g ${STITCHING_ON} --DY 0"
+	#    ["DYJetsToLL_LHEFilterPtZ-250To400"]="-n 600 -x   3.701   -g ${STITCHING_ON} --DY 0"
+	#    ["DYJetsToLL_LHEFilterPtZ-400To650"]="-n 600 -x   0.5086  -g ${STITCHING_ON} --DY 0"
+	#    ["DYJetsToLL_LHEFilterPtZ-650ToInf"]="-n 600 -x   0.04728 -g ${STITCHING_ON} --DY 0"
+	######
+	#    ["DYJetsToLL_0J"]="-n 600 -x 5129.  -g ${STITCHING_ON} --DY 0"
+	#    ["DYJetsToLL_1J"]="-n 600  -x  951.5 -g ${STITCHING_ON} --DY 0"
+	#    ["DYJetsToLL_2J"]="-n 600  -x  361.4 -g ${STITCHING_ON} --DY 0"
 	### 
-	###### LO samples, DY weights exist (--DY True)
-	#### ["DYJets.+_M-50_T.+madgraph"]="		-n 400 -x 6077.22 -g ${stitch_opt} --DY True" # inclusive LO
-	#### ["DY_merged"]="						-n 300 -x 6077.22 -g ${stitch_opt} --DY True"
-	#### ["DY1J"]="							-n 200 -x 1. -g ${stitch_opt} --DY True"
-	#### ["DY2J"]="							-n 200 -x 1. -g ${stitch_opt} --DY True"		   
-	#### ["DY3J"]="							-n 200 -x 1. -g ${stitch_opt} --DY True"
-	#### ["DY4J"]="							-n 200 -x 1. -g ${stitch_opt} --DY True"
-	#### ["DYJetsToLL_M-50_HT-70to100"]="		-n 200 -x 1. -g ${stitch_opt} --DY True"
-	#### ["DYJetsToLL_M-50_HT-100to200"]="		-n 200 -x 1. -g ${stitch_opt} --DY True"
-	#### ["DYJetsToLL_M-50_HT-200to400"]="		-n 200 -x 1. -g ${stitch_opt} --DY True"
-	#### ["DYJetsToLL_M-50_HT-400to600"]="		-n 200 -x 1. -g ${stitch_opt} --DY True"
-	#### ["DYJetsToLL_M-50_HT-600to800"]="		-n 200 -x 1. -g ${stitch_opt} --DY True"
-	#### ["DYJetsToLL_M-50_HT-800to1200"]="	-n 200 -x 1. -g ${stitch_opt} --DY True"
-	#### ["DYJetsToLL_M-50_HT-1200to2500"]="	-n 200 -x 1. -g ${stitch_opt} --DY True"
-	#### ["DYJetsToLL_M-50_HT-2500toInf"]="	-n 200 -x 1. -g ${stitch_opt} --DY True"
+	###### LO samples, DY weights exist (--DY 1)
+	#### ["DYJets.+_M-50_T.+madgraph"]="		-n 400 -x 6077.22 -g ${STITCHING_ON} --DY 1" # inclusive LO
+	#### ["DY_merged"]="						-n 300 -x 6077.22 -g ${STITCHING_ON} --DY 1"
+	#### ["DY1J"]="							-n 200 -x 1. -g ${STITCHING_ON} --DY 1"
+	#### ["DY2J"]="							-n 200 -x 1. -g ${STITCHING_ON} --DY 1"		   
+	#### ["DY3J"]="							-n 200 -x 1. -g ${STITCHING_ON} --DY 1"
+	#### ["DY4J"]="							-n 200 -x 1. -g ${STITCHING_ON} --DY 1"
+	#### ["DYJetsToLL_M-50_HT-70to100"]="		-n 200 -x 1. -g ${STITCHING_ON} --DY 1"
+	#### ["DYJetsToLL_M-50_HT-100to200"]="		-n 200 -x 1. -g ${STITCHING_ON} --DY 1"
+	#### ["DYJetsToLL_M-50_HT-200to400"]="		-n 200 -x 1. -g ${STITCHING_ON} --DY 1"
+	#### ["DYJetsToLL_M-50_HT-400to600"]="		-n 200 -x 1. -g ${STITCHING_ON} --DY 1"
+	#### ["DYJetsToLL_M-50_HT-600to800"]="		-n 200 -x 1. -g ${STITCHING_ON} --DY 1"
+	#### ["DYJetsToLL_M-50_HT-800to1200"]="	-n 200 -x 1. -g ${STITCHING_ON} --DY 1"
+	#### ["DYJetsToLL_M-50_HT-1200to2500"]="	-n 200 -x 1. -g ${STITCHING_ON} --DY 1"
+	#### ["DYJetsToLL_M-50_HT-2500toInf"]="	-n 200 -x 1. -g ${STITCHING_ON} --DY 1"
+#
+	["WJetsToLNu_T.+madgraph"]="-n 50 -x 48917.48 -y 1.213784 -z 70" # for 0 < HT < 70
+	["WJetsToLNu_HT-70To100"]="-n 50 -x 1362 -y 1.213784"
+	["WJetsToLNu_HT-100To200"]="-n 50 -x 1345 -y 1.213784"
+	["WJetsToLNu_HT-200To400"]="-n 50 -x 359.7 -y 1.213784"
+	["WJetsToLNu_HT-400To600"]="-n 50 -x 48.91 -y 1.213784"
+	["WJetsToLNu_HT-600To800"]="-n 50 -x 12.05 -y 1.213784"
+	["WJetsToLNu_HT-800To1200"]="-n 50 -x 5.501 -y 1.213784"
+	["WJetsToLNu_HT-1200To2500"]="-n 50 -x 1.329 -y 1.213784"
+	["WJetsToLNu_HT-2500ToInf"]="-n 50 -x 0.03216 -y 1.213784"
 
-	# ["WJetsToLNu_T.+madgraph"]="-n 20 -x 48917.48 -y 1.213784 -z 70" # for 0 < HT < 70
-	# ["WJetsToLNu_HT-70To100"]="-n 20 -x 1362 -y 1.213784"
-	# ["WJetsToLNu_HT-100To200"]="-n 20 -x 1345 -y 1.213784"
-	# ["WJetsToLNu_HT-200To400"]="-n 20 -x 359.7 -y 1.213784"
-	# ["WJetsToLNu_HT-400To600"]="-n 20 -x 48.91 -y 1.213784"
-	# ["WJetsToLNu_HT-600To800"]="-n 20 -x 12.05 -y 1.213784"
-	# ["WJetsToLNu_HT-800To1200"]="-n 20 -x 5.501 -y 1.213784"
-	# ["WJetsToLNu_HT-1200To2500"]="-n 20 -x 1.329 -y 1.213784"
-	# ["WJetsToLNu_HT-2500ToInf"]="-n 20 -x 0.03216 -y 1.213784"
+	["EWKWPlus2Jets_WToLNu"]="-n 50 -x 25.62"
+	["EWKWMinus2Jets_WToLNu"]="-n 50 -x 20.25"
+	["EWKZ2Jets_ZToLL"]="-n 50 -x 3.987"
 
-	# ["EWKWPlus2Jets_WToLNu"]="-n 50 -x 25.62"
-	# ["EWKWMinus2Jets_WToLNu"]="-n 50 -x 20.25"
-	# ["EWKZ2Jets_ZToLL"]="-n 50 -x 3.987"
+	["ST_tW_antitop_5f_inclusive"]="-n 50 -x 35.85"
+	["ST_tW_top_5f_inclusive"]="-n 50 -x 35.85"
+	["ST_t-channel_antitop"]="-n 50 -x 80.95"
+	["ST_t-channel_top"]="-n 50 -x 136.02"
 
-	# ["ST_tW_antitop"]="-n 50 -x 35.85"
-	# ["ST_tW_top"]="-n 50 -x 35.85"
-	# ["ST_t-channel_antitop"]="-n 50 -x 80.95"
-	# ["ST_t-channel_top"]="-n 50 -x 136.02"
+	["GluGluHToTauTau"]="-n 30 -x 48.61 -y 0.0632"
+	["VBFHToTauTau"]="-n 30 -x 3.766 -y 0.0632"
+	["ZHToTauTau"]="-n 30 -x 0.880 -y 0.0632"
+	["WplusHToTauTau"]="-n 30 -x 0.831 -y 0.0632"
+	["WminusHToTauTau"]="-n 30 -x 0.527 -y 0.0632"
 
-	# ["GluGluHToTauTau"]="-n 30 -x 48.61 -y 0.0632"
-	# ["VBFHToTauTau"]="-n 30 -x 3.766 -y 0.0632"
-	# ["ZHToTauTau"]="-n 30 -x 0.880 -y 0.0632"
-	# ["WplusHToTauTau"]="-n 30 -x 0.831 -y 0.0632"
-	# ["WminusHToTauTau"]="-n 30 -x 0.527 -y 0.0632"
-
-	# ["ttHToNonbb"]="-n 30 -x 0.5071 -y 0.3598"
-	# ["ttHTobb"]="-n 30 -x 0.5071 -y 0.577"
-	# ["ttHToTauTau"]="-n 30 -x 0.5071 -y 0.0632"
+	["ttHToNonbb"]="-n 30 -x 0.5071 -y 0.3598"
+	["ttHTobb"]="-n 30 -x 0.5071 -y 0.577"
+	["ttHToTauTau"]="-n 30 -x 0.5071 -y 0.0632"
 	
-	# ["_WW"]="-n 20 -x 118.7"
-	# ["_WZ"]="-n 20 -x 47.13"
-	# # ["_ZZ"]="-n 20 -x 16.523"
+	["_WW_TuneCP5"]="-n 20 -x 118.7"
+	["_WZ_TuneCP5"]="-n 20 -x 47.13"
+	["_ZZ_TuneCP5"]="-n 20 -x 16.523"
 
-	# ["TTWJetsToLNu"]="-n 20 -x 0.2043"
-	# ["TTWJetsToQQ"]="-n 20 -x 0.4062"
-	# ["TTZToLLNuNu"]="-n 20 -x 0.2529"
-	# ["TTWW"]="-n 20 -x 0.006979"
-	# ["TTZZ"]="-n 20 -x 0.001386"
-	# ["TTWZ"]="-n 20 -x 0.00158"
+	["TTWJetsToLNu"]="-n 50 -x 0.2043"
+	["TTWJetsToQQ"]="-n 50 -x 0.4062"
+	["TTZToLLNuNu"]="-n 50 -x 0.2529"
+	["TTWW"]="-n 50 -x 0.006979"
+	["TTZZ"]="-n 50 -x 0.001386"
+	["TTWZ"]="-n 50 -x 0.00158"
 )
 
 # Sanity checks for Drell-Yan stitching
@@ -337,9 +364,9 @@ if [ ${STITCHING_ON} -eq 1 ]; then
 	if [ ${dy_counter} -eq 0 ]; then
 		echo "You set the DY stitching on while considering no DY samples. Did you forget to include the latter?"
 		exit 1
-	elif [ ${dy_counter} -eq 1 ]; then
-		echo "You set the DY stitching on while considering a single DY sample. This is incorrect."
-		exit 1
+#	elif [ ${dy_counter} -eq 1 ]; then
+#		echo "You set the DY stitching on while considering a single DY sample. This is incorrect."
+#		exit 1
 	fi
 fi
 


### PR DESCRIPTION
- add user option (user that generated the big ntuples, inputs for the submission of the skims)
- comment out the source command which lead to the following (while using ```rfdir``` for listing files on ```/dpm/```):

```shell
send2nsd: NS002 - send error : client_establish_context: The server had a problem while authenticating our connection
/dpm/in2p3.fr/home/cms/trivcat/store/user/<user>/: Could not secure the connection
```

The origin of the above error was not understood, but removing the ```source``` seems to have no impact on the produced skimmed files.

- replace tag name for clarity


@portalesHEP