### PR TITLE
Fill ParticleNet variables in 2016 and 2018

### DIFF
--- a/test/skimNtuple2016_HHbtag.cpp
+++ b/test/skimNtuple2016_HHbtag.cpp
@@ -3834,7 +3834,15 @@ int main (int argc, char** argv)
       theSmallTree.m_bjet1_CvsB = getCvsB(theBigTree, bjet1idx);
       theSmallTree.m_bjet1_bMVAID  = theBigTree.pfCombinedMVAV2BJetTags->at (bjet1idx) ;
       theSmallTree.m_bjet1_PUjetIDupdated = theBigTree.jets_PUJetIDupdated->at(bjet1idx);
-      theSmallTree.m_bjet1_flav = theBigTree.jets_HadronFlavour->at (bjet1idx) ;
+      theSmallTree.m_bjet1_flav = theBigTree.jets_HadronFlavour->at (bjet1idx);
+      theSmallTree.m_bjet1_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(bjet1idx);
+      theSmallTree.m_bjet1_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(bjet1idx);
+      theSmallTree.m_bjet1_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(bjet1idx);
+      theSmallTree.m_bjet1_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(bjet1idx);
+      theSmallTree.m_bjet1_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(bjet1idx);
+      theSmallTree.m_bjet1_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(bjet1idx);
+      theSmallTree.m_bjet1_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(bjet1idx);
+      theSmallTree.m_bjet1_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(bjet1idx);
 
       theSmallTree.m_bjet2_pt   = tlv_secondBjet.Pt () ;
       theSmallTree.m_bjet2_eta  = tlv_secondBjet.Eta () ;
@@ -3849,6 +3857,14 @@ int main (int argc, char** argv)
       theSmallTree.m_bjet2_bMVAID  = theBigTree.pfCombinedMVAV2BJetTags->at (bjet2idx) ;
       theSmallTree.m_bjet2_PUjetIDupdated = theBigTree.jets_PUJetIDupdated->at(bjet2idx);
       theSmallTree.m_bjet2_flav = theBigTree.jets_HadronFlavour->at (bjet2idx) ;
+      theSmallTree.m_bjet2_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(bjet2idx);
+      theSmallTree.m_bjet2_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(bjet2idx);
+      theSmallTree.m_bjet2_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(bjet2idx);
+      theSmallTree.m_bjet2_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(bjet2idx);
+      theSmallTree.m_bjet2_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(bjet2idx);
+      theSmallTree.m_bjet2_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(bjet2idx);
+      theSmallTree.m_bjet2_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(bjet2idx);
+      theSmallTree.m_bjet2_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(bjet2idx);
 
       theSmallTree.m_bjets_bID  = theBigTree.bCSVscore->at (bjet1idx) +theBigTree.bCSVscore->at (bjet2idx) ;
       theSmallTree.m_bjets_bID_deepCSV  = theBigTree.bDeepCSV_probb->at(bjet1idx) + theBigTree.bDeepCSV_probbb->at(bjet1idx) + theBigTree.bDeepCSV_probb->at(bjet2idx) + theBigTree.bDeepCSV_probbb->at(bjet2idx);
