### PR TITLE
Add DeepMET variables

### DIFF
--- a/interface/bigTree.h
+++ b/interface/bigTree.h
@@ -35,6 +35,10 @@ public :
   Float_t         metphi;
   Float_t         met_er;
   Float_t         met_er_phi;
+  Float_t         ShiftedDeepMETresponseTune_pt;
+  Float_t         ShiftedDeepMETresponseTune_phi;
+  Float_t         ShiftedDeepMETresolutionTune_pt;
+  Float_t         ShiftedDeepMETresolutionTune_phi;
   Int_t           npv;
   Float_t         npu;
   Float_t         PUNumInteractions;
@@ -308,6 +312,10 @@ public :
   TBranch        *b_metphi;   //!
   TBranch        *b_met_er;   //!
   TBranch        *b_met_er_phi;   //!
+  TBranch        *b_ShiftedDeepMETresponseTune_pt;
+  TBranch        *b_ShiftedDeepMETresponseTune_phi;
+  TBranch        *b_ShiftedDeepMETresolutionTune_pt;
+  TBranch        *b_ShiftedDeepMETresolutionTune_phi;
   TBranch        *b_npv;   //!
   TBranch        *b_npu;   //!
   TBranch        *b_PUNumInteractions;   //!
@@ -840,6 +848,10 @@ public :
     fChain->SetBranchAddress("metphi", &metphi, &b_metphi);
     fChain->SetBranchAddress("met_er", &met_er, &b_met_er);
     fChain->SetBranchAddress("met_er_phi", &met_er_phi, &b_met_er_phi);
+    fChain->SetBranchAddress("ShiftedDeepMETresponseTune_pt", &ShiftedDeepMETresponseTune_pt, &b_ShiftedDeepMETresponseTune_pt);
+    fChain->SetBranchAddress("ShiftedDeepMETresponseTune_phi", &ShiftedDeepMETresponseTune_phi, &b_ShiftedDeepMETresponseTune_phi);
+    fChain->SetBranchAddress("ShiftedDeepMETresolutionTune_pt", &ShiftedDeepMETresolutionTune_pt, &b_ShiftedDeepMETresolutionTune_pt);
+    fChain->SetBranchAddress("ShiftedDeepMETresolutionTune_phi", &ShiftedDeepMETresolutionTune_phi, &b_ShiftedDeepMETresolutionTune_phi);
     fChain->SetBranchAddress("npv", &npv, &b_npv);
     fChain->SetBranchAddress("npu", &npu, &b_npu);
     fChain->SetBranchAddress("rho", &rho, &b_rho);

--- a/interface/smallTree_HHbtag.h
+++ b/interface/smallTree_HHbtag.h
@@ -242,6 +242,38 @@ struct smallTree
       m_mT1 = -1. ;
       m_mT2 = -1. ;
 
+      m_DeepMET_ResponseTune_px = -999;
+      m_DeepMET_ResponseTune_px_tauup.clear();
+      m_DeepMET_ResponseTune_px_taudown.clear();
+      m_DeepMET_ResponseTune_px_eleup.clear();
+      m_DeepMET_ResponseTune_px_eledown.clear();
+      m_DeepMET_ResponseTune_px_muup = -999;
+      m_DeepMET_ResponseTune_px_mudown = -999;
+
+      m_DeepMET_ResponseTune_py = -999;
+      m_DeepMET_ResponseTune_py_tauup.clear();
+      m_DeepMET_ResponseTune_py_taudown.clear();
+      m_DeepMET_ResponseTune_py_eleup.clear();
+      m_DeepMET_ResponseTune_py_eledown.clear();
+      m_DeepMET_ResponseTune_py_muup = -999;
+      m_DeepMET_ResponseTune_py_mudown = -999;
+
+      m_DeepMET_ResolutionTune_px = -999;
+      m_DeepMET_ResolutionTune_px_tauup.clear();
+      m_DeepMET_ResolutionTune_px_taudown.clear();
+      m_DeepMET_ResolutionTune_px_eleup.clear();
+      m_DeepMET_ResolutionTune_px_eledown.clear();
+      m_DeepMET_ResolutionTune_px_muup = -999;
+      m_DeepMET_ResolutionTune_px_mudown = -999;
+
+      m_DeepMET_ResolutionTune_py = -999;
+      m_DeepMET_ResolutionTune_py_tauup.clear();
+      m_DeepMET_ResolutionTune_py_taudown.clear();
+      m_DeepMET_ResolutionTune_py_eleup.clear();
+      m_DeepMET_ResolutionTune_py_eledown.clear();
+      m_DeepMET_ResolutionTune_py_muup = -999;
+      m_DeepMET_ResolutionTune_py_mudown = -999;
+
       m_dau1_iso  = -1. ;
       m_dau1_eleMVAiso = -1;
       m_dau1_MVAiso = -1 ;
@@ -1470,6 +1502,38 @@ struct smallTree
       m_smallT->Branch ("met_cov11", &m_met_cov11, "met_cov11/F") ;
       m_smallT->Branch ("mT1", &m_mT1, "mT1/F") ;
       m_smallT->Branch ("mT2", &m_mT2, "mT2/F") ;
