### PR TITLE
Single tau trigger in etau and mutau channels

### DIFF
--- a/src/OfflineProducerHelper.cc
+++ b/src/OfflineProducerHelper.cc
@@ -184,46 +184,46 @@ bool OfflineProducerHelper::pairPassBaseline (bigTree* tree, int iPair, TString 
   // if same type of particle, highest pt one is the first
   bool leg1=false;
   bool leg2=false;
+  const float eleEtaMax=2.5, muEtaMax=2.4, tauEtaMax=2.3;
   if (pairType == MuHad)
   {
     float tauIso = whatApply.Contains("TauRlxIzo") ? 7.0 : 3.0 ;
-    leg1 = muBaseline  (tree, dau1index, 15., 2.3, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
-    leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVVLoose, amuTight, tauIso, whatApply, debug);
+    leg1 = muBaseline  (tree, dau1index, 15., muEtaMax, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
+    leg2 = tauBaseline (tree, dau2index, 20., tauEtaMax, aeleVVLoose, amuTight, tauIso, whatApply, debug);
   }
 
   if (pairType == EHad)
   {
     float tauIso = whatApply.Contains("TauRlxIzo") ? 7.0 : 3.0 ;
-    leg1 = eleBaseline (tree, dau1index, 10., 2.3, 0.1, EMVATight, whatApply, debug);
-    //leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleTight, amuTight, tauIso, whatApply, debug); // Switched from 'aeleTight' to 'aeleVLoose' in January 2021
-    leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVVLoose, amuTight, tauIso, whatApply, debug);  // following HTT conveners suggestion
+    leg1 = eleBaseline (tree, dau1index, 10., eleEtaMax, 0.1, EMVATight, whatApply, debug);
+    leg2 = tauBaseline (tree, dau2index, 20., tauEtaMax, aeleVVLoose, amuTight, tauIso, whatApply, debug);
   }
 
   // ordered by pT and not by most isolated, but baseline asked in sync is the same...
   if (pairType == HadHad)
   {
     float tauIso = whatApply.Contains("TauRlxIzo") ? 7.0 : 2.0 ;
-    leg1 = tauBaseline (tree, dau1index, 20., 2.3, aeleVVLoose, amuTight, tauIso, whatApply, debug);
-    leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVVLoose, amuTight, tauIso, whatApply, debug);
+    leg1 = tauBaseline (tree, dau1index, 20., tauEtaMax, aeleVVLoose, amuTight, tauIso, whatApply, debug);
+    leg2 = tauBaseline (tree, dau2index, 20., tauEtaMax, aeleVVLoose, amuTight, tauIso, whatApply, debug);
   }
 
   if (pairType == EMu)
   {
-    leg1 = eleBaseline (tree, dau1index, 13., 2.3, 0.15, EMVAMedium, whatApply, debug);
-    leg2 = muBaseline  (tree, dau2index, 13., 2.3, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
+    leg1 = eleBaseline (tree, dau1index, 13., eleEtaMax, 0.15, EMVAMedium, whatApply, debug);
+    leg2 = muBaseline  (tree, dau2index, 13., muEtaMax, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
   }
 
   // e e, mu mu are still preliminary (not from baseline)
   if (pairType == EE)
   {
-    leg1 = eleBaseline (tree, dau1index, 25., 2.3, 0.15, EMVAMedium, whatApply, debug);
-    leg2 = eleBaseline (tree, dau2index, 25., 2.3, 0.15, EMVAMedium, whatApply, debug);
+    leg1 = eleBaseline (tree, dau1index, 25., eleEtaMax, 0.15, EMVAMedium, whatApply, debug);
+    leg2 = eleBaseline (tree, dau2index, 25., eleEtaMax, 0.15, EMVAMedium, whatApply, debug);
   }
 
   if (pairType == MuMu)
   {
-    leg1 = muBaseline (tree, dau1index, 10., 2.3, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
-    leg2 = muBaseline (tree, dau2index, 10., 2.3, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
+    leg1 = muBaseline (tree, dau1index, 10., muEtaMax, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
+    leg2 = muBaseline (tree, dau2index, 10., muEtaMax, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
   }
 
   bool result = (leg1 && leg2);
@@ -799,8 +799,6 @@ int OfflineProducerHelper::getBestPairHTauTau (bigTree* tree, TString whatApply,
       int dau1index = get<2> (vPairs.at(ipair));
       int dau2index = get<5> (vPairs.at(ipair));
       int ipair_orig = get<6> (vPairs.at(ipair));
-      //bool leg1 = tauBaseline (tree, dau1index, 20., 2.3, aeleVLoose, amuLoose, 99999., whatApply);  // MVA2017v2
-      //bool leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVLoose, amuLoose, 99999., whatApply);  // MVA2017v2
       bool leg1 = tauBaseline (tree, dau1index, 20., 2.3, aeleVVLoose, amuTight, 99999., whatApply); // DeepTauV2p1
       bool leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVVLoose, amuTight, 99999., whatApply); // DeepTauV2p1
       cout << "  > " << ipair << " tau_idx1=" << dau1index << " tau_idx2=" << dau2index << " orig_pair_idx=" << ipair_orig

--- a/src/OfflineProducerHelper.cc
+++ b/src/OfflineProducerHelper.cc
@@ -187,14 +187,14 @@ bool OfflineProducerHelper::pairPassBaseline (bigTree* tree, int iPair, TString 
   if (pairType == MuHad)
   {
     float tauIso = whatApply.Contains("TauRlxIzo") ? 7.0 : 3.0 ;
-    leg1 = muBaseline  (tree, dau1index, 20., 2.3, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
+    leg1 = muBaseline  (tree, dau1index, 15., 2.3, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
     leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVVLoose, amuTight, tauIso, whatApply, debug);
   }
 
   if (pairType == EHad)
   {
     float tauIso = whatApply.Contains("TauRlxIzo") ? 7.0 : 3.0 ;
-    leg1 = eleBaseline (tree, dau1index, 20., 2.3, 0.1, EMVATight, whatApply, debug);
+    leg1 = eleBaseline (tree, dau1index, 10., 2.3, 0.1, EMVATight, whatApply, debug);
     //leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleTight, amuTight, tauIso, whatApply, debug); // Switched from 'aeleTight' to 'aeleVLoose' in January 2021
     leg2 = tauBaseline (tree, dau2index, 20., 2.3, aeleVVLoose, amuTight, tauIso, whatApply, debug);  // following HTT conveners suggestion
   }

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -1462,7 +1462,7 @@ int main (int argc, char** argv)
 		  int dauType = theBigTree.particleType->at(idau);
 		  if (oph.isMuon(dauType))
 			{
-			  bool passMu   = oph.muBaseline (&theBigTree, idau, 20., 2.4,
+			  bool passMu   = oph.muBaseline (&theBigTree, idau, 15., 2.4,
 											  0.15, OfflineProducerHelper::MuTight,
 											  0.15, OfflineProducerHelper::MuHighPt, string("All"), (DEBUG ? true : false));
 			  bool passMu10 = oph.muBaseline (&theBigTree, idau, 10., 2.4,
@@ -1474,7 +1474,7 @@ int main (int argc, char** argv)
 			}
 		  else if (oph.isElectron(dauType))
 			{
-			  bool passEle   = oph.eleBaseline (&theBigTree, idau, 20., 2.5, 0.1, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax") , (DEBUG ? true : false));
+			  bool passEle   = oph.eleBaseline (&theBigTree, idau, 10., 2.5, 0.1, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax") , (DEBUG ? true : false));
 			  bool passEle10 = oph.eleBaseline (&theBigTree, idau, 10., 2.5, 0.3, OfflineProducerHelper::EMVATight, string("Vertex-LepID-pTMin-etaMax") , (DEBUG ? true : false));
 
 			  if (passEle) ++nele;


### PR DESCRIPTION
This PR adds the SingleTau trigger to the etau and mutau channels. Signal-wise, it brings around 5% and 15% for mutau and etau, respectivaly, at m(X)=1.5TeV (grows with m(X)). This benefits stems also from the lower pT threshold applied to electrons (20GeV to 10GeV) and muons (20GeV to 15GeV). The limits are constrained by the ID/Iso SFs currently used. 
Regarding KLUB, no significant modifications are required. The changes were already included in the AN.
The PR also prevents future questions concerning the study of the new triggers in non-tautau channels.