@@ -4513,6 +4529,14 @@ int main (int argc, char** argv)
 	theSmallTree.m_VBFjet1_ctag_deepFlavor = theBigTree.bDeepFlavor_probc->at(VBFidx1) ;
 	theSmallTree.m_VBFjet1_CvsL = getCvsL(theBigTree, VBFidx1);
 	theSmallTree.m_VBFjet1_CvsB = getCvsB(theBigTree, VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(VBFidx1);
 	theSmallTree.m_VBFjet1_PUjetIDupdated  = theBigTree.jets_PUJetIDupdated->at (VBFidx1) ;
 	theSmallTree.m_VBFjet1_flav            = (theBigTree.jets_HadronFlavour->at (VBFidx1)) ;
 	theSmallTree.m_VBFjet1_hasgenjet       = hasgj1_VBF ;
@@ -4552,6 +4576,14 @@ int main (int argc, char** argv)
 	theSmallTree.m_VBFjet2_ctag_deepFlavor = theBigTree.bDeepFlavor_probc->at(VBFidx2) ;
 	theSmallTree.m_VBFjet2_CvsL = getCvsL(theBigTree, VBFidx2);
 	theSmallTree.m_VBFjet2_CvsB = getCvsB(theBigTree, VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(VBFidx2);
 	theSmallTree.m_VBFjet2_PUjetIDupdated  = theBigTree.jets_PUJetIDupdated->at (VBFidx2) ;
 	theSmallTree.m_VBFjet2_flav            = (theBigTree.jets_HadronFlavour->at (VBFidx2)) ;
 	theSmallTree.m_VBFjet2_hasgenjet  	 = hasgj2_VBF ;
@@ -4649,6 +4681,14 @@ int main (int argc, char** argv)
 	theSmallTree.m_jets_CvsB.push_back( getCvsB(theBigTree, iJet) );
 	theSmallTree.m_jets_flav.push_back (theBigTree.jets_HadronFlavour->at (iJet)) ;
 	theSmallTree.m_jets_hasgenjet.push_back (hasgj) ;
+	theSmallTree.m_jets_pnet_bb.push_back(theBigTree.bParticleNetAK4JetTags_probbb->at(iJet));
+	theSmallTree.m_jets_pnet_cc.push_back(theBigTree.bParticleNetAK4JetTags_probcc->at(iJet));
+	theSmallTree.m_jets_pnet_b.push_back(theBigTree.bParticleNetAK4JetTags_probb->at(iJet));
+	theSmallTree.m_jets_pnet_c.push_back(theBigTree.bParticleNetAK4JetTags_probc->at(iJet));
+	theSmallTree.m_jets_pnet_g.push_back(theBigTree.bParticleNetAK4JetTags_probg->at(iJet));
+	theSmallTree.m_jets_pnet_uds.push_back(theBigTree.bParticleNetAK4JetTags_probuds->at(iJet));
+	theSmallTree.m_jets_pnet_pu.push_back(theBigTree.bParticleNetAK4JetTags_probpu->at(iJet));
+	theSmallTree.m_jets_pnet_undef.push_back(theBigTree.bParticleNetAK4JetTags_probundef->at(iJet));
 	++theSmallTree.m_njets ;
       } // loop over jets
 
@@ -4856,6 +4896,14 @@ int main (int argc, char** argv)
             theSmallTree.m_addJetCentr1_CvsL            = getCvsL(theBigTree, iJet);
             theSmallTree.m_addJetCentr1_CvsB            = getCvsB(theBigTree, iJet);
             if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end()) theSmallTree.m_addJetCentr1_HHbtag = jets_and_HHbtag[iJet];
+            theSmallTree.m_addJetCentr1_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
+            theSmallTree.m_addJetCentr1_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
+            theSmallTree.m_addJetCentr1_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
+            theSmallTree.m_addJetCentr1_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
+            theSmallTree.m_addJetCentr1_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
+            theSmallTree.m_addJetCentr1_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
+            theSmallTree.m_addJetCentr1_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
+            theSmallTree.m_addJetCentr1_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
             theSmallTree.m_addJetCentr1_smearFactor = jets_and_smearFactor[iJet];
             for (int isource = 0; isource < N_jecSources; isource++)
             {
@@ -4895,6 +4943,14 @@ int main (int argc, char** argv)
             theSmallTree.m_addJetCentr2_CvsL            = getCvsL(theBigTree, iJet);
             theSmallTree.m_addJetCentr2_CvsB            = getCvsB(theBigTree, iJet);
             if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end()) theSmallTree.m_addJetCentr2_HHbtag = jets_and_HHbtag[iJet];
+            theSmallTree.m_addJetCentr2_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
+            theSmallTree.m_addJetCentr2_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
+            theSmallTree.m_addJetCentr2_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
+            theSmallTree.m_addJetCentr2_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
+            theSmallTree.m_addJetCentr2_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
+            theSmallTree.m_addJetCentr2_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
+            theSmallTree.m_addJetCentr2_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
+            theSmallTree.m_addJetCentr2_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
             theSmallTree.m_addJetCentr2_smearFactor = jets_and_smearFactor[iJet];
             for (int isource = 0; isource < N_jecSources; isource++)
             {
@@ -4934,6 +4990,14 @@ int main (int argc, char** argv)
             theSmallTree.m_addJetCentr3_CvsL            = getCvsL(theBigTree, iJet);
             theSmallTree.m_addJetCentr3_CvsB            = getCvsB(theBigTree, iJet);
             if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end()) theSmallTree.m_addJetCentr3_HHbtag = jets_and_HHbtag[iJet];
