### PR TITLE
Add met phi correction.

### DIFF
--- a/config/skim_UL17_uhh.cfg
+++ b/config/skim_UL17_uhh.cfg
@@ -2,11 +2,11 @@
 # do not select events with at least two jets in the final state
 # false : only >= 2 b jet ; true : all events
 ## for sync use beInclusive==true, for full porduction use false
-beInclusive = true
+beInclusive = false
 #use deepFlavor to order jets
 useDeepFlavor = true
 # Store only ETau/MuTau/TauTau events in the skims
-onlyFinalChannels = false
+onlyFinalChannels = true
 
 
 [parameters]
@@ -156,7 +156,7 @@ coeffFileLO  = /nfs/dust/cms/user/kramerto/hbt_static_files/KLUBAnalysis/weights
 
 
 [Multiclass]
-computeMVA = true
+computeMVA = false
 
 
 [outPutter]

--- a/config/skim_UL17_uhh.cfg
+++ b/config/skim_UL17_uhh.cfg
@@ -2,7 +2,7 @@
 # do not select events with at least two jets in the final state
 # false : only >= 2 b jet ; true : all events
 ## for sync use beInclusive==true, for full porduction use false
-beInclusive = false
+beInclusive = true
 #use deepFlavor to order jets
 useDeepFlavor = true
 # Store only ETau/MuTau/TauTau/MuMu events in the skims

--- a/config/skim_UL17_uhh.cfg
+++ b/config/skim_UL17_uhh.cfg
@@ -5,7 +5,7 @@
 beInclusive = false
 #use deepFlavor to order jets
 useDeepFlavor = true
-# Store only ETau/MuTau/TauTau events in the skims
+# Store only ETau/MuTau/TauTau/MuMu events in the skims
 onlyFinalChannels = true
 
 

--- a/interface/met_phi_corr.h
+++ b/interface/met_phi_corr.h
@@ -178,8 +178,8 @@ std::pair<double, double> met_phi_correction_etphi(
     );
 
     // convert back to et and phi
-    double met_et_correced = sqrt(pxpy_corr.first * pxpy_corr.first + pxpy_corr.second * pxpy_corr.second);
+    double met_pt_correced = sqrt(pxpy_corr.first * pxpy_corr.first + pxpy_corr.second * pxpy_corr.second);
     double met_phi_corrected = atan2(pxpy_corr.second, pxpy_corr.first);
 
-    return std::make_pair(met_et_correced, met_phi_corrected);
+    return std::make_pair(met_pt_correced, met_phi_corrected);
 }

--- a/interface/met_phi_corr.h
+++ b/interface/met_phi_corr.h
@@ -167,7 +167,7 @@ std::pair<double, double> met_phi_correction_pxpy(
     return std::make_pair(met_px + met_px_diff, met_py + met_py_diff);
 }
 