+
+      m_smallT->Branch("DeepMET_ResponseTune_px", &m_DeepMET_ResponseTune_px, "DeepMET_ResponseTune_px/F");
+      m_smallT->Branch("DeepMET_ResponseTune_px_tauup", &m_DeepMET_ResponseTune_px_tauup);
+      m_smallT->Branch("DeepMET_ResponseTune_px_taudown", &m_DeepMET_ResponseTune_px_taudown);
+      m_smallT->Branch("DeepMET_ResponseTune_px_eleup", &m_DeepMET_ResponseTune_px_eleup);
+      m_smallT->Branch("DeepMET_ResponseTune_px_eledown", &m_DeepMET_ResponseTune_px_eledown);
+      m_smallT->Branch("DeepMET_ResponseTune_px_muup", &m_DeepMET_ResponseTune_px_muup, "DeepMET_ResponseTune_px_muup/F");
+      m_smallT->Branch("DeepMET_ResponseTune_px_mudown", &m_DeepMET_ResponseTune_px_mudown, "DeepMET_ResponseTune_px_mudown/F");
+
+      m_smallT->Branch("DeepMET_ResponseTune_py", &m_DeepMET_ResponseTune_py, "DeepMET_ResponseTune_py/F");
+      m_smallT->Branch("DeepMET_ResponseTune_py_tauup", &m_DeepMET_ResponseTune_py_tauup);
+      m_smallT->Branch("DeepMET_ResponseTune_py_taudown", &m_DeepMET_ResponseTune_py_taudown);
+      m_smallT->Branch("DeepMET_ResponseTune_py_eleup", &m_DeepMET_ResponseTune_py_eleup);
+      m_smallT->Branch("DeepMET_ResponseTune_py_eledown", &m_DeepMET_ResponseTune_py_eledown);
+      m_smallT->Branch("DeepMET_ResponseTune_py_muup", &m_DeepMET_ResponseTune_py_muup, "DeepMET_ResponseTune_py_muup/F");
+      m_smallT->Branch("DeepMET_ResponseTune_py_mudown", &m_DeepMET_ResponseTune_py_mudown, "DeepMET_ResponseTune_py_mudown/F");
+
+      m_smallT->Branch("DeepMET_ResolutionTune_px", &m_DeepMET_ResolutionTune_px, "DeepMET_ResolutionTune_px");
+      m_smallT->Branch("DeepMET_ResolutionTune_px_tauup", &m_DeepMET_ResolutionTune_px_tauup);
+      m_smallT->Branch("DeepMET_ResolutionTune_px_taudown", &m_DeepMET_ResolutionTune_px_taudown);
+      m_smallT->Branch("DeepMET_ResolutionTune_px_eleup", &m_DeepMET_ResolutionTune_px_eleup);
+      m_smallT->Branch("DeepMET_ResolutionTune_px_eledown", &m_DeepMET_ResolutionTune_px_eledown);
+      m_smallT->Branch("DeepMET_ResolutionTune_px_muup", &m_DeepMET_ResolutionTune_px_muup, "DeepMET_ResolutionTune_px_muup/F");
+      m_smallT->Branch("DeepMET_ResolutionTune_px_mudown", &m_DeepMET_ResolutionTune_px_mudown, "DeepMET_ResolutionTune_px_mudown/F");
+
+      m_smallT->Branch("DeepMET_ResolutionTune_py", &m_DeepMET_ResolutionTune_py, "DeepMET_ResolutionTune_py");
+      m_smallT->Branch("DeepMET_ResolutionTune_py_tauup", &m_DeepMET_ResolutionTune_py_tauup);
+      m_smallT->Branch("DeepMET_ResolutionTune_py_taudown", &m_DeepMET_ResolutionTune_py_taudown);
+      m_smallT->Branch("DeepMET_ResolutionTune_py_eleup", &m_DeepMET_ResolutionTune_py_eleup);
+      m_smallT->Branch("DeepMET_ResolutionTune_py_eledown", &m_DeepMET_ResolutionTune_py_eledown);
+      m_smallT->Branch("DeepMET_ResolutionTune_py_muup", &m_DeepMET_ResolutionTune_py_muup, "DeepMET_ResolutionTune_py_muup/F");
+      m_smallT->Branch("DeepMET_ResolutionTune_py_mudown", &m_DeepMET_ResolutionTune_py_mudown, "DeepMET_ResolutionTune_py_mudown/F");
 
       m_smallT->Branch ("dau1_iso", &m_dau1_iso, "dau1_iso/F") ;
       m_smallT->Branch ("dau1_eleMVAiso", &m_dau1_eleMVAiso, "dau1_eleMVAiso/I") ;
@@ -2700,6 +2764,38 @@ struct smallTree
   // mt
   Float_t m_mT1 ;
   Float_t m_mT2 ;