+            theSmallTree.m_addJetCentr3_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
+            theSmallTree.m_addJetCentr3_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
+            theSmallTree.m_addJetCentr3_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
+            theSmallTree.m_addJetCentr3_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
+            theSmallTree.m_addJetCentr3_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
+            theSmallTree.m_addJetCentr3_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
+            theSmallTree.m_addJetCentr3_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
+            theSmallTree.m_addJetCentr3_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
             theSmallTree.m_addJetCentr3_smearFactor = jets_and_smearFactor[iJet];
             for (int isource = 0; isource < N_jecSources; isource++)
             {
@@ -4973,6 +5037,14 @@ int main (int argc, char** argv)
             theSmallTree.m_addJetCentr4_CvsL            = getCvsL(theBigTree, iJet);
             theSmallTree.m_addJetCentr4_CvsB            = getCvsB(theBigTree, iJet);
             if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end()) theSmallTree.m_addJetCentr4_HHbtag = jets_and_HHbtag[iJet];
+            theSmallTree.m_addJetCentr4_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
+            theSmallTree.m_addJetCentr4_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
+            theSmallTree.m_addJetCentr4_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
+            theSmallTree.m_addJetCentr4_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
+            theSmallTree.m_addJetCentr4_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
+            theSmallTree.m_addJetCentr4_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
+            theSmallTree.m_addJetCentr4_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
+            theSmallTree.m_addJetCentr4_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
             theSmallTree.m_addJetCentr4_smearFactor = jets_and_smearFactor[iJet];
             for (int isource = 0; isource < N_jecSources; isource++)
             {
@@ -5012,6 +5084,14 @@ int main (int argc, char** argv)
             theSmallTree.m_addJetCentr5_CvsL            = getCvsL(theBigTree, iJet);
             theSmallTree.m_addJetCentr5_CvsB            = getCvsB(theBigTree, iJet);
             if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end()) theSmallTree.m_addJetCentr5_HHbtag = jets_and_HHbtag[iJet];
+            theSmallTree.m_addJetCentr5_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
+            theSmallTree.m_addJetCentr5_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
+            theSmallTree.m_addJetCentr5_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
+            theSmallTree.m_addJetCentr5_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
+            theSmallTree.m_addJetCentr5_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
+            theSmallTree.m_addJetCentr5_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
+            theSmallTree.m_addJetCentr5_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
+            theSmallTree.m_addJetCentr5_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
             theSmallTree.m_addJetCentr5_smearFactor = jets_and_smearFactor[iJet];
             for (int isource = 0; isource < N_jecSources; isource++)
             {

--- a/test/skimNtuple2018_HHbtag.cpp
+++ b/test/skimNtuple2018_HHbtag.cpp
@@ -5371,14 +5371,14 @@ int main (int argc, char** argv)
 	    theSmallTree.m_addJetCentr1_CvsL            = getCvsL(theBigTree, iJet);
 	    theSmallTree.m_addJetCentr1_CvsB            = getCvsB(theBigTree, iJet);
 	    if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end()) theSmallTree.m_addJetCentr1_HHbtag = jets_and_HHbtag[iJet];
-        theSmallTree.m_addJetCentr1_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
-        theSmallTree.m_addJetCentr1_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
-        theSmallTree.m_addJetCentr1_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
-        theSmallTree.m_addJetCentr1_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
-        theSmallTree.m_addJetCentr1_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
-        theSmallTree.m_addJetCentr1_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
-        theSmallTree.m_addJetCentr1_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
-        theSmallTree.m_addJetCentr1_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
+	    theSmallTree.m_addJetCentr1_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
+	    theSmallTree.m_addJetCentr1_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
+	    theSmallTree.m_addJetCentr1_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
+	    theSmallTree.m_addJetCentr1_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
+	    theSmallTree.m_addJetCentr1_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
+	    theSmallTree.m_addJetCentr1_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
+	    theSmallTree.m_addJetCentr1_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
+	    theSmallTree.m_addJetCentr1_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
 	    theSmallTree.m_addJetCentr1_smearFactor = jets_and_smearFactor[iJet];
 	    for (int isource = 0; isource < N_jecSources; isource++)
 	    {
@@ -5467,14 +5467,14 @@ int main (int argc, char** argv)
 	    theSmallTree.m_addJetCentr3_CvsL            = getCvsL(theBigTree, iJet);
 	    theSmallTree.m_addJetCentr3_CvsB            = getCvsB(theBigTree, iJet);
 	    if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end()) theSmallTree.m_addJetCentr3_HHbtag = jets_and_HHbtag[iJet];