-std::pair<double, double> met_phi_correction_etphi(
+std::pair<double, double> met_phi_correction_ptphi(
     double met_et, double met_phi, int npv, int runnb, const std::string& year, bool isMC
 ) {
     // apply the correction
@@ -177,7 +177,7 @@ std::pair<double, double> met_phi_correction_etphi(
         npv, runnb, year, isMC
     );
 
-    // convert back to et and phi
+    // convert back to pt and phi
     double met_pt_correced = sqrt(pxpy_corr.first * pxpy_corr.first + pxpy_corr.second * pxpy_corr.second);
     double met_phi_corrected = atan2(pxpy_corr.second, pxpy_corr.first);
 

--- a/interface/met_phi_corr.h
+++ b/interface/met_phi_corr.h
@@ -1,0 +1,185 @@
+/*
+ * MET phi modulation correction for MC and Data, Run 2 UL.
+ *
+ * Info: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETRun2Corrections#xy_Shift_Correction_MET_phi_modu
+ * Adapted from: https://lathomas.web.cern.ch/lathomas/METStuff/XYCorrections/XYMETCorrection_withUL17andUL18andUL16.h
+ */
+
+#include <iostream>
+#include <cmath>
+
+enum PhiCorrRunEra {
+    yNONE,
+    // data
+    yUL2016B,
+    yUL2016C,
+    yUL2016D,
+    yUL2016E,
+    yUL2016F,
+    yUL2016Flate,
+    yUL2016G,
+    yUL2016H,
+    yUL2017B,
+    yUL2017C,
+    yUL2017D,
+    yUL2017E,
+    yUL2017F,
+    yUL2018A,
+    yUL2018B,
+    yUL2018C,
+    yUL2018D,
+    // mc
+    yUL2016MCAPV,
+    yUL2016MCnonAPV,
+    yUL2017MC,
+    yUL2018MC
+};
+
+std::pair<double, double> met_phi_correction_pxpy(
+    double met_px, double met_py, int npv, int runnb, const std::string& period, bool isMC
+) {
+    // limit npv
+    if (npv > 100) {
+        npv = 100;
+    }
+
+    // determine the run era
+    PhiCorrRunEra runera = yNONE;
+    if (isMC) {
+        if (period == "2016preVFP") {
+            runera = yUL2016MCAPV;
+        } else if (period == "2016postVFP") {
+            runera = yUL2016MCnonAPV;
+        } else if (period == "2017") {
+            runera = yUL2017MC;
+        } else if (period == "2018") {
+            runera = yUL2018MC;
+        }
+    } else {
+        if (runnb >= 315252 && runnb <= 316995) {
+            runera = yUL2018A;
+        } else if (runnb >= 316998 && runnb <= 319312) {
+            runera = yUL2018B;
+        } else if (runnb >= 319313 && runnb <= 320393) {
+            runera = yUL2018C;
+        } else if (runnb >= 320394 && runnb <= 325273) {
+            runera = yUL2018D;
+        } else if (runnb >= 297020 && runnb <= 299329) {
+            runera = yUL2017B;
+        } else if (runnb >= 299337 && runnb <= 302029) {
+            runera = yUL2017C;
+        } else if (runnb >= 302030 && runnb <= 303434) {
+            runera = yUL2017D;
+        } else if (runnb >= 303435 && runnb <= 304826) {
+            runera = yUL2017E;
+        } else if (runnb >= 304911 && runnb <= 306462) {
+            runera = yUL2017F;
+        } else if (runnb >= 272007 && runnb <= 275376) {
+            runera = yUL2016B;
+        } else if (runnb >= 275657 && runnb <= 276283) {
+            runera = yUL2016C;
+        } else if (runnb >= 276315 && runnb <= 276811) {
+            runera = yUL2016D;
+        } else if (runnb >= 276831 && runnb <= 277420) {
+            runera = yUL2016E;
+        } else if (((runnb >= 277772 && runnb <= 278768) || runnb == 278770)) {
+            runera = yUL2016F;
+        } else if (((runnb >= 278801 && runnb <= 278808) || runnb == 278769)) {
+            runera = yUL2016Flate;
+        } else if (runnb >= 278820 && runnb <= 280385) {
+            runera = yUL2016G;
+        } else if (runnb >= 280919 && runnb <= 284044) {
+            runera = yUL2016H;
+        }
+    }
+    if (runera == yNONE) {
+        throw std::runtime_error("Unknown MC period and/or data run number");
+    }
+
+    // determine parameters of the linear correction function
+    double met_px_diff = 0.0;
+    double met_py_diff = 0.0;
+    if (runera == yUL2017B) {
+        met_px_diff = -(-0.211161 * npv + 0.419333);
+        met_py_diff = -(0.251789 * npv + -1.28089);
+    } else if (runera == yUL2017C) {
+        met_px_diff = -(-0.185184 * npv + -0.164009);
+        met_py_diff = -(0.200941 * npv + -0.56853);
+    } else if (runera == yUL2017D) {
+        met_px_diff = -(-0.201606 * npv + 0.426502);
+        met_py_diff = -(0.188208 * npv + -0.58313);
+    } else if (runera == yUL2017E) {
+        met_px_diff = -(-0.162472 * npv + 0.176329);
+        met_py_diff = -(0.138076 * npv + -0.250239);
+    } else if (runera == yUL2017F) {
+        met_px_diff = -(-0.210639 * npv + 0.72934);
+        met_py_diff = -(0.198626 * npv + 1.028);
+    } else if (runera == yUL2017MC) {
+        met_px_diff = -(-0.300155 * npv + 1.90608);
+        met_py_diff = -(0.300213 * npv + -2.02232);
+    } else if (runera == yUL2018A) {
+        met_px_diff = -(0.263733 * npv + -1.91115);
+        met_py_diff = -(0.0431304 * npv + -0.112043);
+    } else if (runera == yUL2018B) {
+        met_px_diff = -(0.400466 * npv + -3.05914);
+        met_py_diff = -(0.146125 * npv + -0.533233);
+    } else if (runera == yUL2018C) {
+        met_px_diff = -(0.430911 * npv + -1.42865);
+        met_py_diff = -(0.0620083 * npv + -1.46021);
+    } else if (runera == yUL2018D) {
+        met_px_diff = -(0.457327 * npv + -1.56856);
+        met_py_diff = -(0.0684071 * npv + -0.928372);
+    } else if (runera == yUL2018MC) {
+        met_px_diff = -(0.183518 * npv + 0.546754);
+        met_py_diff = -(0.192263 * npv + -0.42121);
+    } else if (runera == yUL2016B) {
+        met_px_diff = -(-0.0214894 * npv + -0.188255);
+        met_py_diff = -(0.0876624 * npv + 0.812885);
+    } else if (runera == yUL2016C) {
+        met_px_diff = -(-0.032209 * npv + 0.067288);
+        met_py_diff = -(0.113917 * npv + 0.743906);
+    } else if (runera == yUL2016D) {
+        met_px_diff = -(-0.0293663 * npv + 0.21106);
+        met_py_diff = -(0.11331 * npv + 0.815787);
+    } else if (runera == yUL2016E) {
+        met_px_diff = -(-0.0132046 * npv + 0.20073);
+        met_py_diff = -(0.134809 * npv + 0.679068);
+    } else if (runera == yUL2016F) {
+        met_px_diff = -(-0.0543566 * npv + 0.816597);
+        met_py_diff = -(0.114225 * npv + 1.17266);
+    } else if (runera == yUL2016Flate) {
+        met_px_diff = -(0.134616 * npv + -0.89965);
+        met_py_diff = -(0.0397736 * npv + 1.0385);
+    } else if (runera == yUL2016G) {
+        met_px_diff = -(0.121809 * npv + -0.584893);
+        met_py_diff = -(0.0558974 * npv + 0.891234);
+    } else if (runera == yUL2016H) {
+        met_px_diff = -(0.0868828 * npv + -0.703489);
+        met_py_diff = -(0.0888774 * npv + 0.902632);
+    } else if (runera == yUL2016MCnonAPV) {
+        met_px_diff = -(-0.153497 * npv + -0.231751);
+        met_py_diff = -(0.00731978 * npv + 0.243323);
+    } else if (runera == yUL2016MCAPV) {
+        met_px_diff = -(-0.188743 * npv + 0.136539);
+        met_py_diff = -(0.0127927 * npv + 0.117747);
+    }
+
+    return std::make_pair(met_px + met_px_diff, met_py + met_py_diff);
+}
+
+std::pair<double, double> met_phi_correction_etphi(
+    double met_et, double met_phi, int npv, int runnb, const std::string& year, bool isMC
+) {
+    // apply the correction
+    std::pair<double, double> pxpy_corr = met_phi_correction_pxpy(
+        met_et * cos(met_phi),
+        met_et * sin(met_phi),
+        npv, runnb, year, isMC
+    );
+
+    // convert back to et and phi
+    double met_et_correced = sqrt(pxpy_corr.first * pxpy_corr.first + pxpy_corr.second * pxpy_corr.second);
+    double met_phi_corrected = atan2(pxpy_corr.second, pxpy_corr.first);
+
+    return std::make_pair(met_et_correced, met_phi_corrected);
+}

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -37,7 +37,7 @@
 #include "JECKLUBinterface.h"
 #include "SVfitKLUBinterface.h"
 #include "SmearedJetProducer.h"
-
+#include "met_phi_corr.h"
 #include "lester_mt2_bisect.h"
 
 #include "ScaleFactor.h"
@@ -535,7 +535,7 @@ int main (int argc, char** argv)
 
   // ------------------------------
 
-  cout << "** INFO: useDepFlavor? " << useDeepFlavor << endl;
+  cout << "** INFO: useDeepFlavor? " << useDeepFlavor << endl;
 
   string bTag_SFFile;
   string bTag_effFile;
@@ -1700,8 +1700,12 @@ int main (int argc, char** argv)
 											 theBigTree.daughters_e->at (secondDaughterIndex)
 											 );
 
-	  TVector2 vMET(theBigTree.METx->at(chosenTauPair),
-					theBigTree.METy->at(chosenTauPair));
+	  auto met_phi_corr = met_phi_correction_pxpy(
+		theBigTree.METx->at(chosenTauPair),
+		theBigTree.METy->at(chosenTauPair),
+		theBigTree.npv, theBigTree.RunNumber, PERIOD, isMC
+	  );
+	  TVector2 vMET(float(met_phi_corr.first), float(met_phi_corr.second));
 	  TVector2 vMUON(0., 0.);
 	  if (pairType==0) {
 		// single muon in evt, vetoing events with 3rd lepton
@@ -2275,8 +2279,13 @@ int main (int argc, char** argv)
 		(3rd lepton veto already looks for soft leptons (>10 GeV))
 	  */
 	
+	  met_phi_corr = met_phi_correction_pxpy(
+	  	theBigTree.METx->at(chosenTauPair),
+	  	theBigTree.METy->at(chosenTauPair),
+	  	theBigTree.npv, theBigTree.RunNumber, PERIOD, isMC
+	  );
 	  TLorentzVector tlv_MET;
-	  tlv_MET.SetPxPyPzE(theBigTree.METx->at(chosenTauPair), theBigTree.METy->at(chosenTauPair), 0, std::hypot(theBigTree.METx->at(chosenTauPair), theBigTree.METy->at(chosenTauPair)));
+	  tlv_MET.SetPxPyPzE(met_phi_corr.first, met_phi_corr.second, 0, std::hypot(met_phi_corr.first, met_phi_corr.second));
 
 	  TLorentzVector tlv_DeepMET_ResponseTune;
 	  tlv_DeepMET_ResponseTune.SetPtEtaPhiM(theBigTree.ShiftedDeepMETresponseTune_pt, 0, theBigTree.ShiftedDeepMETresponseTune_phi, 0);
@@ -2314,8 +2323,8 @@ int main (int argc, char** argv)
 	  if (doSmearing)
 		{
 		  // Smear MET
-		  float METx = theBigTree.METx->at(chosenTauPair);
-		  float METy = theBigTree.METy->at(chosenTauPair);
+		  float METx = met_phi_corr.first;
+		  float METy = met_phi_corr.second;
 		  TVector2 metSmeared = getShiftedMET_smear(METx, METy, theBigTree, jets_and_smearFactor);
 		  vMET = metSmeared;
 		  tlv_MET.SetPxPyPzE(metSmeared.Px(), metSmeared.Py(), 0, std::hypot(metSmeared.Px(), metSmeared.Py()));
@@ -4277,8 +4286,13 @@ int main (int argc, char** argv)
 		  if (DEBUG) cout << "  HT = " << theSmallTree.m_BDT_HT20 << endl;
 		  if (DEBUG) cout << "---------------------" << endl;
 
-		  float METx = theBigTree.METx->at (chosenTauPair) ;
-		  float METy = theBigTree.METy->at (chosenTauPair) ;
+		  met_phi_corr = met_phi_correction_pxpy(
+		  	theBigTree.METx->at(chosenTauPair),
+		  	theBigTree.METy->at(chosenTauPair),
+		  	theBigTree.npv, theBigTree.RunNumber, PERIOD, isMC
+		  );
+		  float METx = met_phi_corr.first;
+		  float METy = met_phi_corr.second;
 		  if (doSmearing)
 			{
 			  TVector2 metSmeared = getShiftedMET_smear(METx, METy, theBigTree, jets_and_smearFactor);


### PR DESCRIPTION
This PR corrects the phi modulation of the standard MET object according to the [MissingETRun2Corrections](https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETRun2Corrections#xy_Shift_Correction_MET_phi_modu) Twiki, using a subset of the provided [example implementation](https://lathomas.web.cern.ch/lathomas/METStuff/XYCorrections/XYMETCorrection_withUL17andUL18andUL16.h) (using only UL and non-PUPPI met).

In `skimNtuple_HHbtag.cpp` we simply computed the corrected MET in all places where the `METx` and `METy` values were read from the `bigTree`. These places seemed potentially redundant to us, but we didn't want to change anything to that end without fully understanding why the `vMET` vector (i.e., the MET vector created initially) isn't re-used (possibly some assumption we didn't grasp).

Also, big pardon for the indentation, we just used what we found in the respective context 😇 (maybe we should shoot at it with clang-format at some point).

@bfonta @dzuolo @kramerto @portalesHEP