### PR TITLE
Remove stitching from DY 10<M(Z)<50 sample.

### DIFF
--- a/scripts/skimNtuple.py
+++ b/scripts/skimNtuple.py
@@ -226,7 +226,7 @@ def skim_ntuple(FLAGS, curr_folder):
                                        FLAGS.htcut,
                                        FLAGS.htcutlow,
                                        yes_or_no(FLAGS.toprew),
-                                       yes_or_no(FLAGS.genjets),
+                                       yes_or_no(FLAGS.dystitching),
                                        FLAGS.topstitch,
                                        yes_or_no(FLAGS.domt2),
                                        yes_or_no(FLAGS.ishhsignal),
@@ -324,8 +324,7 @@ if __name__ == "__main__":
     parser.add_argument('-e', '--njets', default='-999', help='njets required for stitching on inclusive')
     parser.add_argument('-t', '--toprew', default=0, type=int, help='is TT bar sample to compute reweight?')
     parser.add_argument('-b', '--topstitch', default='0', help='type of TT gen level decay pruning for stitch')
-    parser.add_argument('-g', '--genjets', default=0, type=int,
-                        help='loop on genjets to determine the number of b hadrons')
+    parser.add_argument('-g', '--dystitching', default=0, type=int, help='whether to use DY stitching or not.')
     parser.add_argument('-a', '--ishhsignal', default=0, type=int, help='isHHsignal')
     parser.add_argument('--BSMname', default='none', help='additional name for EFT benchmarks')
     parser.add_argument('--EFTbm', dest='EFTrew', default='none',

--- a/scripts/submit_skims.sh
+++ b/scripts/submit_skims.sh
@@ -336,7 +336,7 @@ MC_MAP=(
     ["TTToSemiLeptonic"]="-n 400 -x ${SemiLepXSec} -q long"
 
     ["DYJets.+_M-50_T.+amc"]="-n 600 -x 6077.22 -g ${STITCHING_ON} --DY 0 -q long" # inclusive NLO
-    ["DYJets.+_M-10to50.+v2"]="-n 300 -x 20490.0 -g ${STITCHING_ON} --DY 0 -q short" # low mass
+    # ["DYJets.+_M-10to50.+v2"]="-n 300 -x 20490.0 --DY 0 -q short" # low mass
     ["DYJetsToLL_LHEFilterPtZ-0To50"]="-n 200    -x 1409.22 -g ${STITCHING_ON} --DY 0 -q long"
     ["DYJetsToLL_LHEFilterPtZ-50To100"]="-n 2000  -x 377.12  -g ${STITCHING_ON} --DY 0 -q short"
     ["DYJetsToLL_LHEFilterPtZ-100To250"]="-n 200 -x 92.24   -g ${STITCHING_ON} --DY 0 -q long"

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -232,12 +232,7 @@ int main (int argc, char** argv)
   if (!isMC) isTTBar = false; // force it, you never know...
   cout << "** INFO: is this a TTbar sample? : " << isTTBar << endl;
 
-  bool DY_tostitch = false;
-  int I_DY_tostitch = atoi(argv[11]);
-  if (I_DY_tostitch == 1)
-	{
-	  DY_tostitch = true; // FIXME!! this is ok only if we use jet binned samples
-	}
+  bool DY_tostitch = static_cast<bool>(atoi(argv[11]));
 
   int TT_stitchType = atoi(argv[12]);
   if (!isTTBar) TT_stitchType = 0; // just force if not TT...


### PR DESCRIPTION
This PR removes the stitching from the DY sample covering the 10<M(Z)<50GeV mass range. This has no impact on the skims, since we had already decided not to use the sample (it should not be present in the configuration files for the histogramming step). Thanks @kramerto for spotting this.

I've also simplified the reading of the DY stitching flag. You can check it works by running the script below with ```./exe 1``` or ```./exe 0``` (after compiling with ```g++ script.cc -o exe```):

```c++
#include<iostream>

int main(int argc, char** argv)
{
  std::cout << static_cast<bool>(atoi(argv[1])) << std::endl;
  /*
	The following does not work because a non-empty string is always true
	std::cout << static_cast<bool>(argv[1]) << std::endl;
  */
  return 0;
}
```