### PR TITLE
Skip bTag SFs when processing data.

### DIFF
--- a/interface/bTagSF.h
+++ b/interface/bTagSF.h
@@ -16,7 +16,7 @@ class bTagSF
 public:
   enum WP {loose = 0, medium = 1, tight = 2, reshaping = 3};
   enum SFsyst {central = 0, up = 1, down = 2};
-  bTagSF(std::string SFfilename, std::string effFileName, std::string effHistoTag, std::string year, std::string WPset="80X_ICHEP_2016");
+  bTagSF(std::string SFfilename, std::string effFileName, std::string effHistoTag, std::string year, std::string WPset, bool isMC);
   ~bTagSF();
   float getSF (WP wpt, SFsyst syst, int jetFlavor, float pt, float eta, float discr=0.);
   float getSFshifted (std::string systName, int jetFlavor, float pt, float eta, float discr=0.);
@@ -28,6 +28,8 @@ public:
   std::vector<float> getEvtWeightShifted (std::vector <std::pair <int, float> >& jets_and_btag, bigTree &theBigTree, std::map<int,double> jets_and_smearFactor);
 
 private:
+  void m_initialize(std::string, std::string, std::string, std::string, std::string);
+	
   // related to scale factors
   BTagCalibration m_calib;
   BTagCalibrationReader m_readers [4]; // [loose, medium, tight, reshaping]
@@ -39,4 +41,5 @@ private:
   double _WPtag[3]; // loose, medium, tight WP
 
   std::string m_year;
+  bool m_isMC;
 };

--- a/scripts/submit_skims.sh
+++ b/scripts/submit_skims.sh
@@ -403,7 +403,7 @@ MC_MAP=(
     ["TTWH"]="-n 6 -x 0.001143 -q short"
     ["TTZH"]="-n 15 -x 0.001136 -q short"
 
-	["GluGluToHHTo2B2Tau"]="-n 10 -x 0.01618 -q short"
+    ["GluGluToHHTo2B2Tau"]="-n 10 -x 0.01618 -q short"
 )
 
 # Sanity checks for Drell-Yan stitching

--- a/src/bTagSF.cc
+++ b/src/bTagSF.cc
@@ -331,21 +331,17 @@ vector<float> bTagSF::getEvtWeight (std::vector <std::pair <int, float> >& jets_
   }
   // return ratio
   vector<float> weight (4);
-  weight.at(0) = P_Data.at(0) / P_MC.at(0);
-  weight.at(1) = P_Data.at(1) / P_MC.at(1);
-  weight.at(2) = P_Data.at(2) / P_MC.at(2);
+  for (int iWP = 0; iWP < 3; iWP++) {
+	weight.at(iWP) = P_Data.at(iWP) / P_MC.at(iWP);
+  }
   weight.at(3) = SFreshaping;
 
-  if (weight.at(0) < 0.05)
+  if (SFreshaping < 0.05)
   {
-    cout << "------ ERROR Null B-TAG weight!!" << endl;
-	for(int wp=0; wp<3; ++wp) {
-	  cout << "WP: " << wp << endl;
-	  cout << "Probabilities: " << P_Data.at(wp) << " / " << P_MC.at(wp) << endl;
-	}
+    cout << "------ [Warning] Small B_Tag reshape SF!" << endl;
 	cout << "SF reshaping: " << SFreshaping << endl;
   }
-  //cout << "weights: " << weight.at(0) << " " << weight.at(1) << " " << weight.at(2) << endl;
+
   return weight;
 }
 

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -578,8 +578,8 @@ int main (int argc, char** argv)
 	wpset_df = "106X16postVFP_DeepFlavor_V1";
 	wpyear = "2016";
   }
-  bTagSF bTagSFHelper (bTag_SFFile, bTag_effFile, "", wpyear, wpset_csv);
-  if(useDeepFlavor) {
+  bTagSF bTagSFHelper(bTag_SFFile, bTag_effFile, "", wpyear, wpset_csv, isMC);
+  if(useDeepFlavor and isMC) {
     bTagSFHelper.SetWPset(wpset_df);
   }
 
@@ -589,7 +589,7 @@ int main (int argc, char** argv)
   string puYear;
   if (PERIOD=="2018") {
 	puYear = "2018";
-}
+  }
   else if (PERIOD=="2017") {
 	puYear = "2017";
   }
