### PR TITLE
Selection synchronization

### DIFF
--- a/interface/SmearedJetProducer.h
+++ b/interface/SmearedJetProducer.h
@@ -51,7 +51,8 @@ public:
   TLorentzVector matchedGenJet(TLorentzVector jet, double resolution, bigTree & theBigTree);
 
   // Returns the smear factor to be applied to the jet TLorentzVector
-  double getSmearFactor(TLorentzVector jet, bigTree & theBigTree);
+  double getSmearFactor(TLorentzVector jet, bigTree & theBigTree,
+						bool ptJetCut = true);
 
   // Returns the smeared jet starting from the original TLorentzVector
   TLorentzVector getSmearedJet(TLorentzVector jet, bigTree & theBigTree);

--- a/src/AnalysisHelper.cc
+++ b/src/AnalysisHelper.cc
@@ -1198,10 +1198,11 @@ void AnalysisHelper::fillHistosSample(Sample& sample)
   }
 
   cout << "  fillHistos();" << endl;
-  for (uint is = 0; is < bkg_samples_.size(); ++is)
-	{
+  if (DEBUG) {
+	for (uint is = 0; is < bkg_samples_.size(); ++is) {
 	  cout << "  " << is << " >> " << setw(25) << left << bkg_samples_.at(is)->getName() << setw(13) << " nweights: " << bkg_samples_.at(is)->getWeights().size() << endl;
 	}
+  }
 
 }
 

