### PR TITLE
Fixes for write_res_cards.py

### DIFF
--- a/resonantLimits/write_res_card.py
+++ b/resonantLimits/write_res_card.py
@@ -76,6 +76,9 @@ def writeCard(backgrounds, signals, select, varfit, regions=()):
             print('Template: {}'.format(templateName))
             raise
 
+    #use as backgrounds the updated list of processes
+    backgrounds=processes
+
     rates = []
     iQCD = -1
     totRate = 0
@@ -438,6 +441,9 @@ if incfg.hasSection(mergesec):
         for x in mergelist:
             theList.remove(x)
         theList.append(groupname)
+
+#read QCD from file
+backgrounds.append("QCD")
 
 # rename signals following model convention
 for i,sig in enumerate(signals):


### PR DESCRIPTION
This PR adds two fixes to write_res_cards.py: 
- Add QCD bkg to the list of processes, see discussion in https://github.com/LLRCMS/KLUBAnalysis/commit/6e104f5c6ff2fcd5fc94f1662a879231a7e78b3f#r122731246
-  Remove negative templates for being written in the cards 

we will check if there are more differences between the old and new write_res_cards.py

FYI  @bfonta @dzuolo 