@@ -695,28 +695,28 @@ int main (int argc, char** argv)
   if (PERIOD == "2018") {
     muTauTrgSF->init_EG_ScaleFactor(customTrgSFDir + "sf_mu_2018_HLTMu20Tau27.root", true);
     muTrgSF   ->init_ScaleFactor("weights/MuPogSF_UL/2018/Efficiencies_muon_generalTracks_Z_Run2018_UL_SingleMuonTriggers.root",
-				 "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight_abseta_pt", true);
+								 "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight_abseta_pt", true);
     eTauTrgSF ->init_EG_ScaleFactor(customTrgSFDir + "sf_el_2018_HLTEle24Tau30.root",true);
     eTrgSF    ->init_EG_ScaleFactor(customTrgSFDir + "sf_el_2018_HLTEle32.root",true);
   }
   else if (PERIOD == "2017") {
     muTauTrgSF->init_EG_ScaleFactor(customTrgSFDir + "sf_mu_2017_HLTMu20Tau27.root", true);
     muTrgSF   ->init_ScaleFactor("weights/MuPogSF_UL/2017/Efficiencies_muon_generalTracks_Z_Run2017_UL_SingleMuonTriggers.root",
-				 "NUM_IsoMu27_DEN_CutBasedIdTight_and_PFIsoTight_abseta_pt", true);
+								 "NUM_IsoMu27_DEN_CutBasedIdTight_and_PFIsoTight_abseta_pt", true);
     eTauTrgSF ->init_EG_ScaleFactor(customTrgSFDir + "sf_el_2017_HLTEle24Tau30.root", true);
     eTrgSF    ->init_EG_ScaleFactor(customTrgSFDir + "sf_el_2017_HLTEle32.root", true);
   }
   else if (PERIOD == "2016preVFP") {
     muTauTrgSF->init_EG_ScaleFactor(customTrgSFDir + "sf_mu_2016pre_HLTMu20Tau27.root", true);
     muTrgSF   ->init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_SingleMuonTriggers.root",
-				 "NUM_IsoMu24_or_IsoTkMu24_DEN_CutBasedIdTight_and_PFIsoTight_abseta_pt", true);
+								 "NUM_IsoMu24_or_IsoTkMu24_DEN_CutBasedIdTight_and_PFIsoTight_abseta_pt", true);
     //eTauTrgSF ->init_ScaleFactor("weights/trigger_SF_Legacy/2016/Electron_Ele24_eff.root"); //threshold higher than single lepton
     eTrgSF    ->init_EG_ScaleFactor(customTrgSFDir + "sf_el_2016pre_HLTEle25.root",true);
   }
   else if (PERIOD == "2016postVFP") {
     muTauTrgSF->init_EG_ScaleFactor(customTrgSFDir + "sf_mu_2016post_HLTMu20Tau27.root", true);
     muTrgSF   ->init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_SingleMuonTriggers.root",
-				 "NUM_IsoMu24_or_IsoTkMu24_DEN_CutBasedIdTight_and_PFIsoTight_abseta_pt", true);
+								 "NUM_IsoMu24_or_IsoTkMu24_DEN_CutBasedIdTight_and_PFIsoTight_abseta_pt", true);
     //eTauTrgSF ->init_ScaleFactor("weights/trigger_SF_Legacy/2016/Electron_Ele24_eff.root"); //threshold higher than single lepton
     eTrgSF    ->init_EG_ScaleFactor(customTrgSFDir + "sf_el_2016post_HLTEle25.root",true);
   }
@@ -1718,10 +1718,10 @@ int main (int argc, char** argv)
 											 );
 
 	  auto met_phi_corr = met_phi_correction_pxpy(
-		theBigTree.METx->at(chosenTauPair),
-		theBigTree.METy->at(chosenTauPair),
-		theBigTree.npv, theBigTree.RunNumber, PERIOD, isMC
-	  );
+												  theBigTree.METx->at(chosenTauPair),
+												  theBigTree.METy->at(chosenTauPair),
+												  theBigTree.npv, theBigTree.RunNumber, PERIOD, isMC
+												  );
 	  TVector2 vMET(float(met_phi_corr.first), float(met_phi_corr.second));
 	  TVector2 vMUON(0., 0.);
 	  if (pairType==0) {
@@ -1729,7 +1729,7 @@ int main (int argc, char** argv)
 		vMUON.Set(tlv_firstLepton.Px(), tlv_firstLepton.Py());
 	  }
 	  else if(pairType==3) {
-		 // two muons in evt (looser cuts), vetoing events with 3rd lepton
+		// two muons in evt (looser cuts), vetoing events with 3rd lepton
 		vMUON.Set(tlv_firstLepton.Px()+tlv_secondLepton.Px(),
 				  tlv_firstLepton.Py()+tlv_secondLepton.Py());
 	  }