+
+  Float_t m_DeepMET_ResponseTune_px;
+  std::vector<Float_t> m_DeepMET_ResponseTune_px_tauup;
+  std::vector<Float_t> m_DeepMET_ResponseTune_px_taudown;
+  std::vector<Float_t> m_DeepMET_ResponseTune_px_eleup;
+  std::vector<Float_t> m_DeepMET_ResponseTune_px_eledown;
+  Float_t m_DeepMET_ResponseTune_px_muup;
+  Float_t m_DeepMET_ResponseTune_px_mudown;
+
+  Float_t m_DeepMET_ResponseTune_py;
+  std::vector<Float_t> m_DeepMET_ResponseTune_py_tauup;
+  std::vector<Float_t> m_DeepMET_ResponseTune_py_taudown;
+  std::vector<Float_t> m_DeepMET_ResponseTune_py_eleup;
+  std::vector<Float_t> m_DeepMET_ResponseTune_py_eledown;
+  Float_t m_DeepMET_ResponseTune_py_muup;
+  Float_t m_DeepMET_ResponseTune_py_mudown;
+
+  Float_t m_DeepMET_ResolutionTune_px;
+  std::vector<Float_t> m_DeepMET_ResolutionTune_px_tauup;
+  std::vector<Float_t> m_DeepMET_ResolutionTune_px_taudown;
+  std::vector<Float_t> m_DeepMET_ResolutionTune_px_eleup;
+  std::vector<Float_t> m_DeepMET_ResolutionTune_px_eledown;
+  Float_t m_DeepMET_ResolutionTune_px_muup;
+  Float_t m_DeepMET_ResolutionTune_px_mudown;
+
+  Float_t m_DeepMET_ResolutionTune_py;
+  std::vector<Float_t> m_DeepMET_ResolutionTune_py_tauup;
+  std::vector<Float_t> m_DeepMET_ResolutionTune_py_taudown;
+  std::vector<Float_t> m_DeepMET_ResolutionTune_py_eleup;
+  std::vector<Float_t> m_DeepMET_ResolutionTune_py_eledown;
+  Float_t m_DeepMET_ResolutionTune_py_muup;
+  Float_t m_DeepMET_ResolutionTune_py_mudown;
 
   // the largest pT daughter visible candidate
   Float_t m_dau1_iso ;

--- a/test/skimNtuple2016_HHbtag.cpp
+++ b/test/skimNtuple2016_HHbtag.cpp
@@ -2166,6 +2166,14 @@ int main (int argc, char** argv)
     TLorentzVector tlv_MET;
     tlv_MET.SetPxPyPzE(theBigTree.METx->at(chosenTauPair), theBigTree.METy->at(chosenTauPair), 0, std::hypot(theBigTree.METx->at(chosenTauPair), theBigTree.METy->at(chosenTauPair)));
 
