### PR TITLE
good- and badfiles.txt writing in failing scenarios

### DIFF
--- a/scripts/run_all_check_outputs.py
+++ b/scripts/run_all_check_outputs.py
@@ -1,0 +1,52 @@
+import os
+import glob
+import argparse
+import re
+
+def get_number_jobs(condor_file):
+    """Parses condor files outputting the number of jobs that were launched."""
+    with open(condor_file) as f:
+        for line in f:
+            line = line.strip('\n')
+            matches = re.match('queue\s(.+)$', line)
+            if matches is not None:
+                g = matches.groups()
+                assert len(g) == 1
+                return int(g[0])
+    raise RuntimeError('the provided condor file {} does not match the expected format.'.format(condor_file))
+
+def run_all_check_outputs(args):
+    base_dir = os.path.join('/data_CMS/cms/', args.user, 'HHresonant_SKIMS/')
+    base_dir = os.path.join(base_dir, 'SKIMS_' + args.data_period + '_' + args.in_tag)
+
+    sample_dirs = [x for x in glob.glob(os.path.join(base_dir, '*/'))]
+    if len(sample_dirs) == 0:
+        print('No folders were found under {}/.'.format(base_dir))
+
+    for sd in sample_dirs:
+        condor_file = os.path.join(sd, 'job.condor')
+        if not os.path.exists(condor_file):
+            print('[WARNING] File {} was not found.'.format(condor_file))
+            continue
+
+        njobs = get_number_jobs(condor_file)
+        print('Processing folder {} with {} jobs...'.format(sd, njobs))
+        for n in range(njobs):
+            comm = 'python scripts/check_outputs.py -r {sd}/output_{n}.root -o {sd}/live_logs/{n}.out -e {sd}/live_logs/{n}.err -l {sd}/logs/{n}.log -v'
+            comm = comm.format(sd=sd, n=n)
+            if args.dry_run:
+                print(comm)
+            else:
+               os.system(comm)
+
+
+if __name__ == "__main__":
+    usage = 'Produces all `goodfiles.txt` and `badfiles.txt` files when scripts/check_outputs.py fails but the skimmed files were nevertheless produced.'
+    parser = argparse.ArgumentParser(description=usage)
+    parser.add_argument('--data_period', default='UL18', choices=('UL16', 'UL17', 'UL18'), help='data period')
+    parser.add_argument('--in_tag', required=True, help='tag used to generate skimmed files')
+    parser.add_argument('--user', required=True, help='user that submitted the skimming step')
+    parser.add_argument('--dry_run', action='store_true', help='prints debug info and does not launch any command')
+
+    FLAGS = parser.parse_args()
+    run_all_check_outputs(FLAGS)

--- a/scripts/skimNtuple.py
+++ b/scripts/skimNtuple.py
@@ -256,7 +256,7 @@ def skim_ntuple(FLAGS, curr_folder):
         local_err = os.path.join(livedir, '{}{}.err'.format(arg1,arg2))
         s.write(command + ' 1>{} 2>{}\n'.format(local_out, local_err))
         
-        command, comment = double_join('python3 {}'.format(py_exec),
+        command, comment = double_join('python {}'.format(py_exec),
                                        '-r ' + os.path.join(jobs_dir, io_names[1]),
                                        '-o ' + local_out,
                                        '-e ' + local_err,


### PR DESCRIPTION
If for some reason the ```scripts/check_outputs.py``` fails but the skimmed ntuples were created, there is no point in rerunning the skim step solely for obtaining the ```badfiles.txt``` and ```goodfiles.txt``` (used during histogram production and thus essential). Instead, one can run all required commands manually pointing to the correct folders. This PR addresses this, automatizing folder search and command launching.

The script can be run as follows:

```shell
python scripts/run_all_check_outputs.py --in_tag <skim_tag> --user <user>
```

with the following output, which create or append data to the ```goodfiles.txt``` and ```badfiles.txt```

```shell
Processing folder /data_CMS/cms/<user>/HHresonant_SKIMS/SKIMS_UL18_<skim_tag>/GluGluToRadionToHHTo2B2Tau_M-250_/ with 5 jobs...
Processing folder /data_CMS/cms/<user>/HHresonant_SKIMS/SKIMS_UL18_<sim_tag>/GluGluToRadionToHHTo2B2Tau_M-260_/ with 5 jobs...
Processing folder /data_CMS/cms/<user>/HHresonant_SKIMS/SKIMS_UL18_<skim_tag>/GluGluToRadionToHHTo2B2Tau_M-270_/ with 1 jobs...
...
```

The files will be created or modified under ```/data_CMS/cms/<user>/HHresonant_SKIMS/SKIMS_UL18_<skim_tag>/GluGluToRadionToHHTo2B2Tau_M-250_/```, etc.