@@ -2304,10 +2304,10 @@ int main (int argc, char** argv)
 	  */
 	
 	  met_phi_corr = met_phi_correction_pxpy(
-	  	theBigTree.METx->at(chosenTauPair),
-	  	theBigTree.METy->at(chosenTauPair),
-	  	theBigTree.npv, theBigTree.RunNumber, PERIOD, isMC
-	  );
+											 theBigTree.METx->at(chosenTauPair),
+											 theBigTree.METy->at(chosenTauPair),
+											 theBigTree.npv, theBigTree.RunNumber, PERIOD, isMC
+											 );
 	  TLorentzVector tlv_MET;
 	  tlv_MET.SetPxPyPzE(met_phi_corr.first, met_phi_corr.second, 0, std::hypot(met_phi_corr.first, met_phi_corr.second));
 
@@ -3752,64 +3752,65 @@ int main (int argc, char** argv)
 		  for (auto pair : jets_and_sortPar) jets_and_BTag.push_back (make_pair(pair.second, pair.first)); // just for compatibility...
 
 		  // NB !!! the following function only works if jets_and_sortPar contains <CVSscore, idx>
-		  vector<float> bTagWeight = bTagSFHelper.getEvtWeight (jets_and_BTag, theBigTree, jets_and_smearFactor, pType, bTagSF::central) ;
-		  theSmallTree.m_bTagweightL = (isMC ? bTagWeight.at(0) : 1.0) ;
-		  theSmallTree.m_bTagweightM = (isMC ? bTagWeight.at(1) : 1.0) ;
-		  theSmallTree.m_bTagweightT = (isMC ? bTagWeight.at(2) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape = (isMC ? bTagWeight.at(3) : 1.0) ;
+		  vector<float> bTagWeight = bTagSFHelper.getEvtWeight(jets_and_BTag, theBigTree, jets_and_smearFactor, pType, bTagSF::central);
+		  vector<float> bTagWeight_up = bTagSFHelper.getEvtWeight(jets_and_BTag, theBigTree, jets_and_smearFactor, pType, bTagSF::up);
+		  vector<float> bTagWeight_down = bTagSFHelper.getEvtWeight(jets_and_BTag, theBigTree, jets_and_smearFactor, pType, bTagSF::down);
+		  vector<float> bTagWeightReshapeshifts = bTagSFHelper.getEvtWeightShifted(jets_and_BTag, theBigTree, jets_and_smearFactor);
 
-		  vector<float> bTagWeight_up = bTagSFHelper.getEvtWeight (jets_and_BTag, theBigTree, jets_and_smearFactor, pType, bTagSF::up) ;
-		  theSmallTree.m_bTagweightL_up = (isMC ? bTagWeight_up.at(0) : 1.0) ;
-		  theSmallTree.m_bTagweightM_up = (isMC ? bTagWeight_up.at(1) : 1.0) ;
-		  theSmallTree.m_bTagweightT_up = (isMC ? bTagWeight_up.at(2) : 1.0) ;
+		  theSmallTree.m_bTagweightL = bTagWeight.at(0);
+		  theSmallTree.m_bTagweightM = bTagWeight.at(1);
+		  theSmallTree.m_bTagweightT = bTagWeight.at(2);
+		  theSmallTree.m_bTagweightReshape = bTagWeight.at(3);
 
-		  vector<float> bTagWeight_down = bTagSFHelper.getEvtWeight (jets_and_BTag, theBigTree, jets_and_smearFactor, pType, bTagSF::down) ;
-		  theSmallTree.m_bTagweightL_down = (isMC ? bTagWeight_down.at(0) : 1.0) ;
-		  theSmallTree.m_bTagweightM_down = (isMC ? bTagWeight_down.at(1) : 1.0) ;
-		  theSmallTree.m_bTagweightT_down = (isMC ? bTagWeight_down.at(2) : 1.0) ;
+		  theSmallTree.m_bTagweightL_up = bTagWeight_up.at(0);
+		  theSmallTree.m_bTagweightM_up = bTagWeight_up.at(1);
+		  theSmallTree.m_bTagweightT_up = bTagWeight_up.at(2);
 
-		  vector<float> bTagWeightReshapeshifts = bTagSFHelper.getEvtWeightShifted (jets_and_BTag, theBigTree, jets_and_smearFactor) ;
-		  theSmallTree.m_bTagweightReshape_jes_up        = (isMC ? bTagWeightReshapeshifts.at(0) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_lf_up         = (isMC ? bTagWeightReshapeshifts.at(1) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_hf_up         = (isMC ? bTagWeightReshapeshifts.at(2) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_hfstats1_up   = (isMC ? bTagWeightReshapeshifts.at(3) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_hfstats2_up   = (isMC ? bTagWeightReshapeshifts.at(4) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_lfstats1_up   = (isMC ? bTagWeightReshapeshifts.at(5) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_lfstats2_up   = (isMC ? bTagWeightReshapeshifts.at(6) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_cferr1_up     = (isMC ? bTagWeightReshapeshifts.at(7) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_cferr2_up     = (isMC ? bTagWeightReshapeshifts.at(8) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jes_down      = (isMC ? bTagWeightReshapeshifts.at(9) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_lf_down       = (isMC ? bTagWeightReshapeshifts.at(10) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_hf_down       = (isMC ? bTagWeightReshapeshifts.at(11) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_hfstats1_down = (isMC ? bTagWeightReshapeshifts.at(12) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_hfstats2_down = (isMC ? bTagWeightReshapeshifts.at(13) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_lfstats1_down = (isMC ? bTagWeightReshapeshifts.at(14) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_lfstats2_down = (isMC ? bTagWeightReshapeshifts.at(15) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_cferr1_down   = (isMC ? bTagWeightReshapeshifts.at(16) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_cferr2_down   = (isMC ? bTagWeightReshapeshifts.at(17) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetup1        = (isMC ? bTagWeightReshapeshifts.at(18) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetup2        = (isMC ? bTagWeightReshapeshifts.at(19) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetup3        = (isMC ? bTagWeightReshapeshifts.at(20) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetup4        = (isMC ? bTagWeightReshapeshifts.at(21) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetup5        = (isMC ? bTagWeightReshapeshifts.at(22) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetup6        = (isMC ? bTagWeightReshapeshifts.at(23) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetup7        = (isMC ? bTagWeightReshapeshifts.at(24) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetup8        = (isMC ? bTagWeightReshapeshifts.at(25) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetup9        = (isMC ? bTagWeightReshapeshifts.at(26) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetup10       = (isMC ? bTagWeightReshapeshifts.at(27) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetup11       = (isMC ? bTagWeightReshapeshifts.at(28) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetdown1      = (isMC ? bTagWeightReshapeshifts.at(29) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetdown2      = (isMC ? bTagWeightReshapeshifts.at(30) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetdown3      = (isMC ? bTagWeightReshapeshifts.at(31) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetdown4      = (isMC ? bTagWeightReshapeshifts.at(32) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetdown5      = (isMC ? bTagWeightReshapeshifts.at(33) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetdown6      = (isMC ? bTagWeightReshapeshifts.at(34) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetdown7      = (isMC ? bTagWeightReshapeshifts.at(35) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetdown8      = (isMC ? bTagWeightReshapeshifts.at(36) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetdown9      = (isMC ? bTagWeightReshapeshifts.at(37) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetdown10     = (isMC ? bTagWeightReshapeshifts.at(38) : 1.0) ;
-		  theSmallTree.m_bTagweightReshape_jetdown11     = (isMC ? bTagWeightReshapeshifts.at(39) : 1.0) ;
+		  theSmallTree.m_bTagweightL_down = bTagWeight_down.at(0);
+		  theSmallTree.m_bTagweightM_down = bTagWeight_down.at(1);
+		  theSmallTree.m_bTagweightT_down = bTagWeight_down.at(2);
 
+		  theSmallTree.m_bTagweightReshape_jes_up        = bTagWeightReshapeshifts.at(0); 
+		  theSmallTree.m_bTagweightReshape_lf_up		 = bTagWeightReshapeshifts.at(1); 
+		  theSmallTree.m_bTagweightReshape_hf_up		 = bTagWeightReshapeshifts.at(2); 
+		  theSmallTree.m_bTagweightReshape_hfstats1_up	 = bTagWeightReshapeshifts.at(3); 
+		  theSmallTree.m_bTagweightReshape_hfstats2_up	 = bTagWeightReshapeshifts.at(4); 
+		  theSmallTree.m_bTagweightReshape_lfstats1_up	 = bTagWeightReshapeshifts.at(5); 
+		  theSmallTree.m_bTagweightReshape_lfstats2_up	 = bTagWeightReshapeshifts.at(6); 
+		  theSmallTree.m_bTagweightReshape_cferr1_up	 = bTagWeightReshapeshifts.at(7); 
+		  theSmallTree.m_bTagweightReshape_cferr2_up	 = bTagWeightReshapeshifts.at(8); 
+		  theSmallTree.m_bTagweightReshape_jes_down		 = bTagWeightReshapeshifts.at(9); 
+		  theSmallTree.m_bTagweightReshape_lf_down		 = bTagWeightReshapeshifts.at(10);
+		  theSmallTree.m_bTagweightReshape_hf_down		 = bTagWeightReshapeshifts.at(11);
+		  theSmallTree.m_bTagweightReshape_hfstats1_down = bTagWeightReshapeshifts.at(12);
+		  theSmallTree.m_bTagweightReshape_hfstats2_down = bTagWeightReshapeshifts.at(13);
+		  theSmallTree.m_bTagweightReshape_lfstats1_down = bTagWeightReshapeshifts.at(14);
+		  theSmallTree.m_bTagweightReshape_lfstats2_down = bTagWeightReshapeshifts.at(15);
+		  theSmallTree.m_bTagweightReshape_cferr1_down	 = bTagWeightReshapeshifts.at(16);
+		  theSmallTree.m_bTagweightReshape_cferr2_down	 = bTagWeightReshapeshifts.at(17);
+		  theSmallTree.m_bTagweightReshape_jetup1		 = bTagWeightReshapeshifts.at(18);
+		  theSmallTree.m_bTagweightReshape_jetup2		 = bTagWeightReshapeshifts.at(19);
+		  theSmallTree.m_bTagweightReshape_jetup3		 = bTagWeightReshapeshifts.at(20);
+		  theSmallTree.m_bTagweightReshape_jetup4		 = bTagWeightReshapeshifts.at(21);
+		  theSmallTree.m_bTagweightReshape_jetup5		 = bTagWeightReshapeshifts.at(22);
+		  theSmallTree.m_bTagweightReshape_jetup6		 = bTagWeightReshapeshifts.at(23);
+		  theSmallTree.m_bTagweightReshape_jetup7		 = bTagWeightReshapeshifts.at(24);
+		  theSmallTree.m_bTagweightReshape_jetup8		 = bTagWeightReshapeshifts.at(25);
+		  theSmallTree.m_bTagweightReshape_jetup9		 = bTagWeightReshapeshifts.at(26);
+		  theSmallTree.m_bTagweightReshape_jetup10		 = bTagWeightReshapeshifts.at(27);
+		  theSmallTree.m_bTagweightReshape_jetup11		 = bTagWeightReshapeshifts.at(28);
+		  theSmallTree.m_bTagweightReshape_jetdown1		 = bTagWeightReshapeshifts.at(29);
+		  theSmallTree.m_bTagweightReshape_jetdown2		 = bTagWeightReshapeshifts.at(30);
+		  theSmallTree.m_bTagweightReshape_jetdown3		 = bTagWeightReshapeshifts.at(31);
+		  theSmallTree.m_bTagweightReshape_jetdown4		 = bTagWeightReshapeshifts.at(32);
+		  theSmallTree.m_bTagweightReshape_jetdown5		 = bTagWeightReshapeshifts.at(33);
+		  theSmallTree.m_bTagweightReshape_jetdown6		 = bTagWeightReshapeshifts.at(34);
+		  theSmallTree.m_bTagweightReshape_jetdown7		 = bTagWeightReshapeshifts.at(35);
+		  theSmallTree.m_bTagweightReshape_jetdown8		 = bTagWeightReshapeshifts.at(36);
+		  theSmallTree.m_bTagweightReshape_jetdown9		 = bTagWeightReshapeshifts.at(37);
+		  theSmallTree.m_bTagweightReshape_jetdown10	 = bTagWeightReshapeshifts.at(38);
+		  theSmallTree.m_bTagweightReshape_jetdown11	 = bTagWeightReshapeshifts.at(39);
+			  
 		  // Set HHbtaginterface for ordering jets
 		  HHbtagTagger.SetInputValues(theBigTree, jets_and_sortPar, theSmallTree.m_BDT_channel,
 									  tlv_firstLepton, tlv_secondLepton, tlv_tauH, tlv_MET, theSmallTree.m_EventNumber, jets_and_smearFactor);


### PR DESCRIPTION
Reading bTag SFs takes some time. This is not needed when running on data. The code was tested with both signal and data samples.
The error message appearing when using small bTag WP SFs has been replaced by a message printing "Warning" when the bTag **reshaping** SFs are small, since we are now using the latter. The string replacement should prevent jobs triggering the warning to be placed in the "badfiles.txt" file (see ```scripts/check_outputs.py```).