### PR TITLE
Add 2016 SingleTau140 trigger.

### DIFF
--- a/config/skim_UL16.cfg
+++ b/config/skim_UL16.cfg
@@ -61,7 +61,7 @@ TauTau      = NONE
 crossTauTau = HLT_DoubleMediumIsoPFTau35_Trk1_eta2p1_Reg_v, HLT_DoubleMediumCombinedIsoPFTau35_Trk1_eta2p1_Reg_v
 vbfTriggers = NONE
 METtriggers = HLT_PFMETNoMu90_PFMHTNoMu90_IDTight_v
-SingleTau   = HLT_VLooseIsoPFTau120_Trk50_eta2p1_v
+SingleTau   = HLT_VLooseIsoPFTau120_Trk50_eta2p1_v, HLT_VLooseIsoPFTau140_Trk50_eta2p1_v
 
 [triggersMC]
 MuMu        = HLT_IsoMu22_v, HLT_IsoTkMu22_v, HLT_IsoMu22_eta2p1_v , HLT_IsoTkMu22_eta2p1_v
@@ -74,7 +74,7 @@ TauTau      = NONE
 crossTauTau = HLT_DoubleMediumIsoPFTau35_Trk1_eta2p1_Reg_v, HLT_DoubleMediumCombinedIsoPFTau35_Trk1_eta2p1_Reg_v
 vbfTriggers = NONE
 METtriggers = HLT_PFMETNoMu90_PFMHTNoMu90_IDTight_v
-SingleTau   = HLT_VLooseIsoPFTau120_Trk50_eta2p1_v
+SingleTau   = HLT_VLooseIsoPFTau120_Trk50_eta2p1_v, HLT_VLooseIsoPFTau140_Trk50_eta2p1_v
 
 
 [bTagScaleFactors]


### PR DESCRIPTION
The trigger is mentioned on [slide 3](https://indico.cern.ch/event/982713/contributions/4138615/attachments/2162407/3653661/TauId_SingleTauTrigger.pdf) of the presentation where the measurement of single-tau trigger SFs is reported.