-        theSmallTree.m_addJetCentr3_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
-        theSmallTree.m_addJetCentr3_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
-        theSmallTree.m_addJetCentr3_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
-        theSmallTree.m_addJetCentr3_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
-        theSmallTree.m_addJetCentr3_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
-        theSmallTree.m_addJetCentr3_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
-        theSmallTree.m_addJetCentr3_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
-        theSmallTree.m_addJetCentr3_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
+	    theSmallTree.m_addJetCentr3_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
+	    theSmallTree.m_addJetCentr3_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
+	    theSmallTree.m_addJetCentr3_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
+	    theSmallTree.m_addJetCentr3_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
+	    theSmallTree.m_addJetCentr3_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
+	    theSmallTree.m_addJetCentr3_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
+	    theSmallTree.m_addJetCentr3_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
+	    theSmallTree.m_addJetCentr3_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
 	    theSmallTree.m_addJetCentr3_smearFactor = jets_and_smearFactor[iJet];
 	    for (int isource = 0; isource < N_jecSources; isource++)
 	    {
@@ -5515,14 +5515,14 @@ int main (int argc, char** argv)
 	    theSmallTree.m_addJetCentr4_CvsL            = getCvsL(theBigTree, iJet);
 	    theSmallTree.m_addJetCentr4_CvsB            = getCvsB(theBigTree, iJet);
 	    if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end()) theSmallTree.m_addJetCentr4_HHbtag = jets_and_HHbtag[iJet];
-        theSmallTree.m_addJetCentr4_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
-        theSmallTree.m_addJetCentr4_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
-        theSmallTree.m_addJetCentr4_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
-        theSmallTree.m_addJetCentr4_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
-        theSmallTree.m_addJetCentr4_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
-        theSmallTree.m_addJetCentr4_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
-        theSmallTree.m_addJetCentr4_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
-        theSmallTree.m_addJetCentr4_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
+	    theSmallTree.m_addJetCentr4_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
+	    theSmallTree.m_addJetCentr4_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
+	    theSmallTree.m_addJetCentr4_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
+	    theSmallTree.m_addJetCentr4_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
+	    theSmallTree.m_addJetCentr4_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
+	    theSmallTree.m_addJetCentr4_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
+	    theSmallTree.m_addJetCentr4_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
+	    theSmallTree.m_addJetCentr4_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
 	    theSmallTree.m_addJetCentr4_smearFactor = jets_and_smearFactor[iJet];
 	    for (int isource = 0; isource < N_jecSources; isource++)
 	    {
@@ -5563,14 +5563,14 @@ int main (int argc, char** argv)
 	    theSmallTree.m_addJetCentr5_CvsL            = getCvsL(theBigTree, iJet);
 	    theSmallTree.m_addJetCentr5_CvsB            = getCvsB(theBigTree, iJet);
 	    if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end()) theSmallTree.m_addJetCentr5_HHbtag = jets_and_HHbtag[iJet];
