### PR TITLE
Bugfix: Bad assert

### DIFF
--- a/interface/ScaleFactorMET.h
+++ b/interface/ScaleFactorMET.h
@@ -15,27 +15,34 @@
 
 class ScaleFactorMET {
 public:
-  ScaleFactorMET();
+  ScaleFactorMET(std::string);
   ~ScaleFactorMET();
   
-  double getSF(double, std::string);
-  double getSFError(double, std::string);
-
+  double getSF(double);
+  double getSFError(double);
+  float getMinThreshold();
+  
   template <typename T>
   using uMap = std::unordered_map<std::string, T>;
   
 private:
   uMap<std::string> inputs;
-  uMap<std::unique_ptr<TFile>> fileIn;
-  uMap<TF1*> funcSF, funcData, funcMC;
-  std::array<std::string, 4> mPeriods = {"2016preVFP", "2016postVFP", "2017", "2018"};
-  std::pair<double, double> mRange;
+  std::unique_ptr<TFile> fileIn;
+  TF1 *funcSF, *funcData, *funcMC;
+  std::string mPeriod;
+  std::array<std::string, 4> mPeriods = {{"2016preVFP", "2016postVFP", "2017", "2018"}};
+  const uMap<std::pair<double, double>> mRange = {
+	{"2016preVFP",  {160., 325.}},
+	{"2016postVFP", {160., 325.}},
+	{"2017",        {160., 325.}},
+	{"2018",        {150., 325.}}
+  };
 
   void mCheckFile(std::unique_ptr<TFile>&, std::string);
-  void mCheckPeriod(std::string);
+  void mCheckPeriod();
   void mCheckChannel(std::string);
-  double mErrorQuadSumSquared(double, std::string, std::string);
-  double mErrorRatio(double, std::string);
+  double mErrorQuadSumSquared(double, std::string);
+  double mErrorRatio(double);
   double mImposeBounds(double);
 };
 

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -367,17 +367,18 @@ int main (int argc, char** argv)
 	assert (datasetType==0);
   }
 
-  float met_thresh, tau_thresh;
+  // MET scale Factors
+  ScaleFactorMET metSF(PERIOD);
+
+  float tau_thresh;
+  float met_thresh = metSF.getMinThreshold();
   if (PERIOD=="2016preVFP" or PERIOD=="2016postVFP") {
-	met_thresh = 160.;
 	tau_thresh = 130.;
   }
   else if (PERIOD=="2017") {
-	met_thresh = 160.;
 	tau_thresh = 190.;
   }
   else { // 2018
-	met_thresh = 150.;
 	tau_thresh = 190.;
   }
 
@@ -747,9 +748,6 @@ int main (int argc, char** argv)
     //eTauTrgSF ->init_ScaleFactor("weights/trigger_SF_Legacy/2016/Electron_Ele24_eff.root"); //threshold higher than single lepton
     eTrgSF    ->init_EG_ScaleFactor(customTrgSFDir + "sf_el_2016post_HLTEle25.root",true);
   }
-
-  // MET scale Factors
-  ScaleFactorMET metSF;
     
   // electron/muon IdAndIso SF
   ScaleFactor * myIDandISOScaleFactor[3]; // [0: muID, 1: eleID, 2:muISO,]
@@ -3005,9 +3003,9 @@ int main (int argc, char** argv)
 			{
 			  if (trgRegions["met"])
 				{
-				  trigSF          = metSF.getSF(vMETnoMu.Mod(), PERIOD);
-				  trigSF_met_up   = trigSF + metSF.getSFError(vMETnoMu.Mod(), PERIOD);
-				  trigSF_met_down = trigSF - metSF.getSFError(vMETnoMu.Mod(), PERIOD);
+				  trigSF          = metSF.getSF(vMETnoMu.Mod());
+				  trigSF_met_up   = trigSF + metSF.getSFError(vMETnoMu.Mod());
+				  trigSF_met_down = trigSF - metSF.getSFError(vMETnoMu.Mod());
 				}
 
 			  else if (trgRegions["tau"])
@@ -3142,9 +3140,9 @@ int main (int argc, char** argv)
 			{
 			  if (trgRegions["met"])
 				{
-				  trigSF          = metSF.getSF(vMETnoMu.Mod(), PERIOD);
-				  trigSF_met_up   = trigSF + metSF.getSFError(vMETnoMu.Mod(), PERIOD);
-				  trigSF_met_down = trigSF - metSF.getSFError(vMETnoMu.Mod(), PERIOD);
+				  trigSF          = metSF.getSF(vMETnoMu.Mod());
+				  trigSF_met_up   = trigSF + metSF.getSFError(vMETnoMu.Mod());
+				  trigSF_met_down = trigSF - metSF.getSFError(vMETnoMu.Mod());
 				}
 
 			  else if (trgRegions["tau"])
@@ -3283,9 +3281,9 @@ int main (int argc, char** argv)
 			{
 			  if (trgRegions["met"])
 				{
-				  trigSF          = metSF.getSF(vMETnoMu.Mod(), PERIOD);
-				  trigSF_met_up   = trigSF + metSF.getSFError(vMETnoMu.Mod(), PERIOD);
-				  trigSF_met_down = trigSF - metSF.getSFError(vMETnoMu.Mod(), PERIOD);
+				  trigSF          = metSF.getSF(vMETnoMu.Mod());
+				  trigSF_met_up   = trigSF + metSF.getSFError(vMETnoMu.Mod());
+				  trigSF_met_down = trigSF - metSF.getSFError(vMETnoMu.Mod());
 				}
 
 			  else if (trgRegions["tau"])

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -4234,7 +4234,6 @@ int main (int argc, char** argv)
 
 		  // loop over jets
 		  int genjets = 0;
-		  int jets  = 0;
 		  for (unsigned int iJet = 0; (iJet < theBigTree.jets_px->size ()) && (theSmallTree.m_njets < maxNjetsSaved); ++iJet)
 			{
 			  // PG filter jets at will


### PR DESCRIPTION
Fix bug introduced in #343, caused by different MET SF function ranges for different years, which was not taken into account by the ```assert``` statements.
I took this chance to optimize the MET SF class, by removing loops and checks concerning different periods. Those are not required since each period is run by an independent skimmer, and so there is no need to keep track of the information from different periods in the same MET SF object.