### PR TITLE
Use HHbtag_v2 in skim configs.

### DIFF
--- a/config/skim_UL16.cfg
+++ b/config/skim_UL16.cfg
@@ -141,7 +141,7 @@ features = /gwpool/users/spalluotto/HH_bbtautau/CMSSW_11_1_9/src/cms_runII_dnn_m
 kl = 1
 
 [HHbtag]
-weights = /gwpool/users/spalluotto/HH_bbtautau/CMSSW_11_1_9/src/HHTools/HHbtag/models/HHbtag_v1_par_
+weights = /gwpool/users/spalluotto/HH_bbtautau/CMSSW_11_1_9/src/HHTools/HHbtag/models/HHbtag_v2_par_
 
 [HHReweight]
 inputFile = /gwpool/users/brivio/Hhh_1718/LegacyRun2/May2020/LIMdev/CMSSW_11_1_9/src/KLUBAnalysis/weights/allHHnodeMap_5DdiffRew_2016.root

--- a/config/skim_UL17.cfg
+++ b/config/skim_UL17.cfg
@@ -98,7 +98,7 @@ features	= /nfs/dust/cms/user/kramerto/hbt_static_files/cms_runII_dnn_models/mod
 kl			= 1
 
 [HHbtag]
-weights = /nfs/dust/cms/user/kramerto/hbt_static_files/HHTools/HHbtag/models/HHbtag_v1_par_
+weights = /nfs/dust/cms/user/kramerto/hbt_static_files/HHTools/HHbtag/models/HHbtag_v2_par_
 
 [HHReweight]
 inputFile    = /nfs/dust/cms/user/kramerto/hbt_static_files/KLUBAnalysis/weights/allHHnodeMap_5DdiffRew_2017.root

--- a/config/skim_UL18.cfg
+++ b/config/skim_UL18.cfg
@@ -99,7 +99,7 @@ features = /grid_mnt/vol_home/llr/cms/alves/CMSSW_11_1_9/src/cms_runII_dnn_model
 kl = 1
 
 [HHbtag]
-weights = /grid_mnt/vol_home/llr/cms/alves/CMSSW_11_1_9/src/HHTools/HHbtag/models/HHbtag_v1_par_
+weights = /grid_mnt/vol_home/llr/cms/alves/CMSSW_11_1_9/src/HHTools/HHbtag/models/HHbtag_v2_par_
 
 [HHReweight]
 inputFile = /grid_mnt/vol_home/llr/cms/alves/CMSSW_11_1_9/src/KLUBAnalysis/weights/allHHnodeMap_5DdiffRew_2018.root


### PR DESCRIPTION
This PR changes the three skim configs to use v2 of the HHbtag model.

Input features and output format did not change, so no additional changes are needed. A test on a 2017 signal file was successful.

**Note** that this requires pulling the HHbtag plugin in `HHTools/HHbtag` and `scram build`'ing the project.

@portalesHEP @dzuolo @kramerto 