--- a/src/OfflineProducerHelper.cc
+++ b/src/OfflineProducerHelper.cc
@@ -302,10 +302,10 @@ OfflineProducerHelper::eleBaseline (bigTree* tree, int iDau,
   if (debug)
   {
     cout << "@ ele baseline" << endl;
-    cout << " idS     "  << idS     << " skypped? " << byp_idS << endl;
-    cout << " vertexS "  << vertexS << " skypped? " << byp_vertexS << endl;
-    cout << " ptS     "  << ptS     << " skypped? " << byp_ptS << endl;
-    cout << " etaS    "  << etaS    << " skypped? " << byp_etaS << endl;
+    cout << " idS     "  << idS     << " skipped? " << byp_idS << endl;
+    cout << " vertexS "  << vertexS << " skipped? " << byp_vertexS << endl;
+    cout << " ptS     "  << ptS     << " skipped? " << byp_ptS << endl;
+    cout << " etaS    "  << etaS    << " skipped? " << byp_etaS << endl;
   }
 
   return totalS;
@@ -375,12 +375,12 @@ OfflineProducerHelper::eleBaseline (bigTree* tree, int iDau,
   if (debug)
   {
     cout << "@ ele baseline" << endl;
-    cout << " idS     "  << idS     << " skypped? " << byp_idS << endl;
-    cout << " nISOidS "  << nISOidS << " skypped? " << byp_noISOidS << endl;
-    cout << " isoS    "  << isoS    << " skypped? " << byp_isoS << endl;
-    cout << " vertexS "  << vertexS << " skypped? " << byp_vertexS << endl;
-    cout << " ptS     "  << ptS     << " skypped? " << byp_ptS << endl;
-    cout << " etaS    "  << etaS    << " skypped? " << byp_etaS << endl;
+    cout << " idS     "  << idS     << " skipped? " << byp_idS << endl;
+    cout << " nISOidS "  << nISOidS << " skipped? " << byp_noISOidS << endl;
+    cout << " isoS    "  << isoS    << " skipped? " << byp_isoS << endl;
+    cout << " vertexS "  << vertexS << " skipped? " << byp_vertexS << endl;
+    cout << " ptS     "  << ptS     << " skipped? " << byp_ptS << endl;
+    cout << " etaS    "  << etaS    << " skipped? " << byp_etaS << endl;
   }
 
   return totalS;
@@ -439,13 +439,13 @@ bool OfflineProducerHelper::muBaseline (
   if (debug)
   {
     cout << "@ mu baseline" << endl;
-	cout << " id1S	   " << id1S	<< " skypped? " << byp_idS << endl;
-	cout << " id2S	   " << id2S	<< " skypped? " << byp_idS << endl;
-	cout << " vertexS "	 << vertexS	<< " skypped? " << byp_vertexS << endl;
-	cout << " iso1S	   " << iso1S	<< " skypped? " << byp_isoS << endl;
-	cout << " iso2S	   " << iso2S	<< " skypped? " << byp_isoS << endl;
-	cout << " ptS	  "	 << ptS		<< " skypped? " << byp_ptS << endl;
-	cout << " etaS	  "	 << etaS	<< " skypped? " << byp_etaS << endl;
+	cout << " id1S	   " << id1S	<< " skipped? " << byp_idS << endl;
+	cout << " id2S	   " << id2S	<< " skipped? " << byp_idS << endl;
+	cout << " vertexS "	 << vertexS	<< " skipped? " << byp_vertexS << endl;
+	cout << " iso1S	   " << iso1S	<< " skipped? " << byp_isoS << endl;
+	cout << " iso2S	   " << iso2S	<< " skipped? " << byp_isoS << endl;
+	cout << " ptS	  "	 << ptS		<< " skipped? " << byp_ptS << endl;
+	cout << " etaS	  "	 << etaS	<< " skipped? " << byp_etaS << endl;
   }
 
   return totalS;
@@ -570,13 +570,13 @@ bool OfflineProducerHelper::tauBaseline (bigTree* tree, int iDau, float ptMin,
   if (debug)
   {
     cout << "@ tau baseline" << endl;
-    cout << " dmfS    "  << dmfS    << " skypped? " << byp_dmfS << endl;
-    cout << " vertexS "  << vertexS << " skypped? " << byp_vertexS << endl;
-    cout << " agEleS  "  << agEleS  << " skypped? " << byp_agEleS << endl;
-    cout << " agMuS   "  << agMuS   << " skypped? " << byp_agMuS << endl;
-    cout << " isoS    "  << isoS    << " skypped? " << byp_isoS << endl;
-    cout << " ptS     "  << ptS     << " skypped? " << byp_ptS << endl;
-    cout << " etaS    "  << etaS    << " skypped? " << byp_etaS << endl;
+    cout << " dmfS    "  << dmfS    << " skipped? " << byp_dmfS << endl;
+    cout << " vertexS "  << vertexS << " skipped? " << byp_vertexS << endl;
+    cout << " agEleS  "  << agEleS  << " skipped? " << byp_agEleS << endl;
+    cout << " agMuS   "  << agMuS   << " skipped? " << byp_agMuS << endl;
+    cout << " isoS    "  << isoS    << " skipped? " << byp_isoS << endl;
+    cout << " ptS     "  << ptS     << " skipped? " << byp_ptS << endl;
+    cout << " etaS    "  << etaS    << " skipped? " << byp_etaS << endl;
   }
   return totalS;
 }

--- a/src/OfflineProducerHelper.cc
+++ b/src/OfflineProducerHelper.cc
@@ -427,21 +427,25 @@ bool OfflineProducerHelper::muBaseline (
   }
 
   bool vertexS = (fabs(tree->dxy->at(iDau)) < 0.045 && fabs(tree->dz->at(iDau)) < 0.2) || byp_vertexS;
-  bool idS = checkBit (discr, muIDWP) || byp_idS; // bit 0 is LOOSE id, bit 2 is MEDIUM mu id, bit 3 is TIGHT mu id
-  bool isoS = (tree->combreliso->at(iDau) < relIso) || byp_isoS;
+  bool id1S = checkBit (discr, muIDWP) || byp_idS; // bit 0 is LOOSE id, bit 2 is MEDIUM mu id, bit 3 is TIGHT mu id
+  bool id2S = checkBit (discr, 4) || byp_idS; // bit 4 is highPt
+  bool iso1S = (tree->combreliso->at(iDau) < relIso) || byp_isoS;
+  bool iso2S = (tree->combreliso->at(iDau) < relIso) || byp_isoS;
   if (whatApply.Contains ("InvertIzo")) isoS = !isoS ;
   bool ptS = (p4.Pt() > ptMin) || byp_ptS;
   bool etaS = (fabs(p4.Eta()) < etaMax) || byp_etaS;
 
-  bool totalS = (vertexS && idS && isoS && ptS && etaS);
+  bool totalS = (vertexS && ((id1S && iso1S) || (id2S && iso2S)) && ptS && etaS);
   if (debug)
   {
     cout << "@ mu baseline" << endl;
-    cout << " idS     "  << idS     << " skypped? " << byp_idS << endl;
-    cout << " vertexS "  << vertexS << " skypped? " << byp_vertexS << endl;
-    cout << " isoS    "  << isoS    << " skypped? " << byp_isoS << endl;
-    cout << " ptS     "  << ptS     << " skypped? " << byp_ptS << endl;
-    cout << " etaS    "  << etaS    << " skypped? " << byp_etaS << endl;
+	cout << " id1S	   " << id1S	<< " skypped? " << byp_idS << endl;
+	cout << " id2S	   " << id2S	<< " skypped? " << byp_idS << endl;
+	cout << " vertexS "	 << vertexS	<< " skypped? " << byp_vertexS << endl;
+	cout << " iso1S	   " << iso1S	<< " skypped? " << byp_isoS << endl;
+	cout << " iso2S	   " << iso2S	<< " skypped? " << byp_isoS << endl;
+	cout << " ptS	  "	 << ptS		<< " skypped? " << byp_ptS << endl;
+	cout << " etaS	  "	 << etaS	<< " skypped? " << byp_etaS << endl;
   }
 
   return totalS;

--- a/src/OfflineProducerHelper.cc
+++ b/src/OfflineProducerHelper.cc
@@ -187,14 +187,14 @@ bool OfflineProducerHelper::pairPassBaseline (bigTree* tree, int iPair, TString 
   if (pairType == MuHad)
   {
     float tauIso = whatApply.Contains("TauRlxIzo") ? 7.0 : 3.0 ;
-    leg1 = muBaseline  (tree, dau1index, 20., 2.1, 0.15, MuTight, whatApply, debug);
+    leg1 = muBaseline  (tree, dau1index, 20., 2.3, 0.15, MuTight, whatApply, debug);
     leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVLoose, amuTight, tauIso, whatApply, debug);
   }
 
   if (pairType == EHad)
   {
     float tauIso = whatApply.Contains("TauRlxIzo") ? 7.0 : 3.0 ;
-    leg1 = eleBaseline (tree, dau1index, 20., 2.1, 0.1, EMVATight, whatApply, debug);
+    leg1 = eleBaseline (tree, dau1index, 20., 2.3, 0.1, EMVATight, whatApply, debug);
     //leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleTight, amuTight, tauIso, whatApply, debug); // Switched from 'aeleTight' to 'aeleVLoose' in January 2021
     leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVLoose, amuTight, tauIso, whatApply, debug);  // following HTT conveners suggestion
   }
@@ -203,29 +203,29 @@ bool OfflineProducerHelper::pairPassBaseline (bigTree* tree, int iPair, TString 
   if (pairType == HadHad)
   {
     float tauIso = whatApply.Contains("TauRlxIzo") ? 7.0 : 2.0 ;
-    leg1 = tauBaseline (tree, dau1index, 20., 2.1, aeleVVLoose, amuVLoose, tauIso, whatApply, debug);
-    leg2 = tauBaseline (tree, dau2index, 20., 2.1, aeleVVLoose, amuVLoose, tauIso, whatApply, debug);
+    leg1 = tauBaseline (tree, dau1index, 20., 2.3, aeleVVLoose, amuVLoose, tauIso, whatApply, debug);
+    leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVVLoose, amuVLoose, tauIso, whatApply, debug);
   }
 
   if (pairType == EMu)
   {
-    leg1 = eleBaseline (tree, dau1index, 13., 2.1, 0.15, EMVAMedium, whatApply, debug);
-    leg2 = muBaseline  (tree, dau2index, 13., 2.1, 0.15, MuTight, whatApply, debug);
+    leg1 = eleBaseline (tree, dau1index, 13., 2.3, 0.15, EMVAMedium, whatApply, debug);
+    leg2 = muBaseline  (tree, dau2index, 13., 2.3, 0.15, MuTight, whatApply, debug);
   }
 
   // e e, mu mu are still preliminary (not from baseline)
   if (pairType == EE)
   {
-    leg1 = eleBaseline (tree, dau1index, 25., 2.1, 0.15, EMVAMedium, whatApply, debug);
-    leg2 = eleBaseline (tree, dau2index, 25., 2.1, 0.15, EMVAMedium, whatApply, debug);
+    leg1 = eleBaseline (tree, dau1index, 25., 2.3, 0.15, EMVAMedium, whatApply, debug);
+    leg2 = eleBaseline (tree, dau2index, 25., 2.3, 0.15, EMVAMedium, whatApply, debug);
   }
 
   if (pairType == MuMu)
   {
-    leg1 = muBaseline (tree, dau1index, 10., 2.1, 0.15, MuTight, whatApply, debug);
-    leg2 = muBaseline (tree, dau2index, 10., 2.1, 0.15, MuTight, whatApply, debug);
-    bool leg1ER = muBaseline (tree, dau1index, 10., 2.1, 0.15, MuTight, whatApply, debug);
-    bool leg2ER = muBaseline (tree, dau2index, 10., 2.1, 0.15, MuTight, whatApply, debug);
+    leg1 = muBaseline (tree, dau1index, 10., 2.3, 0.15, MuTight, whatApply, debug);
+    leg2 = muBaseline (tree, dau2index, 10., 2.3, 0.15, MuTight, whatApply, debug);
+    bool leg1ER = muBaseline (tree, dau1index, 10., 2.3, 0.15, MuTight, whatApply, debug);
+    bool leg2ER = muBaseline (tree, dau2index, 10., 2.3, 0.15, MuTight, whatApply, debug);
 
     return ( ((leg1ER && leg2) || (leg2ER && leg1)) && drMin );
   }
@@ -427,23 +427,19 @@ bool OfflineProducerHelper::muBaseline (
   }
 
   bool vertexS = (fabs(tree->dxy->at(iDau)) < 0.045 && fabs(tree->dz->at(iDau)) < 0.2) || byp_vertexS;
-  bool id1S = checkBit (discr, muIDWP) || byp_idS; // bit 0 is LOOSE id, bit 2 is MEDIUM mu id, bit 3 is TIGHT mu id
-  bool id2S = checkBit (discr, 4) || byp_idS; // bit 4 is highPt
-  bool iso1S = (tree->combreliso->at(iDau) < relIso) || byp_isoS;
-  bool iso2S = (tree->combreliso->at(iDau) < relIso) || byp_isoS;
+  bool idS = checkBit (discr, muIDWP) || byp_idS; // bit 0 is LOOSE id, bit 2 is MEDIUM mu id, bit 3 is TIGHT mu id
+  bool isoS = (tree->combreliso->at(iDau) < relIso) || byp_isoS;
   if (whatApply.Contains ("InvertIzo")) isoS = !isoS ;
   bool ptS = (p4.Pt() > ptMin) || byp_ptS;
   bool etaS = (fabs(p4.Eta()) < etaMax) || byp_etaS;
 
-  bool totalS = (vertexS && ((id1S && iso1S) || (id2S && iso2S)) && ptS && etaS);
+  bool totalS = (vertexS && idS && isoS && ptS && etaS);
   if (debug)
   {
     cout << "@ mu baseline" << endl;
-	cout << " id1S	   " << id1S	<< " skipped? " << byp_idS << endl;
-	cout << " id2S	   " << id2S	<< " skipped? " << byp_idS << endl;
+	cout << " idS	   " << idS	<< " skipped? " << byp_idS << endl;
 	cout << " vertexS "	 << vertexS	<< " skipped? " << byp_vertexS << endl;
-	cout << " iso1S	   " << iso1S	<< " skipped? " << byp_isoS << endl;
-	cout << " iso2S	   " << iso2S	<< " skipped? " << byp_isoS << endl;
+	cout << " isoS	   " << isoS	<< " skipped? " << byp_isoS << endl;
 	cout << " ptS	  "	 << ptS		<< " skipped? " << byp_ptS << endl;
 	cout << " etaS	  "	 << etaS	<< " skipped? " << byp_etaS << endl;
   }
@@ -804,10 +800,10 @@ int OfflineProducerHelper::getBestPairHTauTau (bigTree* tree, TString whatApply,
       int dau1index = get<2> (vPairs.at(ipair));
       int dau2index = get<5> (vPairs.at(ipair));
       int ipair_orig = get<6> (vPairs.at(ipair));
-      //bool leg1 = tauBaseline (tree, dau1index, 20., 2.1, aeleVLoose, amuLoose, 99999., whatApply);  // MVA2017v2
-      //bool leg2 = tauBaseline (tree, dau2index, 20., 2.1, aeleVLoose, amuLoose, 99999., whatApply);  // MVA2017v2
-      bool leg1 = tauBaseline (tree, dau1index, 20., 2.1, aeleVVLoose, amuVLoose, 99999., whatApply); // DeepTauV2p1
-      bool leg2 = tauBaseline (tree, dau2index, 20., 2.1, aeleVVLoose, amuVLoose, 99999., whatApply); // DeepTauV2p1
+      //bool leg1 = tauBaseline (tree, dau1index, 20., 2.3, aeleVLoose, amuLoose, 99999., whatApply);  // MVA2017v2
+      //bool leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVLoose, amuLoose, 99999., whatApply);  // MVA2017v2
+      bool leg1 = tauBaseline (tree, dau1index, 20., 2.3, aeleVVLoose, amuVLoose, 99999., whatApply); // DeepTauV2p1
+      bool leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVVLoose, amuVLoose, 99999., whatApply); // DeepTauV2p1
       cout << "  > " << ipair << " tau_idx1=" << dau1index << " tau_idx2=" << dau2index << " orig_pair_idx=" << ipair_orig
            << " | iso1=" << get<1> (pp) << " pt1=" << get<0> (pp) << " iso2=" << get<4> (pp) << " pt2=" << get<3> (pp)
            << " base1=" << leg1 << " base2=" << leg2 << " dR="<< DeltaRDau(tree, dau1index, dau2index) <<endl;
@@ -819,10 +815,10 @@ int OfflineProducerHelper::getBestPairHTauTau (bigTree* tree, TString whatApply,
     int dau1index = get<2> (vPairs.at(ipair));
     int dau2index = get<5> (vPairs.at(ipair));
     int ipair_orig = get<6> (vPairs.at(ipair));
-    //bool leg1 = tauBaseline (tree, dau1index, 20., 2.1, aeleVLoose, amuLoose, 99999., whatApply, debug);  // MVA2017v2
-    //bool leg2 = tauBaseline (tree, dau2index, 20., 2.1, aeleVLoose, amuLoose, 99999., whatApply, debug);  // MVA2017v2
-    bool leg1 = tauBaseline (tree, dau1index, 20., 2.1, aeleVVLoose, amuVLoose, 99999., whatApply, debug); // DeepTauV2p1
-    bool leg2 = tauBaseline (tree, dau2index, 20., 2.1, aeleVVLoose, amuVLoose, 99999., whatApply, debug); // DeepTauV2p1
+    //bool leg1 = tauBaseline (tree, dau1index, 20., 2.3, aeleVLoose, amuLoose, 99999., whatApply, debug);  // MVA2017v2
+    //bool leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVLoose, amuLoose, 99999., whatApply, debug);  // MVA2017v2
+    bool leg1 = tauBaseline (tree, dau1index, 20., 2.3, aeleVVLoose, amuVLoose, 99999., whatApply, debug); // DeepTauV2p1
+    bool leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVVLoose, amuVLoose, 99999., whatApply, debug); // DeepTauV2p1
 
     bool isOS = tree->isOSCand->at(ipair_orig);
     if (whatApply.Contains("OScharge") && !isOS) {
@@ -913,10 +909,10 @@ int OfflineProducerHelper::getBestPairPtAndRawIsoOrd (bigTree* tree, TString wha
       int dau1index = get<2> (vPairs.at(ipair));
       int dau2index = get<5> (vPairs.at(ipair));
       int ipair_orig = get<6> (vPairs.at(ipair));
-      //bool leg1 = tauBaseline (tree, dau1index, 20., 2.1, aeleVLoose, amuLoose, 99999., whatApply);  // MVA2017v2
-      //bool leg2 = tauBaseline (tree, dau2index, 20., 2.1, aeleVLoose, amuLoose, 99999., whatApply);  // MVA2017v2
-      bool leg1 = tauBaseline (tree, dau1index, 20., 2.1, aeleVVLoose, amuVLoose, 99999., whatApply); // DeepTauV2p1
-      bool leg2 = tauBaseline (tree, dau2index, 20., 2.1, aeleVVLoose, amuVLoose, 99999., whatApply); // DeepTauV2p1
+      //bool leg1 = tauBaseline (tree, dau1index, 20., 2.3, aeleVLoose, amuLoose, 99999., whatApply);  // MVA2017v2
+      //bool leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVLoose, amuLoose, 99999., whatApply);  // MVA2017v2
+      bool leg1 = tauBaseline (tree, dau1index, 20., 2.3, aeleVVLoose, amuVLoose, 99999., whatApply); // DeepTauV2p1
+      bool leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVVLoose, amuVLoose, 99999., whatApply); // DeepTauV2p1
 
       cout << "  > " << ipair << " idx1=" << dau1index << " idx2=" << dau2index << " ipair=" << ipair_orig
            << " | iso1=" << get<1> (pp) << " pt1=" << get<0> (pp) << " iso2=" << get<4> (pp) << " pt2=" << get<3> (pp)
@@ -929,10 +925,10 @@ int OfflineProducerHelper::getBestPairPtAndRawIsoOrd (bigTree* tree, TString wha
     int dau1index = get<2> (vPairs.at(ipair));
     int dau2index = get<5> (vPairs.at(ipair));
     int ipair_orig = get<6> (vPairs.at(ipair));
-    //bool leg1 = tauBaseline (tree, dau1index, 20., 2.1, aeleVLoose, amuLoose, 99999., whatApply, debug);  // MVA2017v2
-    //bool leg2 = tauBaseline (tree, dau2index, 20., 2.1, aeleVLoose, amuLoose, 99999., whatApply, debug);  // MVA2017v2
-    bool leg1 = tauBaseline (tree, dau1index, 20., 2.1, aeleVVLoose, amuVLoose, 99999., whatApply, debug); // DeepTauV2p1
-    bool leg2 = tauBaseline (tree, dau2index, 20., 2.1, aeleVVLoose, amuVLoose, 99999., whatApply, debug); // DeepTauV2p1
+    //bool leg1 = tauBaseline (tree, dau1index, 20., 2.3, aeleVLoose, amuLoose, 99999., whatApply, debug);  // MVA2017v2
+    //bool leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVLoose, amuLoose, 99999., whatApply, debug);  // MVA2017v2
+    bool leg1 = tauBaseline (tree, dau1index, 20., 2.3, aeleVVLoose, amuVLoose, 99999., whatApply, debug); // DeepTauV2p1
+    bool leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVVLoose, amuVLoose, 99999., whatApply, debug); // DeepTauV2p1
 
     bool isOS = tree->isOSCand->at(ipair_orig);
     if (whatApply.Contains("OScharge") && !isOS) {

--- a/src/OfflineProducerHelper.cc
+++ b/src/OfflineProducerHelper.cc
@@ -342,9 +342,9 @@ OfflineProducerHelper::eleBaseline (bigTree* tree, int iDau,
 	  if (whatApply.Contains("etaMax")) byp_etaS = false;
 	  if (whatApply.Contains("thirdLep"))                                           // For third lepton veto use noISO-MVA and relIso
 		{                                                                             // instead of ISO-MVA
-		  byp_isoS     = true;  // bypass pfRelIso < 0.3
-		  byp_noISOidS = true;  // bypass nonIsoMVA (mvaEleID-Fall17-noIso-V2-wp90)
-		  byp_idS      = false; // use IsoMVA (mvaEleID-Fall17-Iso-V2-wp90)
+		  byp_isoS     = false; // use pfRelIso < 0.3
+		  byp_noISOidS = false; // use nonIsoMVA (mvaEleID-Fall17-noIso-V2-wp90)
+		  byp_idS      = true;  // bypass IsoMVA (mvaEleID-Fall17-Iso-V2-wp90)
 		}
 	}
 

--- a/src/OfflineProducerHelper.cc
+++ b/src/OfflineProducerHelper.cc
@@ -332,23 +332,21 @@ OfflineProducerHelper::eleBaseline (bigTree* tree, int iDau,
   bool byp_noISOidS = false;
 
   // whatApply: use "All", "Iso", "LepID", pTMin", "etaMax", "againstEle", "againstMu", "Vertex", "SScharge"; separate various arguments with a semicolon
-  if (!whatApply.Contains("All") &&
-      !whatApply.Contains("SScharge") &&
-      !whatApply.Contains("OScharge"))
-  {
-    byp_vertexS = byp_idS = byp_isoS = byp_ptS = byp_etaS = byp_noISOidS = true;  // For signal elect and first lepton veto: first bypass all...
-    // set selections
-    if (whatApply.Contains("Vertex")) byp_vertexS = false;                        // ...then use only these four selections
-    if (whatApply.Contains("LepID"))  byp_idS = false;
-    if (whatApply.Contains("pTMin"))  byp_ptS = false;
-    if (whatApply.Contains("etaMax")) byp_etaS = false;
-    if (whatApply.Contains("thirdLep"))                                           // For second lepton veto use noISO-MVA and relIso
-    {                                                                             // instead of ISO-MVA
-      byp_isoS     = false; // use pfRelIso < 0.3
-      byp_noISOidS = false; // use    nonIsoMVA (mvaEleID-Fall17-noIso-V2-wp90)
-      byp_idS      = true;  // bypass IsoMVA    (mvaEleID-Fall17-Iso-V2-wp90)
-    }
-  }
+  if (!whatApply.Contains("All") and !whatApply.Contains("SScharge") and !whatApply.Contains("OScharge"))
+	{
+	  byp_vertexS = byp_idS = byp_isoS = byp_ptS = byp_etaS = byp_noISOidS = true;  // For signal elect and first lepton veto: first bypass all...
+	  // set selections
+	  if (whatApply.Contains("Vertex")) byp_vertexS = false;                        // ...then use only these four selections
+	  if (whatApply.Contains("LepID"))  byp_idS = false;
+	  if (whatApply.Contains("pTMin"))  byp_ptS = false;
+	  if (whatApply.Contains("etaMax")) byp_etaS = false;
+	  if (whatApply.Contains("thirdLep"))                                           // For third lepton veto use noISO-MVA and relIso
+		{                                                                             // instead of ISO-MVA
+		  byp_isoS     = true;  // bypass pfRelIso < 0.3
+		  byp_noISOidS = true;  // bypass nonIsoMVA (mvaEleID-Fall17-noIso-V2-wp90)
+		  byp_idS      = false; // use IsoMVA (mvaEleID-Fall17-Iso-V2-wp90)
+		}
+	}
 
   bool vertexS = (fabs(tree->dxy->at(iDau)) < 0.045 && fabs(tree->dz->at(iDau)) < 0.2) || byp_vertexS;
   bool ptS = (p4.Pt() > ptMin) || byp_ptS;

--- a/src/SmearedJetProducer.cc
+++ b/src/SmearedJetProducer.cc
@@ -126,7 +126,8 @@ double SmearedJetProducer::getSmearFactor(TLorentzVector jet, bigTree & theBigTr
   TLorentzVector genJet = SmearedJetProducer::matchedGenJet(jet, jet.Pt() * jet_resolution, theBigTree);
 
   // Set the smearing factor according to "hybrid" method described in the twiki
-  if (genJet.E() > 0)
+  // https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution
+  if (genJet.Pt() > 10) // nanoAOD applies this cut
   {
     // Case 1: we have a "good" gen jet matched to the reco jet
     if (DEBUG)

--- a/src/SmearedJetProducer.cc
+++ b/src/SmearedJetProducer.cc
@@ -99,7 +99,7 @@ TLorentzVector SmearedJetProducer::matchedGenJet(TLorentzVector jet,  double res
 }
 
 // Returns the smear factor to be applied to the jet TLorentzVector
-double SmearedJetProducer::getSmearFactor(TLorentzVector jet, bigTree & theBigTree)
+double SmearedJetProducer::getSmearFactor(TLorentzVector jet, bigTree& theBigTree, bool ptJetCut)
 {
   // Declare smear factor
   double smearFactor = 1.;
@@ -127,7 +127,8 @@ double SmearedJetProducer::getSmearFactor(TLorentzVector jet, bigTree & theBigTr
 
   // Set the smearing factor according to "hybrid" method described in the twiki
   // https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution
-  if (genJet.Pt() > 10) // nanoAOD applies this cut
+  bool hybridCut = ptJetCut ? genJet.Pt() > 10 : genJet.E() > 0;
+  if (hybridCut) // nanoAOD applies this cut
   {
     // Case 1: we have a "good" gen jet matched to the reco jet
     if (DEBUG)

--- a/test/skimNtuple2016_HHbtag.cpp
+++ b/test/skimNtuple2016_HHbtag.cpp
@@ -1465,7 +1465,7 @@ int main (int argc, char** argv)
       int dauType = theBigTree.particleType->at(idau);
       if (oph.isMuon(dauType))
       {
-	bool passMu   = oph.muBaseline (&theBigTree, idau, 19., 2.1, 0.15, OfflineProducerHelper::MuTight, string("All") , (DEBUG ? true : false));
+	bool passMu   = oph.muBaseline (&theBigTree, idau, 19., 2.3, 0.15, OfflineProducerHelper::MuTight, string("All") , (DEBUG ? true : false));
 	bool passMu10 = oph.muBaseline (&theBigTree, idau, 10., 2.4, 0.30, OfflineProducerHelper::MuTight, string("All") , (DEBUG ? true : false));
 
 	if (passMu) ++nmu;
@@ -1473,7 +1473,7 @@ int main (int argc, char** argv)
       }
       else if (oph.isElectron(dauType))
       {
-	bool passEle   = oph.eleBaseline (&theBigTree, idau, 25., 2.1, 0.1, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax") , (DEBUG ? true : false));
+	bool passEle   = oph.eleBaseline (&theBigTree, idau, 25., 2.3, 0.1, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax") , (DEBUG ? true : false));
 	bool passEle10 = oph.eleBaseline (&theBigTree, idau, 10., 2.5, 0.3, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax") , (DEBUG ? true : false));
 
 	if (passEle) ++nele;
@@ -1499,8 +1499,8 @@ int main (int argc, char** argv)
 	     << " dxy="       << setw(15) << left << theBigTree.dxy->at(idau)
 	     << " dz="        << setw(15) << left << theBigTree.dz->at(idau)
 	     << " mutightID=" << setw(3)  << left << CheckBit(theBigTree.daughters_muonID->at(idau),3)
-	     << " mubase="    << setw(3)  << left << oph.muBaseline (&theBigTree, idau, 10., 2.1, 0.15, OfflineProducerHelper::MuTight, string("All"))
-	     << " ebase="     << setw(3)  << left << oph.eleBaseline(&theBigTree, idau, 10., 2.1, 0.1, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax"))
+	     << " mubase="    << setw(3)  << left << oph.muBaseline (&theBigTree, idau, 10., 2.3, 0.15, OfflineProducerHelper::MuTight, string("All"))
+	     << " ebase="     << setw(3)  << left << oph.eleBaseline(&theBigTree, idau, 10., 2.3, 0.1, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax"))
 	     << endl;
       }
     } // end loop on daughters

--- a/test/skimNtuple2016_HHbtag.cpp
+++ b/test/skimNtuple2016_HHbtag.cpp
@@ -3512,9 +3512,9 @@ int main (int argc, char** argv)
       {
 	// Fra Mar2020: for electron, we check (mvaEleID-Fall17-iso-V2-wp90 OR (mvaEleID-Fall17-noIso-V2-wp90 AND pfRelIso < 0.3))
 	if (DEBUG) std::cout << "--- Debug for extra electrons:" << std::endl;
-	bool passIso    = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-LepID-pTMin-etaMax"), (DEBUG ? true : false));
-	bool passNonISo = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-pTMin-etaMax-thirdLep"), (DEBUG ? true : false));
-	if (!passIso && !passNonISo) continue; // if it passes one of the two --> the "if" is false and the lepton is saved as an extra lepton
+	bool passIsoMVA = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-LepID-pTMin-etaMax"), (DEBUG ? true : false));
+	//bool passNonISo = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-pTMin-etaMax-thirdLep"), (DEBUG ? true : false));
+	if (!passIsoMVA) continue; // if it passes --> the "if" is false and the lepton is saved as an extra lepton
       }
 
       TLorentzVector tlv_dummyLepton

--- a/test/skimNtuple2017_HHbtag.cpp
+++ b/test/skimNtuple2017_HHbtag.cpp
@@ -1491,7 +1491,7 @@ int main (int argc, char** argv)
       int dauType = theBigTree.particleType->at(idau);
       if (oph.isMuon(dauType))
       {
-	bool passMu   = oph.muBaseline (&theBigTree, idau, 20., 2.1, 0.15, OfflineProducerHelper::MuTight, string("All") , (DEBUG ? true : false));
+	bool passMu   = oph.muBaseline (&theBigTree, idau, 20., 2.3, 0.15, OfflineProducerHelper::MuTight, string("All") , (DEBUG ? true : false));
 	bool passMu10 = oph.muBaseline (&theBigTree, idau, 10., 2.4, 0.30, OfflineProducerHelper::MuTight, string("All") , (DEBUG ? true : false));
 
 	if (passMu) ++nmu;
@@ -1499,7 +1499,7 @@ int main (int argc, char** argv)
       }
       else if (oph.isElectron(dauType))
       {
-	bool passEle   = oph.eleBaseline (&theBigTree, idau, 24., 2.1, 0.1, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax") , (DEBUG ? true : false));
+	bool passEle   = oph.eleBaseline (&theBigTree, idau, 24., 2.3, 0.1, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax") , (DEBUG ? true : false));
 	bool passEle10 = oph.eleBaseline (&theBigTree, idau, 10., 2.5, 0.3, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax") , (DEBUG ? true : false));
 
 	if (passEle) ++nele;
@@ -1525,8 +1525,8 @@ int main (int argc, char** argv)
 	     << " dxy="       << setw(15) << left << theBigTree.dxy->at(idau)
 	     << " dz="        << setw(15) << left << theBigTree.dz->at(idau)
 	     << " mutightID=" << setw(3)  << left << CheckBit(theBigTree.daughters_muonID->at(idau),3)
-	     << " mubase="    << setw(3)  << left << oph.muBaseline (&theBigTree, idau, 10., 2.1, 0.15, OfflineProducerHelper::MuTight, string("All"))
-	     << " ebase="     << setw(3)  << left << oph.eleBaseline(&theBigTree, idau, 10., 2.1, 0.1, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax"))
+	     << " mubase="    << setw(3)  << left << oph.muBaseline (&theBigTree, idau, 10., 2.3, 0.15, OfflineProducerHelper::MuTight, string("All"))
+	     << " ebase="     << setw(3)  << left << oph.eleBaseline(&theBigTree, idau, 10., 2.3, 0.1, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax"))
 	     << endl;
       }
     } // end loop on daughters
@@ -3766,50 +3766,51 @@ int main (int argc, char** argv)
     for (unsigned int iLep = 0 ; (iLep < theBigTree.daughters_px->size ()) ; ++iLep)
     {
       // skip the H decay candiates
-      if (int (iLep) == firstDaughterIndex || int (iLep) == secondDaughterIndex) continue;
+      if (int (iLep) == firstDaughterIndex || int (iLep) == secondDaughterIndex)
+		continue;
 
       // remove taus
       if (theBigTree.particleType->at (iLep) == 2)
-      {
-	continue ;
-      }
+		{
+		  continue ;
+		}
       else if (theBigTree.particleType->at (iLep) == 0) // muons
-      {
-	// Fra Mar2020: for muon, Tight does not imply Medium so we check both
-	bool passMed = oph.muBaseline (&theBigTree, iLep, 10., 2.4, 0.3, OfflineProducerHelper::MuMedium);
-	bool passTig = oph.muBaseline (&theBigTree, iLep, 10., 2.4, 0.3, OfflineProducerHelper::MuTight);
-	if (!passMed && !passTig) continue; // if it passes one of the two --> the "if" is false and the lepton is saved as an extra lepton
-      }
+		{
+		  // Fra Mar2020: for muon, Tight does not imply Medium so we check both
+		  bool passMed = oph.muBaseline (&theBigTree, iLep, 10., 2.4, 0.3, OfflineProducerHelper::MuMedium);
+		  bool passTig = oph.muBaseline (&theBigTree, iLep, 10., 2.4, 0.3, OfflineProducerHelper::MuTight);
+		  if (!passMed && !passTig) continue; // if it passes one of the two --> the "if" is false and the lepton is saved as an extra lepton
+		}
       else if (theBigTree.particleType->at (iLep) == 1) // electrons
-      {
-	// Fra Mar2020: for electron, we check (mvaEleID-Fall17-iso-V2-wp90 OR (mvaEleID-Fall17-noIso-V2-wp90 AND pfRelIso < 0.3))
-	if (DEBUG) std::cout << "--- Debug for extra electrons:" << std::endl;
-	bool passIso    = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-LepID-pTMin-etaMax"), (DEBUG ? true : false));
-	bool passNonISo = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-pTMin-etaMax-thirdLep"), (DEBUG ? true : false));
-	if (!passIso && !passNonISo) continue; // if it passes one of the two --> the "if" is false and the lepton is saved as an extra lepton
-      }
+		{
+		  // Fra Mar2020: for electron, we check (mvaEleID-Fall17-iso-V2-wp90 OR (mvaEleID-Fall17-noIso-V2-wp90 AND pfRelIso < 0.3))
+		  if (DEBUG) std::cout << "--- Debug for extra electrons:" << std::endl;
+		  bool passIsoMVA = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-LepID-pTMin-etaMax"), (DEBUG ? true : false));
+		  //bool passNonIsoMVA = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-pTMin-etaMax-thirdLep"), (DEBUG ? true : false));
+		  if (!passIso) continue; // if it passes --> the "if" is false and the lepton is saved as an extra lepton
+		}
 
       TLorentzVector tlv_dummyLepton
         (
-          theBigTree.daughters_px->at (iLep),
-          theBigTree.daughters_py->at (iLep),
-          theBigTree.daughters_pz->at (iLep),
-          theBigTree.daughters_e->at (iLep)
-	  );
+		 theBigTree.daughters_px->at (iLep),
+		 theBigTree.daughters_py->at (iLep),
+		 theBigTree.daughters_pz->at (iLep),
+		 theBigTree.daughters_e->at (iLep)
+		 );
       thirdLeptons.push_back (make_pair(tlv_dummyLepton.Pt(), iLep)) ;
 
       if(DEBUG)
       {
-	cout << "** 3rd lep veto passed"
-	     << " idx="  << iLep
-	     << " type=" << theBigTree.particleType->at(iLep)
-	     << " pt="   << tlv_dummyLepton.Pt()
-	     << " eta="  << tlv_dummyLepton.Eta()
-	     << " phi="  << tlv_dummyLepton.Phi()
-	     << " iso="  << getIso (iLep, tlv_dummyLepton.Pt (), theBigTree)
-	     << " dxy="  << theBigTree.dxy->at(iLep)
-	     << " dz="   << theBigTree.dz->at(iLep)
-	     << endl;
+		cout << "** 3rd lep veto passed"
+			 << " idx="  << iLep
+			 << " type=" << theBigTree.particleType->at(iLep)
+			 << " pt="   << tlv_dummyLepton.Pt()
+			 << " eta="  << tlv_dummyLepton.Eta()
+			 << " phi="  << tlv_dummyLepton.Phi()
+			 << " iso="  << getIso (iLep, tlv_dummyLepton.Pt (), theBigTree)
+			 << " dxy="  << theBigTree.dxy->at(iLep)
+			 << " dz="   << theBigTree.dz->at(iLep)
+			 << endl;
       }
     } // loop over leptons
 

--- a/test/skimNtuple2017_HHbtag.cpp
+++ b/test/skimNtuple2017_HHbtag.cpp
@@ -3787,7 +3787,7 @@ int main (int argc, char** argv)
 		  if (DEBUG) std::cout << "--- Debug for extra electrons:" << std::endl;
 		  bool passIsoMVA = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-LepID-pTMin-etaMax"), (DEBUG ? true : false));
 		  //bool passNonIsoMVA = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-pTMin-etaMax-thirdLep"), (DEBUG ? true : false));
-		  if (!passIso) continue; // if it passes --> the "if" is false and the lepton is saved as an extra lepton
+		  if (!passIsoMVA) continue; // if it passes --> the "if" is false and the lepton is saved as an extra lepton
 		}
 
       TLorentzVector tlv_dummyLepton

--- a/test/skimNtuple2018_HHbtag.cpp
+++ b/test/skimNtuple2018_HHbtag.cpp
@@ -1535,7 +1535,7 @@ int main (int argc, char** argv)
 		  int dauType = theBigTree.particleType->at(idau);
 		  if (oph.isMuon(dauType))
 			{
-			  bool passMu   = oph.muBaseline (&theBigTree, idau, 20., 2.1, 0.15, OfflineProducerHelper::MuTight, string("All") , (DEBUG ? true : false));
+			  bool passMu   = oph.muBaseline (&theBigTree, idau, 20., 2.3, 0.15, OfflineProducerHelper::MuTight, string("All") , (DEBUG ? true : false));
 			  bool passMu10 = oph.muBaseline (&theBigTree, idau, 10., 2.4, 0.30, OfflineProducerHelper::MuTight, string("All") , (DEBUG ? true : false));
 
 			  if (passMu) ++nmu;
@@ -1543,7 +1543,7 @@ int main (int argc, char** argv)
 			}
 		  else if (oph.isElectron(dauType))
 			{
-			  bool passEle   = oph.eleBaseline (&theBigTree, idau, 24., 2.1, 0.1, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax") , (DEBUG ? true : false));
+			  bool passEle   = oph.eleBaseline (&theBigTree, idau, 24., 2.3, 0.1, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax") , (DEBUG ? true : false));
 			  bool passEle10 = oph.eleBaseline (&theBigTree, idau, 10., 2.5, 0.3, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax") , (DEBUG ? true : false));
 
 			  if (passEle) ++nele;
@@ -1569,8 +1569,8 @@ int main (int argc, char** argv)
 				   << " dxy="       << setw(15) << left << theBigTree.dxy->at(idau)
 				   << " dz="        << setw(15) << left << theBigTree.dz->at(idau)
 				   << " mutightID=" << setw(3)  << left << CheckBit(theBigTree.daughters_muonID->at(idau),3)
-				   << " mubase="    << setw(3)  << left << oph.muBaseline (&theBigTree, idau, 10., 2.1, 0.15, OfflineProducerHelper::MuTight, string("All"))
-				   << " ebase="     << setw(3)  << left << oph.eleBaseline(&theBigTree, idau, 10., 2.1, 0.1, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax"))
+				   << " mubase="    << setw(3)  << left << oph.muBaseline (&theBigTree, idau, 10., 2.3, 0.15, OfflineProducerHelper::MuTight, string("All"))
+				   << " ebase="     << setw(3)  << left << oph.eleBaseline(&theBigTree, idau, 10., 2.3, 0.1, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax"))
 				   << endl;
 			}
 		} // end loop on daughters
@@ -3758,11 +3758,13 @@ int main (int argc, char** argv)
 	  vector<pair<float, int> > thirdLeptons ; // pt, idx
 	  for (unsigned int iLep = 0 ; (iLep < theBigTree.daughters_px->size ()) ; ++iLep)
 		{
-		  // skip the H decay candiates
-		  if (int (iLep) == firstDaughterIndex || int (iLep) == secondDaughterIndex) continue;
+		  // skip the H decay candidates
+		  if (int (iLep) == firstDaughterIndex || int (iLep) == secondDaughterIndex)
+			continue;
 
 		  // remove taus
-		  if (theBigTree.particleType->at (iLep) == 2) continue;
+		  if (theBigTree.particleType->at (iLep) == 2)
+			continue;
 		  else if (theBigTree.particleType->at (iLep) == 0) // muons
 			{
 			  // Fra Mar2020: for muon, Tight does not imply Medium so we check both
@@ -3774,9 +3776,12 @@ int main (int argc, char** argv)
 			{
 			  // Fra Mar2020: for electron, we check (mvaEleID-Fall17-iso-V2-wp90 OR (mvaEleID-Fall17-noIso-V2-wp90 AND pfRelIso < 0.3))
 			  if (DEBUG) std::cout << "--- Debug for extra electrons:" << std::endl;
-			  bool passIso    = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-LepID-pTMin-etaMax"), (DEBUG ? true : false));
-			  bool passNonISo = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-pTMin-etaMax-thirdLep"), (DEBUG ? true : false));
-			  if (!passIso && !passNonISo) continue; // if it passes one of the two --> the "if" is false and the lepton is saved as an extra lepton
+			  bool passIsoMVA = oph.eleBaseline(&theBigTree, iLep, 10., 2.5, 0.3,
+												OfflineProducerHelper::EMVAMedium,
+												string("Vertex-LepID-pTMin-etaMax"), (DEBUG ? true : false));
+			  //bool passNonIsoMVA = oph.eleBaseline (&theBigTree, iLep, 10., 2.5, 0.3, OfflineProducerHelper::EMVAMedium, string("Vertex-pTMin-etaMax-thirdLep"), (DEBUG ? true : false));
+			  if (!passIsoMVA) // if it passes --> the "if" is false and the lepton is saved as an extra lepton
+				continue; 
 			}
 
 		  TLorentzVector tlv_dummyLepton(


### PR DESCRIPTION
### Electrons

- Remove ```pfRelIso < 0.3``` and ```mvaEleID-Fall17-noIso-V2-wp90``` cuts for the third lepton veto
- Selection eta cut at 2.3
- Veto eta cut at 2.5

### Muons

- Modification of id cut: now it can pass ((pfRelIso < 0.15 AND MuTight) OR (tkRelIso < 0.15 MuHighPt))
   - [X] ```tkRelIso``` is missing (removed from selection)
- Selection cut at eta 2.3
- Veto cut at eta 2.4

### Jet Smearing

- the "scale approach" requires now ```genJet.Pt() > 10```, to reproduce what is applied in nanoAOD samples
- include the above as an input ```bool``` parameter to ```SmearJetProducer::getSmearFactor()``` 