+    TLorentzVector tlv_DeepMET_ResponseTune;
+    tlv_DeepMET_ResponseTune.SetPtEtaPhiM(theBigTree.ShiftedDeepMETresponseTune_pt, 0, theBigTree.ShiftedDeepMETresponseTune_phi, 0);
+    TVector2 vDeepMET_ResponseTune(tlv_DeepMET_ResponseTune.Px(), tlv_DeepMET_ResponseTune.Py());
+
+    TLorentzVector tlv_DeepMET_ResolutionTune;
+    tlv_DeepMET_ResolutionTune.SetPtEtaPhiM(theBigTree.ShiftedDeepMETresolutionTune_pt, 0, theBigTree.ShiftedDeepMETresolutionTune_phi, 0);
+    TVector2 vDeepMET_ResolutionTune(tlv_DeepMET_ResolutionTune.Px(), tlv_DeepMET_ResolutionTune.Py());
+
     // Temporary SVFit recomputation for data.
     if(!isMC){
       TMatrixD metcov_tmp (2, 2) ;
@@ -2306,6 +2314,10 @@ int main (int argc, char** argv)
     theSmallTree.m_met_cov01 = theBigTree.MET_cov01->at (chosenTauPair);
     theSmallTree.m_met_cov10 = theBigTree.MET_cov10->at (chosenTauPair);
     theSmallTree.m_met_cov11 = theBigTree.MET_cov11->at (chosenTauPair);
+    theSmallTree.m_DeepMET_ResponseTune_px = vDeepMET_ResponseTune.X();
+    theSmallTree.m_DeepMET_ResponseTune_py = vDeepMET_ResponseTune.Y();
+    theSmallTree.m_DeepMET_ResolutionTune_px = vDeepMET_ResolutionTune.X();
+    theSmallTree.m_DeepMET_ResolutionTune_py = vDeepMET_ResolutionTune.Y();
 
     // L1ECALPrefiringWeight - https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1ECALPrefiringWeightRecipe
     theSmallTree.m_L1pref_weight = theBigTree.prefiringweight;
@@ -4289,9 +4301,20 @@ int main (int argc, char** argv)
       {
 	// Shifted MET for TES/EES
 	auto vMET_shifts_tes_ees = getShiftedMET_tes_ees(N_tauhDM, N_tauhDM_EES, vMET, theBigTree, DEBUG);
+
+	// Shifted DeepMET for TES/EES
+	auto vDeepMET_ResponseTune_shifts_tes_ees = getShiftedMET_tes_ees(N_tauhDM, N_tauhDM_EES, vDeepMET_ResponseTune, theBigTree, DEBUG);
+	auto vDeepMET_ResolutionTune_shifts_tes_ees = getShiftedMET_tes_ees(N_tauhDM, N_tauhDM_EES, vDeepMET_ResolutionTune, theBigTree, DEBUG);
+
 	//unpack: first is tes, second is ees
 	auto vMET_shift_tes = vMET_shifts_tes_ees.first;
 	auto vMET_shift_ees = vMET_shifts_tes_ees.second;
+
+	auto vDeepMET_ResponseTune_shifts_tes = vDeepMET_ResponseTune_shifts_tes_ees.first;
+	auto vDeepMET_ResponseTune_shifts_ees = vDeepMET_ResponseTune_shifts_tes_ees.second;
+
+	auto vDeepMET_ResolutionTune_shifts_tes = vDeepMET_ResolutionTune_shifts_tes_ees.first;
+	auto vDeepMET_ResolutionTune_shifts_ees = vDeepMET_ResolutionTune_shifts_tes_ees.second;
 	for (int idm = 0; idm < N_tauhDM; idm++)
 	{
 	  theSmallTree.m_METx_tauup.push_back(vMET_shift_tes.first.at(idm).X());
@@ -4299,12 +4322,32 @@ int main (int argc, char** argv)
 	  theSmallTree.m_METx_taudown.push_back(vMET_shift_tes.second.at(idm).X());
 	  theSmallTree.m_METy_taudown.push_back(vMET_shift_tes.second.at(idm).Y());
 
+	  theSmallTree.m_DeepMET_ResponseTune_px_tauup.push_back(vDeepMET_ResponseTune_shifts_tes.first.at(idm).X());
+	  theSmallTree.m_DeepMET_ResponseTune_py_tauup.push_back(vDeepMET_ResponseTune_shifts_tes.first.at(idm).Y());
+	  theSmallTree.m_DeepMET_ResponseTune_px_taudown.push_back(vDeepMET_ResponseTune_shifts_tes.second.at(idm).X());
+	  theSmallTree.m_DeepMET_ResponseTune_py_taudown.push_back(vDeepMET_ResponseTune_shifts_tes.second.at(idm).Y());
+
+	  theSmallTree.m_DeepMET_ResolutionTune_px_tauup.push_back(vDeepMET_ResolutionTune_shifts_tes.first.at(idm).X());
+	  theSmallTree.m_DeepMET_ResolutionTune_py_tauup.push_back(vDeepMET_ResolutionTune_shifts_tes.first.at(idm).Y());
+	  theSmallTree.m_DeepMET_ResolutionTune_px_taudown.push_back(vDeepMET_ResolutionTune_shifts_tes.second.at(idm).X());
+	  theSmallTree.m_DeepMET_ResolutionTune_py_taudown.push_back(vDeepMET_ResolutionTune_shifts_tes.second.at(idm).Y());
+
 	  if (idm <N_tauhDM_EES)
 	  {
 	    theSmallTree.m_METx_eleup.push_back(vMET_shift_ees.first.at(idm).X());
 	    theSmallTree.m_METy_eleup.push_back(vMET_shift_ees.first.at(idm).Y());
 	    theSmallTree.m_METx_eledown.push_back(vMET_shift_ees.second.at(idm).X());
 	    theSmallTree.m_METy_eledown.push_back(vMET_shift_ees.second.at(idm).Y());
+
+	    theSmallTree.m_DeepMET_ResponseTune_px_eleup.push_back(vDeepMET_ResponseTune_shifts_ees.first.at(idm).X());
+	    theSmallTree.m_DeepMET_ResponseTune_py_eleup.push_back(vDeepMET_ResponseTune_shifts_ees.first.at(idm).Y());
+	    theSmallTree.m_DeepMET_ResponseTune_px_eledown.push_back(vDeepMET_ResponseTune_shifts_ees.second.at(idm).X());
+	    theSmallTree.m_DeepMET_ResponseTune_py_eledown.push_back(vDeepMET_ResponseTune_shifts_ees.second.at(idm).Y());
+
+	    theSmallTree.m_DeepMET_ResolutionTune_px_eleup.push_back(vDeepMET_ResolutionTune_shifts_ees.first.at(idm).X());
+	    theSmallTree.m_DeepMET_ResolutionTune_py_eleup.push_back(vDeepMET_ResolutionTune_shifts_ees.first.at(idm).Y());
+	    theSmallTree.m_DeepMET_ResolutionTune_px_eledown.push_back(vDeepMET_ResolutionTune_shifts_ees.second.at(idm).X());
+	    theSmallTree.m_DeepMET_ResolutionTune_py_eledown.push_back(vDeepMET_ResolutionTune_shifts_ees.second.at(idm).Y());
 	  }
 	}
 
@@ -4314,6 +4357,19 @@ int main (int argc, char** argv)
 	theSmallTree.m_METy_muup = vMET_shift_mes.first.Y();
 	theSmallTree.m_METx_mudown = vMET_shift_mes.second.X();
 	theSmallTree.m_METy_mudown = vMET_shift_mes.second.Y();
+
+	// Shifted DeepMET for MES
+	auto vDeepMET_ResponseTune_shift_mes = getShiftedMET_mes(vDeepMET_ResponseTune, theBigTree, DEBUG);
+	theSmallTree.m_DeepMET_ResponseTune_px_muup = vDeepMET_ResponseTune_shift_mes.first.X();
+	theSmallTree.m_DeepMET_ResponseTune_py_muup = vDeepMET_ResponseTune_shift_mes.first.Y();
+	theSmallTree.m_DeepMET_ResponseTune_px_mudown = vDeepMET_ResponseTune_shift_mes.second.X();
+	theSmallTree.m_DeepMET_ResponseTune_py_mudown = vDeepMET_ResponseTune_shift_mes.second.Y();
+
+	auto vDeepMET_ResolutionTune_shift_mes = getShiftedMET_mes(vDeepMET_ResolutionTune, theBigTree, DEBUG);
+	theSmallTree.m_DeepMET_ResolutionTune_px_muup = vDeepMET_ResolutionTune_shift_mes.first.X();
+	theSmallTree.m_DeepMET_ResolutionTune_py_muup = vDeepMET_ResolutionTune_shift_mes.first.Y();
+	theSmallTree.m_DeepMET_ResolutionTune_px_mudown = vDeepMET_ResolutionTune_shift_mes.second.X();
+	theSmallTree.m_DeepMET_ResolutionTune_py_mudown = vDeepMET_ResolutionTune_shift_mes.second.Y();
 
 	// Shifted MET for JES total
 	auto vMET_shift_jetTot = getShiftedMET_jetTot(N_jecSources, vMET, theBigTree, JECprovider, DEBUG);

--- a/test/skimNtuple2017_HHbtag.cpp
+++ b/test/skimNtuple2017_HHbtag.cpp
@@ -2193,7 +2193,15 @@ int main (int argc, char** argv)
     TVector2 vMET(theBigTree.METx->at(chosenTauPair) , theBigTree.METy->at(chosenTauPair));
     TLorentzVector tlv_MET;
     tlv_MET.SetPxPyPzE(theBigTree.METx->at(chosenTauPair), theBigTree.METy->at(chosenTauPair), 0, std::hypot(theBigTree.METx->at(chosenTauPair), theBigTree.METy->at(chosenTauPair)));
-    
+
+    TLorentzVector tlv_DeepMET_ResponseTune;
+    tlv_DeepMET_ResponseTune.SetPtEtaPhiM(theBigTree.ShiftedDeepMETresponseTune_pt, 0, theBigTree.ShiftedDeepMETresponseTune_phi, 0);
+    TVector2 vDeepMET_ResponseTune(tlv_DeepMET_ResponseTune.Px(), tlv_DeepMET_ResponseTune.Py());
+
+    TLorentzVector tlv_DeepMET_ResolutionTune;
+    tlv_DeepMET_ResolutionTune.SetPtEtaPhiM(theBigTree.ShiftedDeepMETresolutionTune_pt, 0, theBigTree.ShiftedDeepMETresolutionTune_phi, 0);
+    TVector2 vDeepMET_ResolutionTune(tlv_DeepMET_ResolutionTune.Px(), tlv_DeepMET_ResolutionTune.Py());
+
     // Temporary SVFit recomputation for data.
     if(!isMC){
       TMatrixD metcov_tmp (2, 2) ;
@@ -2333,6 +2341,11 @@ int main (int argc, char** argv)
     theSmallTree.m_met_cov01 = theBigTree.MET_cov01->at (chosenTauPair);
     theSmallTree.m_met_cov10 = theBigTree.MET_cov10->at (chosenTauPair);
     theSmallTree.m_met_cov11 = theBigTree.MET_cov11->at (chosenTauPair);
+    theSmallTree.m_DeepMET_ResponseTune_px = vDeepMET_ResponseTune.X();
+    theSmallTree.m_DeepMET_ResponseTune_py = vDeepMET_ResponseTune.Y();
+    theSmallTree.m_DeepMET_ResolutionTune_px = vDeepMET_ResolutionTune.X();
+    theSmallTree.m_DeepMET_ResolutionTune_py = vDeepMET_ResolutionTune.Y();
+
 
     // L1ECALPrefiringWeight - https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1ECALPrefiringWeightRecipe
     theSmallTree.m_L1pref_weight = theBigTree.prefiringweight;
@@ -4586,20 +4599,52 @@ int main (int argc, char** argv)
       {
         // Shifted MET for TES/EES
         auto vMET_shifts_tes_ees = getShiftedMET_tes_ees(N_tauhDM, N_tauhDM_EES, vMET, theBigTree, DEBUG);
+
+        // Shifted DeepMET for TES/EES
+        auto vDeepMET_ResponseTune_shifts_tes_ees = getShiftedMET_tes_ees(N_tauhDM, N_tauhDM_EES, vDeepMET_ResponseTune, theBigTree, DEBUG);
+        auto vDeepMET_ResolutionTune_shifts_tes_ees = getShiftedMET_tes_ees(N_tauhDM, N_tauhDM_EES, vDeepMET_ResolutionTune, theBigTree, DEBUG);
+
         //unpack: first is tes, second is ees
         auto vMET_shift_tes = vMET_shifts_tes_ees.first;
         auto vMET_shift_ees = vMET_shifts_tes_ees.second;
+
+        auto vDeepMET_ResponseTune_shifts_tes = vDeepMET_ResponseTune_shifts_tes_ees.first;
+        auto vDeepMET_ResponseTune_shifts_ees = vDeepMET_ResponseTune_shifts_tes_ees.second;
+
+        auto vDeepMET_ResolutionTune_shifts_tes = vDeepMET_ResolutionTune_shifts_tes_ees.first;
+        auto vDeepMET_ResolutionTune_shifts_ees = vDeepMET_ResolutionTune_shifts_tes_ees.second;
         for (int idm = 0; idm < N_tauhDM; idm++)
         {
           theSmallTree.m_METx_tauup.push_back(vMET_shift_tes.first.at(idm).X());
           theSmallTree.m_METy_tauup.push_back(vMET_shift_tes.first.at(idm).Y());
           theSmallTree.m_METx_taudown.push_back(vMET_shift_tes.second.at(idm).X());
           theSmallTree.m_METy_taudown.push_back(vMET_shift_tes.second.at(idm).Y());
+
+          theSmallTree.m_DeepMET_ResponseTune_px_tauup.push_back(vDeepMET_ResponseTune_shifts_tes.first.at(idm).X());
+          theSmallTree.m_DeepMET_ResponseTune_py_tauup.push_back(vDeepMET_ResponseTune_shifts_tes.first.at(idm).Y());
+          theSmallTree.m_DeepMET_ResponseTune_px_taudown.push_back(vDeepMET_ResponseTune_shifts_tes.second.at(idm).X());
+          theSmallTree.m_DeepMET_ResponseTune_py_taudown.push_back(vDeepMET_ResponseTune_shifts_tes.second.at(idm).Y());
+
+          theSmallTree.m_DeepMET_ResolutionTune_px_tauup.push_back(vDeepMET_ResolutionTune_shifts_tes.first.at(idm).X());
+          theSmallTree.m_DeepMET_ResolutionTune_py_tauup.push_back(vDeepMET_ResolutionTune_shifts_tes.first.at(idm).Y());
+          theSmallTree.m_DeepMET_ResolutionTune_px_taudown.push_back(vDeepMET_ResolutionTune_shifts_tes.second.at(idm).X());
+          theSmallTree.m_DeepMET_ResolutionTune_py_taudown.push_back(vDeepMET_ResolutionTune_shifts_tes.second.at(idm).Y());
+
           if (idm <N_tauhDM_EES){
             theSmallTree.m_METx_eleup.push_back(vMET_shift_ees.first.at(idm).X());
             theSmallTree.m_METy_eleup.push_back(vMET_shift_ees.first.at(idm).Y());
             theSmallTree.m_METx_eledown.push_back(vMET_shift_ees.second.at(idm).X());
             theSmallTree.m_METy_eledown.push_back(vMET_shift_ees.second.at(idm).Y());
+
+            theSmallTree.m_DeepMET_ResponseTune_px_eleup.push_back(vDeepMET_ResponseTune_shifts_ees.first.at(idm).X());
+            theSmallTree.m_DeepMET_ResponseTune_py_eleup.push_back(vDeepMET_ResponseTune_shifts_ees.first.at(idm).Y());
+            theSmallTree.m_DeepMET_ResponseTune_px_eledown.push_back(vDeepMET_ResponseTune_shifts_ees.second.at(idm).X());
+            theSmallTree.m_DeepMET_ResponseTune_py_eledown.push_back(vDeepMET_ResponseTune_shifts_ees.second.at(idm).Y());
+
+            theSmallTree.m_DeepMET_ResolutionTune_px_eleup.push_back(vDeepMET_ResolutionTune_shifts_ees.first.at(idm).X());
+            theSmallTree.m_DeepMET_ResolutionTune_py_eleup.push_back(vDeepMET_ResolutionTune_shifts_ees.first.at(idm).Y());
+            theSmallTree.m_DeepMET_ResolutionTune_px_eledown.push_back(vDeepMET_ResolutionTune_shifts_ees.second.at(idm).X());
+            theSmallTree.m_DeepMET_ResolutionTune_py_eledown.push_back(vDeepMET_ResolutionTune_shifts_ees.second.at(idm).Y());
           }
         }
 
@@ -4609,6 +4654,19 @@ int main (int argc, char** argv)
         theSmallTree.m_METy_muup = vMET_shift_mes.first.Y();
         theSmallTree.m_METx_mudown = vMET_shift_mes.second.X();
         theSmallTree.m_METy_mudown = vMET_shift_mes.second.Y();
+
+        // Shifted DeepMET for MES
+        auto vDeepMET_ResponseTune_shift_mes = getShiftedMET_mes(vDeepMET_ResponseTune, theBigTree, DEBUG);
+        theSmallTree.m_DeepMET_ResponseTune_px_muup = vDeepMET_ResponseTune_shift_mes.first.X();
+        theSmallTree.m_DeepMET_ResponseTune_py_muup = vDeepMET_ResponseTune_shift_mes.first.Y();
+        theSmallTree.m_DeepMET_ResponseTune_px_mudown = vDeepMET_ResponseTune_shift_mes.second.X();
+        theSmallTree.m_DeepMET_ResponseTune_py_mudown = vDeepMET_ResponseTune_shift_mes.second.Y();
+
+        auto vDeepMET_ResolutionTune_shift_mes = getShiftedMET_mes(vDeepMET_ResolutionTune, theBigTree, DEBUG);
+        theSmallTree.m_DeepMET_ResolutionTune_px_muup = vDeepMET_ResolutionTune_shift_mes.first.X();
+        theSmallTree.m_DeepMET_ResolutionTune_py_muup = vDeepMET_ResolutionTune_shift_mes.first.Y();
+        theSmallTree.m_DeepMET_ResolutionTune_px_mudown = vDeepMET_ResolutionTune_shift_mes.second.X();
+        theSmallTree.m_DeepMET_ResolutionTune_py_mudown = vDeepMET_ResolutionTune_shift_mes.second.Y();
 
         // Shifted MET for JES total
         auto vMET_shift_jetTot = getShiftedMET_jetTot(N_jecSources, vMET, theBigTree, JECprovider, DEBUG);

--- a/test/skimNtuple2018_HHbtag.cpp
+++ b/test/skimNtuple2018_HHbtag.cpp
@@ -2309,6 +2309,14 @@ int main (int argc, char** argv)
     TLorentzVector tlv_MET;
     tlv_MET.SetPxPyPzE(theBigTree.METx->at(chosenTauPair), theBigTree.METy->at(chosenTauPair), 0, std::hypot(theBigTree.METx->at(chosenTauPair), theBigTree.METy->at(chosenTauPair)));
 
+    TLorentzVector tlv_DeepMET_ResponseTune;
+    tlv_DeepMET_ResponseTune.SetPtEtaPhiM(theBigTree.ShiftedDeepMETresponseTune_pt, 0, theBigTree.ShiftedDeepMETresponseTune_phi, 0);
+    TVector2 vDeepMET_ResponseTune(tlv_DeepMET_ResponseTune.Px(), tlv_DeepMET_ResponseTune.Py());
+
+    TLorentzVector tlv_DeepMET_ResolutionTune;
+    tlv_DeepMET_ResolutionTune.SetPtEtaPhiM(theBigTree.ShiftedDeepMETresolutionTune_pt, 0, theBigTree.ShiftedDeepMETresolutionTune_phi, 0);
+    TVector2 vDeepMET_ResolutionTune(tlv_DeepMET_ResolutionTune.Px(), tlv_DeepMET_ResolutionTune.Py());
+
     // Temporary SVFit recomputation for data.
     if(!isMC){
       TMatrixD metcov_tmp (2, 2) ;
@@ -2450,6 +2458,10 @@ int main (int argc, char** argv)
     theSmallTree.m_met_cov01 = theBigTree.MET_cov01->at (chosenTauPair);
     theSmallTree.m_met_cov10 = theBigTree.MET_cov10->at (chosenTauPair);
     theSmallTree.m_met_cov11 = theBigTree.MET_cov11->at (chosenTauPair);
+    theSmallTree.m_DeepMET_ResponseTune_px = vDeepMET_ResponseTune.X();
+    theSmallTree.m_DeepMET_ResponseTune_py = vDeepMET_ResponseTune.Y();
+    theSmallTree.m_DeepMET_ResolutionTune_px = vDeepMET_ResolutionTune.X();
+    theSmallTree.m_DeepMET_ResolutionTune_py = vDeepMET_ResolutionTune.Y();
 
     theSmallTree.m_metnomu_phi   = vMETnoMu.Phi();
     theSmallTree.m_metnomu_et    = vMETnoMu.Mod();
@@ -4572,20 +4584,52 @@ int main (int argc, char** argv)
       {
 	// Shifted MET for TES/EES
 	auto vMET_shifts_tes_ees = getShiftedMET_tes_ees(N_tauhDM, N_tauhDM_EES, vMET, theBigTree, DEBUG);
+
+	// Shifted DeepMET for TES/EES
+	auto vDeepMET_ResponseTune_shifts_tes_ees = getShiftedMET_tes_ees(N_tauhDM, N_tauhDM_EES, vDeepMET_ResponseTune, theBigTree, DEBUG);
+	auto vDeepMET_ResolutionTune_shifts_tes_ees = getShiftedMET_tes_ees(N_tauhDM, N_tauhDM_EES, vDeepMET_ResolutionTune, theBigTree, DEBUG);
+
 	//unpack: first is tes, second is ees
 	auto vMET_shift_tes = vMET_shifts_tes_ees.first;
 	auto vMET_shift_ees = vMET_shifts_tes_ees.second;
+
+	auto vDeepMET_ResponseTune_shifts_tes = vDeepMET_ResponseTune_shifts_tes_ees.first;
+	auto vDeepMET_ResponseTune_shifts_ees = vDeepMET_ResponseTune_shifts_tes_ees.second;
+
+	auto vDeepMET_ResolutionTune_shifts_tes = vDeepMET_ResolutionTune_shifts_tes_ees.first;
+	auto vDeepMET_ResolutionTune_shifts_ees = vDeepMET_ResolutionTune_shifts_tes_ees.second;
 	for (int idm = 0; idm < N_tauhDM; idm++)
 	{
 	  theSmallTree.m_METx_tauup.push_back(vMET_shift_tes.first.at(idm).X());
 	  theSmallTree.m_METy_tauup.push_back(vMET_shift_tes.first.at(idm).Y());
 	  theSmallTree.m_METx_taudown.push_back(vMET_shift_tes.second.at(idm).X());
 	  theSmallTree.m_METy_taudown.push_back(vMET_shift_tes.second.at(idm).Y());
+
+	  theSmallTree.m_DeepMET_ResponseTune_px_tauup.push_back(vDeepMET_ResponseTune_shifts_tes.first.at(idm).X());
+	  theSmallTree.m_DeepMET_ResponseTune_py_tauup.push_back(vDeepMET_ResponseTune_shifts_tes.first.at(idm).Y());
+	  theSmallTree.m_DeepMET_ResponseTune_px_taudown.push_back(vDeepMET_ResponseTune_shifts_tes.second.at(idm).X());
+	  theSmallTree.m_DeepMET_ResponseTune_py_taudown.push_back(vDeepMET_ResponseTune_shifts_tes.second.at(idm).Y());
+
+	  theSmallTree.m_DeepMET_ResolutionTune_px_tauup.push_back(vDeepMET_ResolutionTune_shifts_tes.first.at(idm).X());
+	  theSmallTree.m_DeepMET_ResolutionTune_py_tauup.push_back(vDeepMET_ResolutionTune_shifts_tes.first.at(idm).Y());
+	  theSmallTree.m_DeepMET_ResolutionTune_px_taudown.push_back(vDeepMET_ResolutionTune_shifts_tes.second.at(idm).X());
+	  theSmallTree.m_DeepMET_ResolutionTune_py_taudown.push_back(vDeepMET_ResolutionTune_shifts_tes.second.at(idm).Y());
+
 	  if (idm <N_tauhDM_EES){
 	    theSmallTree.m_METx_eleup.push_back(vMET_shift_ees.first.at(idm).X());
 	    theSmallTree.m_METy_eleup.push_back(vMET_shift_ees.first.at(idm).Y());
 	    theSmallTree.m_METx_eledown.push_back(vMET_shift_ees.second.at(idm).X());
 	    theSmallTree.m_METy_eledown.push_back(vMET_shift_ees.second.at(idm).Y());
+
+	    theSmallTree.m_DeepMET_ResponseTune_px_eleup.push_back(vDeepMET_ResponseTune_shifts_ees.first.at(idm).X());
+	    theSmallTree.m_DeepMET_ResponseTune_py_eleup.push_back(vDeepMET_ResponseTune_shifts_ees.first.at(idm).Y());
+	    theSmallTree.m_DeepMET_ResponseTune_px_eledown.push_back(vDeepMET_ResponseTune_shifts_ees.second.at(idm).X());
+	    theSmallTree.m_DeepMET_ResponseTune_py_eledown.push_back(vDeepMET_ResponseTune_shifts_ees.second.at(idm).Y());
+
+	    theSmallTree.m_DeepMET_ResolutionTune_px_eleup.push_back(vDeepMET_ResolutionTune_shifts_ees.first.at(idm).X());
+	    theSmallTree.m_DeepMET_ResolutionTune_py_eleup.push_back(vDeepMET_ResolutionTune_shifts_ees.first.at(idm).Y());
+	    theSmallTree.m_DeepMET_ResolutionTune_px_eledown.push_back(vDeepMET_ResolutionTune_shifts_ees.second.at(idm).X());
+	    theSmallTree.m_DeepMET_ResolutionTune_py_eledown.push_back(vDeepMET_ResolutionTune_shifts_ees.second.at(idm).Y());
 	  }
 	}
 
@@ -4595,6 +4639,19 @@ int main (int argc, char** argv)
 	theSmallTree.m_METy_muup = vMET_shift_mes.first.Y();
 	theSmallTree.m_METx_mudown = vMET_shift_mes.second.X();
 	theSmallTree.m_METy_mudown = vMET_shift_mes.second.Y();
+
+	// Shifted DeepMET for MES
+	auto vDeepMET_ResponseTune_shift_mes = getShiftedMET_mes(vDeepMET_ResponseTune, theBigTree, DEBUG);
+	theSmallTree.m_DeepMET_ResponseTune_px_muup = vDeepMET_ResponseTune_shift_mes.first.X();
+	theSmallTree.m_DeepMET_ResponseTune_py_muup = vDeepMET_ResponseTune_shift_mes.first.Y();
+	theSmallTree.m_DeepMET_ResponseTune_px_mudown = vDeepMET_ResponseTune_shift_mes.second.X();
+	theSmallTree.m_DeepMET_ResponseTune_py_mudown = vDeepMET_ResponseTune_shift_mes.second.Y();
+
+	auto vDeepMET_ResolutionTune_shift_mes = getShiftedMET_mes(vDeepMET_ResolutionTune, theBigTree, DEBUG);
+	theSmallTree.m_DeepMET_ResolutionTune_px_muup = vDeepMET_ResolutionTune_shift_mes.first.X();
+	theSmallTree.m_DeepMET_ResolutionTune_py_muup = vDeepMET_ResolutionTune_shift_mes.first.Y();
+	theSmallTree.m_DeepMET_ResolutionTune_px_mudown = vDeepMET_ResolutionTune_shift_mes.second.X();
+	theSmallTree.m_DeepMET_ResolutionTune_py_mudown = vDeepMET_ResolutionTune_shift_mes.second.Y();
 
 	// Shifted MET for JES total
 	auto vMET_shift_jetTot = getShiftedMET_jetTot(N_jecSources, vMET, theBigTree, JECprovider, DEBUG);


### PR DESCRIPTION
This PR adds px and py for the two DeepMET Tunes (Response and Resolution) as well as the shifted values for TES, EES and MES