-        theSmallTree.m_addJetCentr5_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
-        theSmallTree.m_addJetCentr5_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
-        theSmallTree.m_addJetCentr5_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
-        theSmallTree.m_addJetCentr5_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
-        theSmallTree.m_addJetCentr5_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
-        theSmallTree.m_addJetCentr5_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
-        theSmallTree.m_addJetCentr5_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
-        theSmallTree.m_addJetCentr5_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
+	    theSmallTree.m_addJetCentr5_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
+	    theSmallTree.m_addJetCentr5_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
+	    theSmallTree.m_addJetCentr5_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
+	    theSmallTree.m_addJetCentr5_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
+	    theSmallTree.m_addJetCentr5_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
+	    theSmallTree.m_addJetCentr5_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
+	    theSmallTree.m_addJetCentr5_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
+	    theSmallTree.m_addJetCentr5_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
 	    theSmallTree.m_addJetCentr5_smearFactor = jets_and_smearFactor[iJet];
 	    for (int isource = 0; isource < N_jecSources; isource++)
 	    {

--- a/test/skimNtuple2018_HHbtag.cpp
+++ b/test/skimNtuple2018_HHbtag.cpp
@@ -4257,6 +4257,14 @@ int main (int argc, char** argv)
       theSmallTree.m_bjet1_bMVAID  = theBigTree.pfCombinedMVAV2BJetTags->at (bjet1idx) ;
       theSmallTree.m_bjet1_PUjetIDupdated = theBigTree.jets_PUJetIDupdated->at(bjet1idx);
       theSmallTree.m_bjet1_flav = theBigTree.jets_HadronFlavour->at (bjet1idx) ;
+      theSmallTree.m_bjet1_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(bjet1idx);
+      theSmallTree.m_bjet1_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(bjet1idx);
+      theSmallTree.m_bjet1_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(bjet1idx);
+      theSmallTree.m_bjet1_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(bjet1idx);
+      theSmallTree.m_bjet1_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(bjet1idx);
+      theSmallTree.m_bjet1_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(bjet1idx);
+      theSmallTree.m_bjet1_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(bjet1idx);
+      theSmallTree.m_bjet1_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(bjet1idx);
 
       theSmallTree.m_bjet2_pt   = tlv_secondBjet.Pt () ;
       theSmallTree.m_bjet2_eta  = tlv_secondBjet.Eta () ;
@@ -4925,6 +4933,14 @@ int main (int argc, char** argv)
 	theSmallTree.m_VBFjet1_ctag_deepFlavor = theBigTree.bDeepFlavor_probc->at(VBFidx1) ;
 	theSmallTree.m_VBFjet1_CvsL = getCvsL(theBigTree, VBFidx1);
 	theSmallTree.m_VBFjet1_CvsB = getCvsB(theBigTree, VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(VBFidx1);
+	theSmallTree.m_VBFjet1_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(VBFidx1);
 	theSmallTree.m_VBFjet1_PUjetIDupdated = theBigTree.jets_PUJetIDupdated->at (VBFidx1) ;
 	theSmallTree.m_VBFjet1_flav       = (theBigTree.jets_HadronFlavour->at (VBFidx1)) ;
 	theSmallTree.m_VBFjet1_hasgenjet  = hasgj1_VBF ;
@@ -4964,6 +4980,14 @@ int main (int argc, char** argv)
 	theSmallTree.m_VBFjet2_ctag_deepFlavor = theBigTree.bDeepFlavor_probc->at(VBFidx2) ;
 	theSmallTree.m_VBFjet2_CvsL = getCvsL(theBigTree, VBFidx2);
 	theSmallTree.m_VBFjet2_CvsB = getCvsB(theBigTree, VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(VBFidx2);
+	theSmallTree.m_VBFjet2_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(VBFidx2);
 	theSmallTree.m_VBFjet2_PUjetIDupdated = theBigTree.jets_PUJetIDupdated->at (VBFidx2) ;
 	theSmallTree.m_VBFjet2_flav       = (theBigTree.jets_HadronFlavour->at (VBFidx2)) ;
 	theSmallTree.m_VBFjet2_hasgenjet  = hasgj2_VBF ;
@@ -5126,6 +5150,14 @@ int main (int argc, char** argv)
 	theSmallTree.m_jets_CvsB.push_back( getCvsB(theBigTree, iJet) );
 	theSmallTree.m_jets_flav.push_back (theBigTree.jets_HadronFlavour->at (iJet)) ;
 	theSmallTree.m_jets_hasgenjet.push_back (hasgj) ;
+	theSmallTree.m_jets_pnet_bb.push_back(theBigTree.bParticleNetAK4JetTags_probbb->at(iJet));
+	theSmallTree.m_jets_pnet_cc.push_back(theBigTree.bParticleNetAK4JetTags_probcc->at(iJet));
+	theSmallTree.m_jets_pnet_b.push_back(theBigTree.bParticleNetAK4JetTags_probb->at(iJet));
+	theSmallTree.m_jets_pnet_c.push_back(theBigTree.bParticleNetAK4JetTags_probc->at(iJet));
+	theSmallTree.m_jets_pnet_g.push_back(theBigTree.bParticleNetAK4JetTags_probg->at(iJet));
+	theSmallTree.m_jets_pnet_uds.push_back(theBigTree.bParticleNetAK4JetTags_probuds->at(iJet));
+	theSmallTree.m_jets_pnet_pu.push_back(theBigTree.bParticleNetAK4JetTags_probpu->at(iJet));
+	theSmallTree.m_jets_pnet_undef.push_back(theBigTree.bParticleNetAK4JetTags_probundef->at(iJet));
 	++theSmallTree.m_njets ;
       } // loop over jets
 
@@ -5331,6 +5363,14 @@ int main (int argc, char** argv)
 	    theSmallTree.m_addJetCentr1_CvsL            = getCvsL(theBigTree, iJet);
 	    theSmallTree.m_addJetCentr1_CvsB            = getCvsB(theBigTree, iJet);
 	    if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end()) theSmallTree.m_addJetCentr1_HHbtag = jets_and_HHbtag[iJet];
+        theSmallTree.m_addJetCentr1_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
+        theSmallTree.m_addJetCentr1_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
+        theSmallTree.m_addJetCentr1_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
+        theSmallTree.m_addJetCentr1_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
+        theSmallTree.m_addJetCentr1_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
+        theSmallTree.m_addJetCentr1_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
+        theSmallTree.m_addJetCentr1_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
+        theSmallTree.m_addJetCentr1_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
 	    theSmallTree.m_addJetCentr1_smearFactor = jets_and_smearFactor[iJet];
 	    for (int isource = 0; isource < N_jecSources; isource++)
 	    {
@@ -5371,6 +5411,14 @@ int main (int argc, char** argv)
 	    theSmallTree.m_addJetCentr2_CvsL            = getCvsL(theBigTree, iJet);
 	    theSmallTree.m_addJetCentr2_CvsB            = getCvsB(theBigTree, iJet);
 	    if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end()) theSmallTree.m_addJetCentr2_HHbtag = jets_and_HHbtag[iJet];
+	    theSmallTree.m_addJetCentr2_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
+	    theSmallTree.m_addJetCentr2_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
+	    theSmallTree.m_addJetCentr2_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
+	    theSmallTree.m_addJetCentr2_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
+	    theSmallTree.m_addJetCentr2_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
+	    theSmallTree.m_addJetCentr2_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
+	    theSmallTree.m_addJetCentr2_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
+	    theSmallTree.m_addJetCentr2_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
 	    theSmallTree.m_addJetCentr2_smearFactor = jets_and_smearFactor[iJet];
 	    for (int isource = 0; isource < N_jecSources; isource++)
 	    {
@@ -5411,6 +5459,14 @@ int main (int argc, char** argv)
 	    theSmallTree.m_addJetCentr3_CvsL            = getCvsL(theBigTree, iJet);
 	    theSmallTree.m_addJetCentr3_CvsB            = getCvsB(theBigTree, iJet);
 	    if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end()) theSmallTree.m_addJetCentr3_HHbtag = jets_and_HHbtag[iJet];
+        theSmallTree.m_addJetCentr3_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
+        theSmallTree.m_addJetCentr3_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
+        theSmallTree.m_addJetCentr3_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
+        theSmallTree.m_addJetCentr3_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
+        theSmallTree.m_addJetCentr3_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
+        theSmallTree.m_addJetCentr3_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
+        theSmallTree.m_addJetCentr3_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
+        theSmallTree.m_addJetCentr3_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
 	    theSmallTree.m_addJetCentr3_smearFactor = jets_and_smearFactor[iJet];
 	    for (int isource = 0; isource < N_jecSources; isource++)
 	    {
@@ -5451,6 +5507,14 @@ int main (int argc, char** argv)
 	    theSmallTree.m_addJetCentr4_CvsL            = getCvsL(theBigTree, iJet);
 	    theSmallTree.m_addJetCentr4_CvsB            = getCvsB(theBigTree, iJet);
 	    if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end()) theSmallTree.m_addJetCentr4_HHbtag = jets_and_HHbtag[iJet];
+        theSmallTree.m_addJetCentr4_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
+        theSmallTree.m_addJetCentr4_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
+        theSmallTree.m_addJetCentr4_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
+        theSmallTree.m_addJetCentr4_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
+        theSmallTree.m_addJetCentr4_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
+        theSmallTree.m_addJetCentr4_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
+        theSmallTree.m_addJetCentr4_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
+        theSmallTree.m_addJetCentr4_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
 	    theSmallTree.m_addJetCentr4_smearFactor = jets_and_smearFactor[iJet];
 	    for (int isource = 0; isource < N_jecSources; isource++)
 	    {
@@ -5491,6 +5555,14 @@ int main (int argc, char** argv)
 	    theSmallTree.m_addJetCentr5_CvsL            = getCvsL(theBigTree, iJet);
 	    theSmallTree.m_addJetCentr5_CvsB            = getCvsB(theBigTree, iJet);
 	    if (jets_and_HHbtag.find(iJet) != jets_and_HHbtag.end()) theSmallTree.m_addJetCentr5_HHbtag = jets_and_HHbtag[iJet];
+        theSmallTree.m_addJetCentr5_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(iJet);
+        theSmallTree.m_addJetCentr5_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(iJet);
+        theSmallTree.m_addJetCentr5_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(iJet);
+        theSmallTree.m_addJetCentr5_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(iJet);
+        theSmallTree.m_addJetCentr5_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(iJet);
+        theSmallTree.m_addJetCentr5_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(iJet);
+        theSmallTree.m_addJetCentr5_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(iJet);
+        theSmallTree.m_addJetCentr5_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(iJet);
 	    theSmallTree.m_addJetCentr5_smearFactor = jets_and_smearFactor[iJet];
 	    for (int isource = 0; isource < N_jecSources; isource++)
 	    {

--- a/test/skimNtuple2018_HHbtag.cpp
+++ b/test/skimNtuple2018_HHbtag.cpp
@@ -4279,6 +4279,14 @@ int main (int argc, char** argv)
       theSmallTree.m_bjet2_bMVAID  = theBigTree.pfCombinedMVAV2BJetTags->at (bjet2idx) ;
       theSmallTree.m_bjet2_PUjetIDupdated = theBigTree.jets_PUJetIDupdated->at(bjet2idx);
       theSmallTree.m_bjet2_flav = theBigTree.jets_HadronFlavour->at (bjet2idx) ;
+      theSmallTree.m_bjet2_pnet_bb = theBigTree.bParticleNetAK4JetTags_probbb->at(bjet2idx);
+      theSmallTree.m_bjet2_pnet_cc = theBigTree.bParticleNetAK4JetTags_probcc->at(bjet2idx);
+      theSmallTree.m_bjet2_pnet_b = theBigTree.bParticleNetAK4JetTags_probb->at(bjet2idx);
+      theSmallTree.m_bjet2_pnet_c = theBigTree.bParticleNetAK4JetTags_probc->at(bjet2idx);
+      theSmallTree.m_bjet2_pnet_g = theBigTree.bParticleNetAK4JetTags_probg->at(bjet2idx);
+      theSmallTree.m_bjet2_pnet_uds = theBigTree.bParticleNetAK4JetTags_probuds->at(bjet2idx);
+      theSmallTree.m_bjet2_pnet_pu = theBigTree.bParticleNetAK4JetTags_probpu->at(bjet2idx);
+      theSmallTree.m_bjet2_pnet_undef = theBigTree.bParticleNetAK4JetTags_probundef->at(bjet2idx);
 
       theSmallTree.m_bjets_bID  = theBigTree.bCSVscore->at (bjet1idx) +theBigTree.bCSVscore->at (bjet2idx) ;
       theSmallTree.m_bjets_bID_deepCSV  = theBigTree.bDeepCSV_probb->at(bjet1idx) + theBigTree.bDeepCSV_probbb->at(bjet1idx) + theBigTree.bDeepCSV_probb->at(bjet2idx) + theBigTree.bDeepCSV_probbb->at(bjet2idx);


### PR DESCRIPTION
In the PR #296 adding our (UHH) changes, the branches for the ParticleNet discriminators were already added to bigTree.h and smallTree_HHbtag.h (filled with dummy values). We added filling them in the 2017 skimmer some time ago, this PR adds that also for 2016 and 2018.