### PR TITLE
Bugfix: Lepton Trigger Scale Factors

### DIFF
--- a/interface/ScaleFactor.h
+++ b/interface/ScaleFactor.h
@@ -26,7 +26,7 @@ private:
   void  SetAxisBins(TGraphAsymmErrors*);
   bool  check_SameBinning(TGraphAsymmErrors*, TGraphAsymmErrors*);
   //std::string FindEtaLabel(double, std::string);
-  int FindPtBin( std::map<std::string, TGraphAsymmErrors *>, std::string, double);
+  int FindPtBin( std::map<std::string, TGraphAsymmErrors *>, std::string, double, double);
 
 public:
   ScaleFactor(){};

--- a/interface/ScaleFactor.h
+++ b/interface/ScaleFactor.h
@@ -23,19 +23,18 @@ private:
 
   TH1D * etaBinsH;
 
-  void  SetAxisBins(TGraphAsymmErrors*);
-  bool  check_SameBinning(TGraphAsymmErrors*, TGraphAsymmErrors*);
-  //std::string FindEtaLabel(double, std::string);
-  int FindPtBin( std::map<std::string, TGraphAsymmErrors *>, std::string, double, double);
+  void SetAxisBins(TGraphAsymmErrors*);
+  bool check_SameBinning(TGraphAsymmErrors*, TGraphAsymmErrors*);
+  std::string FindEtaLabel(double, std::string);
+  int FindPtBin(std::map<std::string, TGraphAsymmErrors *>, std::string, double, double);
 
 public:
   ScaleFactor(){};
+  ~ScaleFactor(){};
   void init_ScaleFactor(TString);
-  void init_ScaleFactor(TString,std::string);
+  void init_ScaleFactor(TString, std::string);
   void init_ScaleFactor(TString, std::string, bool);
   void init_EG_ScaleFactor(TString, bool);
-  ~ ScaleFactor(){};
-  std::string FindEtaLabel(double, std::string);
   double get_EfficiencyData(double, double); //pt, eta
   double get_EfficiencyMC(double, double);
   double get_ScaleFactor(double, double);

--- a/interface/ScaleFactor.h
+++ b/interface/ScaleFactor.h
@@ -21,7 +21,7 @@ private:
   std::map<std::string, TGraphAsymmErrors *> eff_data;
   std::map<std::string, TGraphAsymmErrors *> eff_mc;
 
-  TH1D * etaBinsH;
+  TH1D *etaBinsH;
 
   void SetAxisBins(TGraphAsymmErrors*);
   bool check_SameBinning(TGraphAsymmErrors*, TGraphAsymmErrors*);

--- a/interface/ScaleFactorMET.h
+++ b/interface/ScaleFactorMET.h
@@ -40,7 +40,6 @@ private:
 
   void mCheckFile(std::unique_ptr<TFile>&, std::string);
   void mCheckPeriod();
-  void mCheckChannel(std::string);
   double mErrorQuadSumSquared(double, std::string);
   double mErrorRatio(double);
   double mImposeBounds(double);

--- a/interface/smallTree_HHbtag.h
+++ b/interface/smallTree_HHbtag.h
@@ -109,7 +109,6 @@ struct smallTree
       m_trigSF_DM1_down = -1.;
       m_trigSF_DM10_down = -1.;
       m_trigSF_DM11_down = -1.;
-      m_trigSF_single = -1.;
       m_trigSF_cross = -1.;
 	  m_trigSF_met_up = -1.;
 	  m_trigSF_met_down = -1.;
@@ -1048,7 +1047,6 @@ struct smallTree
       m_smallT->Branch ("trigSF_DM1_down",  &m_trigSF_DM1_down,  "trigSF_DM1_down/F") ;
       m_smallT->Branch ("trigSF_DM10_down", &m_trigSF_DM10_down, "trigSF_DM10_down/F") ;
       m_smallT->Branch ("trigSF_DM11_down", &m_trigSF_DM11_down, "trigSF_DM11_down/F") ;
-      m_smallT->Branch ("trigSF_single", &m_trigSF_single, "trigSF_single/F") ;
       m_smallT->Branch ("trigSF_cross", &m_trigSF_cross, "trigSF_cross/F") ;
 	  m_smallT->Branch ("trigSF_met_up", &m_trigSF_met_up, "trigSF_met_up/F") ;
 	  m_smallT->Branch ("trigSF_met_down", &m_trigSF_met_down, "trigSF_met_down/F") ;
@@ -1919,7 +1917,6 @@ struct smallTree
   Float_t m_trigSF_met_down ;
   Float_t m_trigSF_stau_up ;
   Float_t m_trigSF_stau_down ;
-  Float_t m_trigSF_single ;
   Float_t m_FakeRateSF ;
   Float_t m_jetFakeSF ;
   Float_t m_IdSF_deep_2d ;

--- a/interface/smallTree_HHbtag.h
+++ b/interface/smallTree_HHbtag.h
@@ -109,7 +109,6 @@ struct smallTree
       m_trigSF_DM1_down = -1.;
       m_trigSF_DM10_down = -1.;
       m_trigSF_DM11_down = -1.;
-      m_trigSF_cross = -1.;
 	  m_trigSF_met_up = -1.;
 	  m_trigSF_met_down = -1.;
 	  m_trigSF_stau_up = -1.;
@@ -1047,7 +1046,6 @@ struct smallTree
       m_smallT->Branch ("trigSF_DM1_down",  &m_trigSF_DM1_down,  "trigSF_DM1_down/F") ;
       m_smallT->Branch ("trigSF_DM10_down", &m_trigSF_DM10_down, "trigSF_DM10_down/F") ;
       m_smallT->Branch ("trigSF_DM11_down", &m_trigSF_DM11_down, "trigSF_DM11_down/F") ;
-      m_smallT->Branch ("trigSF_cross", &m_trigSF_cross, "trigSF_cross/F") ;
 	  m_smallT->Branch ("trigSF_met_up", &m_trigSF_met_up, "trigSF_met_up/F") ;
 	  m_smallT->Branch ("trigSF_met_down", &m_trigSF_met_down, "trigSF_met_down/F") ;
 	  m_smallT->Branch ("trigSF_stau_up", &m_trigSF_stau_up, "trigSF_stau_up/F") ;
@@ -1912,7 +1910,6 @@ struct smallTree
   Float_t m_trigSF_DM1_down ;
   Float_t m_trigSF_DM10_down ;
   Float_t m_trigSF_DM11_down ;
-  Float_t m_trigSF_cross ;
   Float_t m_trigSF_met_up ;
   Float_t m_trigSF_met_down ;
   Float_t m_trigSF_stau_up ;

--- a/src/ScaleFactor.cc
+++ b/src/ScaleFactor.cc
@@ -342,24 +342,28 @@ std::string ScaleFactor::FindEtaLabel(double Eta, std::string Which){
 }
 
 
-int ScaleFactor::FindPtBin( std::map<std::string, TGraphAsymmErrors *> eff_map, std::string EtaLabel, double Pt){
-
+int ScaleFactor::FindPtBin(std::map<std::string, TGraphAsymmErrors *> eff_map,
+						   std::string EtaLabel, double Pt, double Eta)
+{
   int Npoints = eff_map[EtaLabel]->GetN();
   double ptMAX = (eff_map[EtaLabel]->GetX()[Npoints-1])+(eff_map[EtaLabel]->GetErrorXhigh(Npoints-1));
   double ptMIN = (eff_map[EtaLabel]->GetX()[0])-(eff_map[EtaLabel]->GetErrorXlow(0));
   // if pt is overflow, return last pt bin
   if (Pt >= ptMAX ) return Npoints;
   // if pt is underflow, return nonsense number and warning
-  else if (Pt < ptMIN){
-    std::cout<< "WARNING in ScaleFactor::get_EfficiencyData(double pt, double eta) from src/ScaleFactor.cc: pT too low (pt = " << Pt << "), min value is " << ptMIN << ". Returned efficiency =1. Weight will be 1. " << std::endl;
-    return -99;}
+  else if (Pt < ptMIN) {
+    std::cout << "WARNING in ScaleFactor::get_EfficiencyData(double pt, double eta) from src/ScaleFactor.cc: "
+			  << "pT too low (pt=" << Pt << ", eta=" << Eta << "), min value is " << ptMIN << ". "
+			  << "Returned efficiency =1. Weight will be 1. " << std::endl;
+    return -99;
+  }
   // if pt is in range
   else {
     //return eff_map[EtaLabel]->GetXaxis()->FindFixBin(Pt);
     for (int graphBin=0; graphBin < Npoints; graphBin++) {
       if (Pt >= eff_map[EtaLabel]->GetPointX(graphBin) - eff_map[EtaLabel]->GetErrorXlow(graphBin)
-	  && Pt < eff_map[EtaLabel]->GetPointX(graphBin) + eff_map[EtaLabel]->GetErrorXhigh(graphBin))
-	return graphBin+1;
+		  && Pt < eff_map[EtaLabel]->GetPointX(graphBin) + eff_map[EtaLabel]->GetErrorXhigh(graphBin))
+		return graphBin+1;
     }
   }
 }
@@ -368,9 +372,9 @@ int ScaleFactor::FindPtBin( std::map<std::string, TGraphAsymmErrors *> eff_map, 
 double ScaleFactor::get_EfficiencyData(double pt, double eta){
 
   double eff;
-  std::string label = FindEtaLabel(eta,"data");
+  std::string label = FindEtaLabel(eta, "data");
 
-  int ptbin = FindPtBin(eff_data, label, pt);
+  int ptbin = FindPtBin(eff_data, label, pt, eta);
   if (ptbin == -99){eff =1;} // if pt is underflow
   else eff = eff_data[label]->GetY()[ptbin-1];
 
@@ -385,8 +389,8 @@ double ScaleFactor::get_EfficiencyData(double pt, double eta){
 double ScaleFactor::get_EfficiencyMC(double pt, double eta) {
 
   double eff;
-  std::string label = FindEtaLabel(eta,"mc");
-  int ptbin = FindPtBin(eff_mc, label, pt);
+  std::string label = FindEtaLabel(eta, "mc");
+  int ptbin = FindPtBin(eff_mc, label, pt, eta);
   if (ptbin == -99){eff =1;} // if pt is underflow
   else eff= eff_mc[label]->GetY()[ptbin-1];
 
@@ -415,8 +419,8 @@ double ScaleFactor::get_ScaleFactor(double pt, double eta){
 }
 double ScaleFactor::get_direct_ScaleFactor(double pt, double eta){
 
-  std::string label = FindEtaLabel(eta,"data");
-  int ptbin = FindPtBin(eff_data, label, pt); // when available, SF stored in eff_data (lazy implementation that should be improved)
+  std::string label = FindEtaLabel(eta, "data");
+  int ptbin = FindPtBin(eff_data, label, pt, eta); // when available, SF stored in eff_data (lazy implementation that should be improved)
   double SF;
 
   if (ptbin == -99){SF =1;} // if pt is underflow
@@ -430,8 +434,8 @@ double ScaleFactor::get_direct_ScaleFactor(double pt, double eta){
 double ScaleFactor::get_EfficiencyDataError(double pt, double eta){
 
   double eff_error;
-  std::string label = FindEtaLabel(eta,"data");
-  int ptbin = FindPtBin(eff_data, label, pt);
+  std::string label = FindEtaLabel(eta, "data");
+  int ptbin = FindPtBin(eff_data, label, pt, eta);
   if (ptbin == -99){eff_error =0.;} // if pt is underflow
   else eff_error= eff_data[label]->GetErrorYhigh(ptbin-1);
   // errors are supposed to be symmetric, can use GetErrorYhigh or GetErrorYlow
@@ -447,7 +451,7 @@ double ScaleFactor::get_EfficiencyMCError(double pt, double eta){
 
   double eff_error;
   std::string label = FindEtaLabel(eta,"mc");
-  int ptbin = FindPtBin(eff_mc, label, pt);
+  int ptbin = FindPtBin(eff_mc, label, pt, eta);
   if (ptbin == -99){eff_error =0.;} // if pt is underflow
   else eff_error= eff_mc[label]->GetErrorYhigh(ptbin-1);
   // errors are supposed to be symmetric, can use GetErrorYhigh or GetErrorYlow

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -2989,7 +2989,6 @@ int main (int argc, char** argv)
 	  float trigSF_DM1_down		= 1.0;
 	  float trigSF_DM10_down	= 1.0;
 	  float trigSF_DM11_down	= 1.0;
-	  float trigSF_single		= 1.0;
 	  float trigSF_cross		= 1.0;
 	  float trigSF_met_up   	= 1.0;
 	  float trigSF_met_down   	= 1.0;
@@ -3016,7 +3015,7 @@ int main (int argc, char** argv)
 				}
 
 			  // eta region covered both by cross-trigger and single lepton trigger
-			  else if (trgRegions["legacy"]) 
+			  else if (trgRegions["legacy"])
 				{
 				  int passSingle = 1, passCross = 1;
 
@@ -3131,8 +3130,6 @@ int main (int argc, char** argv)
 				  trigSF_mu_up   = SF + 1. * SF_Err;
 				  trigSF_mu_down = SF - 1. * SF_Err;
 				}
-			  //trig SF for analysis only with single-mu trigger
-			  trigSF_single = muTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 			}
 
 		  // EleTau Channel
@@ -3272,8 +3269,6 @@ int main (int argc, char** argv)
 				  trigSF_ele_up   = SF + 1. * SF_Err;
 				  trigSF_ele_down = SF - 1. * SF_Err;
 				}
-			  //trig SF for analysis only with single-e trigger
-			  trigSF_single =  eTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 			}
 
 		  // TauTau Channel
@@ -3366,7 +3361,6 @@ int main (int argc, char** argv)
 	  theSmallTree.m_trigSF_DM1_down	= (isMC ? trigSF_DM1_down : 1.0);
 	  theSmallTree.m_trigSF_DM10_down	= (isMC ? trigSF_DM10_down : 1.0);
 	  theSmallTree.m_trigSF_DM11_down	= (isMC ? trigSF_DM11_down : 1.0);
-	  theSmallTree.m_trigSF_single		= (isMC ? trigSF_single : 1.0);
 	  theSmallTree.m_trigSF_cross		= (isMC ? trigSF_cross : 1.0);
 	  theSmallTree.m_trigSF_met_up		= (isMC ? trigSF_met_up : 1.0);
 	  theSmallTree.m_trigSF_met_down	= (isMC ? trigSF_met_down : 1.0);

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -2956,8 +2956,8 @@ int main (int argc, char** argv)
 				{
 				  int passSingle = 1, passCross = 1;
 
-				  float lep1_thresh = trgAssigner.getLepton1Threshold(PERIOD, "mutau");
-				  float lep2_thresh = trgAssigner.getLepton2Threshold(PERIOD, "mutau");
+				  float lep1_thresh = trgAssigner.getLepton1PtThresh(PERIOD, "mutau");
+				  float lep2_thresh = trgAssigner.getLepton2PtThresh(PERIOD, "mutau");
 				  if (tlv_firstLepton.Pt()  < lep1_thresh) passSingle = 0;
 				  if (tlv_secondLepton.Pt() < lep2_thresh) passCross = 0;
 
@@ -3054,6 +3054,8 @@ int main (int argc, char** argv)
 				}
 			  else // eta region covered only by single lepton trigger
 				{
+				  assert (trgRegions["legacy"]);
+				  
 				  double SF = muTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 				  double SF_Err = muTrgSF->get_ScaleFactorError(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 				  trigSF = SF;
@@ -3084,8 +3086,8 @@ int main (int argc, char** argv)
 				{
 				  int passSingle = 1, passCross = 1;
 
-				  float lep1_thresh = trgAssigner.getLepton1Threshold(PERIOD, "etau");
-				  float lep2_thresh = trgAssigner.getLepton2Threshold(PERIOD, "etau");
+				  float lep1_thresh = trgAssigner.getLepton1PtThresh(PERIOD, "etau");
+				  float lep2_thresh = trgAssigner.getLepton2PtThresh(PERIOD, "etau");
 				  if (tlv_firstLepton.Pt() < lep1_thresh) passSingle = 0;
 				  if (tlv_secondLepton.Pt() < lep2_thresh) passCross = 0;
 

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -2926,7 +2926,6 @@ int main (int argc, char** argv)
 	  float trigSF_DM1_down		= 1.0;
 	  float trigSF_DM10_down	= 1.0;
 	  float trigSF_DM11_down	= 1.0;
-	  float trigSF_cross		= 1.0;
 	  float trigSF_met_up   	= 1.0;
 	  float trigSF_met_down   	= 1.0;
 	  float trigSF_stau_up   	= 1.0;
@@ -2952,7 +2951,7 @@ int main (int argc, char** argv)
 				}
 
 			  // eta region covered both by cross-trigger and single lepton trigger
-			  else if (trgRegions["legacy"])
+			  else if (trgRegions["legacy_cross"])
 				{
 				  int passSingle = 1, passCross = 1;
 
@@ -3046,11 +3045,6 @@ int main (int argc, char** argv)
 				  trigSF_DM1_down	= Eff_Data_down[1]	/ Eff_MC_down[1];
 				  trigSF_DM10_down	= Eff_Data_down[2]	/ Eff_MC_down[2];
 				  trigSF_DM11_down	= Eff_Data_down[3]	/ Eff_MC_down[3];
-
-				  //trig SF for analysis only with cross-trigger
-				  double SFl = muTauTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), fabs(tlv_firstLepton.Eta()));
-				  double SFtau = tauTrgSF_mutau->getSF(tlv_secondLepton.Pt(), DM2, 0); // last entry is uncertainty: 0 central, +1 up, -1 down
-				  trigSF_cross = SFl*SFtau;
 				}
 			  else // eta region covered only by single lepton trigger
 				{
@@ -3082,7 +3076,7 @@ int main (int argc, char** argv)
 				}
 
 			  // eta region covered both by cross-trigger and single lepton trigger
-			  else if(PERIOD != "2016preVFP" and PERIOD != "2016postVFP" and trgRegions["legacy"])
+			  else if(PERIOD != "2016preVFP" and PERIOD != "2016postVFP" and trgRegions["legacy_cross"])
 				{
 				  int passSingle = 1, passCross = 1;
 
@@ -3176,11 +3170,6 @@ int main (int argc, char** argv)
 				  trigSF_DM1_down  = Eff_Data_down[1]  / Eff_MC_down[1];
 				  trigSF_DM10_down = Eff_Data_down[2]  / Eff_MC_down[2];
 				  trigSF_DM11_down = Eff_Data_down[3]  / Eff_MC_down[3];
-
-				  //trig SF for analysis only with cross-trigger
-				  double SFl   = eTauTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
-				  double SFtau = tauTrgSF_etau->getSF(tlv_secondLepton.Pt(), DM2, 0); // last entry is uncertainty: 0 central, +1 up, -1 down
-				  trigSF_cross = SFl*SFtau;
 				}
 
 			  else //eta region covered only by single lepton trigger
@@ -3193,11 +3182,11 @@ int main (int argc, char** argv)
 				  // should only affect one bin in sf_el_2016post_HLTEle25.root
 				  if(PERIOD == "2016postVFP" and tlv_firstLepton.Pt() >= 100. and tlv_firstLepton.Eta() <= -2.)
 					{
-					  SF = eTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), -tlv_firstLepton.Eta());
+					  SF     = eTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), -tlv_firstLepton.Eta());
 					  SF_Err = eTrgSF->get_ScaleFactorError(tlv_firstLepton.Pt(), -tlv_firstLepton.Eta());
 					}
 				  else {
-				    SF = eTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
+				    SF     = eTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 				    SF_Err = eTrgSF->get_ScaleFactorError(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 				  }
 
@@ -3297,7 +3286,6 @@ int main (int argc, char** argv)
 	  theSmallTree.m_trigSF_DM1_down  = isMC ? trigSF_DM1_down  : 1.0;
 	  theSmallTree.m_trigSF_DM10_down = isMC ? trigSF_DM10_down : 1.0;
 	  theSmallTree.m_trigSF_DM11_down = isMC ? trigSF_DM11_down : 1.0;
-	  theSmallTree.m_trigSF_cross	  = isMC ? trigSF_cross     : 1.0;
 	  theSmallTree.m_trigSF_met_up	  = isMC ? trigSF_met_up    : 1.0;
 	  theSmallTree.m_trigSF_met_down  = isMC ? trigSF_met_down  : 1.0;
 	  theSmallTree.m_trigSF_stau_up	  = isMC ? trigSF_stau_up   : 1.0;

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -2958,15 +2958,15 @@ int main (int argc, char** argv)
 
 				  float lep1_thresh = trgAssigner.getLepton1Threshold(PERIOD, "mutau");
 				  float lep2_thresh = trgAssigner.getLepton2Threshold(PERIOD, "mutau");
-				  if (tlv_firstLepton.Pt() < lep1_thresh) passSingle = 0;
+				  if (tlv_firstLepton.Pt()  < lep1_thresh) passSingle = 0;
 				  if (tlv_secondLepton.Pt() < lep2_thresh) passCross = 0;
 
 				  //lepton trigger
 				  double SFL_Data = muTrgSF->get_EfficiencyData(tlv_firstLepton.Pt(), fabs(tlv_firstLepton.Eta()));
-				  double SFL_MC = muTrgSF->get_EfficiencyMC(tlv_firstLepton.Pt(), fabs(tlv_firstLepton.Eta()));
+				  double SFL_MC   = muTrgSF->get_EfficiencyMC(tlv_firstLepton.Pt(), fabs(tlv_firstLepton.Eta()));
 
 				  double SFL_Data_Err = muTrgSF->get_EfficiencyDataError(tlv_firstLepton.Pt(), fabs(tlv_firstLepton.Eta()));
-				  double SFL_MC_Err = muTrgSF->get_EfficiencyMCError(tlv_firstLepton.Pt(), fabs(tlv_firstLepton.Eta()));
+				  double SFL_MC_Err   = muTrgSF->get_EfficiencyMCError(tlv_firstLepton.Pt(), fabs(tlv_firstLepton.Eta()));
 
 				  double SFL_Data_up   = SFL_Data + 1. * SFL_Data_Err;
 				  double SFL_Data_down = SFL_Data - 1. * SFL_Data_Err;
@@ -2976,10 +2976,10 @@ int main (int argc, char** argv)
 				  //cross-trigger
 				  //mu leg
 				  double SFl_Data = muTauTrgSF->get_EfficiencyData(tlv_firstLepton.Pt(), fabs(tlv_firstLepton.Eta()));
-				  double SFl_MC = muTauTrgSF->get_EfficiencyMC(tlv_firstLepton.Pt(), fabs(tlv_firstLepton.Eta()));
+				  double SFl_MC   = muTauTrgSF->get_EfficiencyMC(tlv_firstLepton.Pt(), fabs(tlv_firstLepton.Eta()));
 
 				  double SFl_Data_Err = muTauTrgSF->get_EfficiencyDataError(tlv_firstLepton.Pt(), fabs(tlv_firstLepton.Eta()));
-				  double SFl_MC_Err = muTauTrgSF->get_EfficiencyMCError(tlv_firstLepton.Pt(), fabs(tlv_firstLepton.Eta()));
+				  double SFl_MC_Err   = muTauTrgSF->get_EfficiencyMCError(tlv_firstLepton.Pt(), fabs(tlv_firstLepton.Eta()));
 
 				  double SFl_Data_up   = SFl_Data + 1. * SFl_Data_Err;
 				  double SFl_Data_down = SFl_Data - 1. * SFl_Data_Err;
@@ -3091,10 +3091,10 @@ int main (int argc, char** argv)
 
 				  //lepton trigger
 				  double SFL_Data = eTrgSF->get_EfficiencyData(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
-				  double SFL_MC = eTrgSF->get_EfficiencyMC(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
+				  double SFL_MC   = eTrgSF->get_EfficiencyMC(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 
 				  double SFL_Data_Err = eTrgSF->get_EfficiencyDataError(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
-				  double SFL_MC_Err = eTrgSF->get_EfficiencyMCError(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
+				  double SFL_MC_Err   = eTrgSF->get_EfficiencyMCError(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 
 				  double SFL_Data_up   = SFL_Data + 1. * SFL_Data_Err;
 				  double SFL_Data_down = SFL_Data - 1. * SFL_Data_Err;
@@ -3104,10 +3104,10 @@ int main (int argc, char** argv)
 				  //cross-trigger
 				  //e leg
 				  double SFl_Data = eTauTrgSF->get_EfficiencyData(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
-				  double SFl_MC = eTauTrgSF->get_EfficiencyMC(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
+				  double SFl_MC   = eTauTrgSF->get_EfficiencyMC(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 
 				  double SFl_Data_Err = eTauTrgSF->get_EfficiencyDataError(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
-				  double SFl_MC_Err = eTauTrgSF->get_EfficiencyMCError(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
+				  double SFl_MC_Err   = eTauTrgSF->get_EfficiencyMCError(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 
 				  double SFl_Data_up   = SFl_Data + 1. * SFl_Data_Err;
 				  double SFl_Data_down = SFl_Data - 1. * SFl_Data_Err;
@@ -3163,20 +3163,20 @@ int main (int argc, char** argv)
 					  cout << "SFtau_MC: "   << SFtau_MC   << endl;
 					}
 
-				  trigSF			= Eff_Data			/ Eff_MC;
-				  trigSF_ele_up		= Eff_Data_ele_up	/ Eff_MC_ele_up;
-				  trigSF_ele_down	= Eff_Data_ele_down / Eff_MC_ele_down;
-				  trigSF_DM0_up		= Eff_Data_up[0]	/ Eff_MC_up[0];
-				  trigSF_DM1_up		= Eff_Data_up[1]	/ Eff_MC_up[1];
-				  trigSF_DM10_up	= Eff_Data_up[2]	/ Eff_MC_up[2];
-				  trigSF_DM11_up	= Eff_Data_up[3]	/ Eff_MC_up[3];
-				  trigSF_DM0_down	= Eff_Data_down[0]	/ Eff_MC_down[0];
-				  trigSF_DM1_down	= Eff_Data_down[1]	/ Eff_MC_down[1];
-				  trigSF_DM10_down	= Eff_Data_down[2]	/ Eff_MC_down[2];
-				  trigSF_DM11_down	= Eff_Data_down[3]	/ Eff_MC_down[3];
+				  trigSF		   = Eff_Data		   / Eff_MC;
+				  trigSF_ele_up	   = Eff_Data_ele_up   / Eff_MC_ele_up;
+				  trigSF_ele_down  = Eff_Data_ele_down / Eff_MC_ele_down;
+				  trigSF_DM0_up	   = Eff_Data_up[0]	   / Eff_MC_up[0];
+				  trigSF_DM1_up	   = Eff_Data_up[1]	   / Eff_MC_up[1];
+				  trigSF_DM10_up   = Eff_Data_up[2]	   / Eff_MC_up[2];
+				  trigSF_DM11_up   = Eff_Data_up[3]	   / Eff_MC_up[3];
+				  trigSF_DM0_down  = Eff_Data_down[0]  / Eff_MC_down[0];
+				  trigSF_DM1_down  = Eff_Data_down[1]  / Eff_MC_down[1];
+				  trigSF_DM10_down = Eff_Data_down[2]  / Eff_MC_down[2];
+				  trigSF_DM11_down = Eff_Data_down[3]  / Eff_MC_down[3];
 
 				  //trig SF for analysis only with cross-trigger
-				  double SFl = eTauTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
+				  double SFl   = eTauTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 				  double SFtau = tauTrgSF_etau->getSF(tlv_secondLepton.Pt(), DM2, 0); // last entry is uncertainty: 0 central, +1 up, -1 down
 				  trigSF_cross = SFl*SFtau;
 				}
@@ -3189,10 +3189,12 @@ int main (int argc, char** argv)
 				  double SF_Err = 1.;
 				  // dirty trick to deal with bad efficiency values in a (very) low-stat bins
 				  // should only affect one bin in sf_el_2016post_HLTEle25.root
-				  if(PERIOD == "2016postVFP" and tlv_firstLepton.Pt() >= 100. and tlv_firstLepton.Eta() <= -2.) {
-				    SF = eTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), -tlv_firstLepton.Eta());
-				    SF_Err = eTrgSF->get_ScaleFactorError(tlv_firstLepton.Pt(), -tlv_firstLepton.Eta());
-				  } else {
+				  if(PERIOD == "2016postVFP" and tlv_firstLepton.Pt() >= 100. and tlv_firstLepton.Eta() <= -2.)
+					{
+					  SF = eTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), -tlv_firstLepton.Eta());
+					  SF_Err = eTrgSF->get_ScaleFactorError(tlv_firstLepton.Pt(), -tlv_firstLepton.Eta());
+					}
+				  else {
 				    SF = eTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 				    SF_Err = eTrgSF->get_ScaleFactorError(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 				  }
@@ -3247,22 +3249,22 @@ int main (int argc, char** argv)
 					  }
 				  }
 				
-				trigSF				= SF1         * SF2;
-				trigSF_DM0_up		= SF1_up[0]   *	SF2_up[0];
-				trigSF_DM1_up		= SF1_up[1]   *	SF2_up[1];
-				trigSF_DM10_up		= SF1_up[2]   *	SF2_up[2];
-				trigSF_DM11_up		= SF1_up[3]   *	SF2_up[3];
-				trigSF_DM0_down		= SF1_down[0] *	SF2_down[0];
-				trigSF_DM1_down		= SF1_down[1] *	SF2_down[1];
-				trigSF_DM10_down	= SF1_down[2] *	SF2_down[2];
-				trigSF_DM11_down	= SF1_down[3] *	SF2_down[3];
+				trigSF			 = SF1         * SF2;
+				trigSF_DM0_up	 = SF1_up[0]   * SF2_up[0];
+				trigSF_DM1_up	 = SF1_up[1]   * SF2_up[1];
+				trigSF_DM10_up	 = SF1_up[2]   * SF2_up[2];
+				trigSF_DM11_up	 = SF1_up[3]   * SF2_up[3];
+				trigSF_DM0_down	 = SF1_down[0] * SF2_down[0];
+				trigSF_DM1_down	 = SF1_down[1] * SF2_down[1];
+				trigSF_DM10_down = SF1_down[2] * SF2_down[2];
+				trigSF_DM11_down = SF1_down[3] * SF2_down[3];
 			  }
 			}
 		  
 		  // MuMu Channel
 		  else if (pType == 3 && isMC)
 			{
-			  double SF = muTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
+			  double SF     = muTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 			  double SF_Err = muTrgSF->get_ScaleFactorError(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 			  trigSF = SF;
 			  trigSF_mu_up   = SF + 1. * SF_Err;
@@ -3272,7 +3274,7 @@ int main (int argc, char** argv)
 		  // EleEle Channel
 		  else if (pType == 4 && isMC)
 			{
-			  double SF = eTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
+			  double SF     = eTrgSF->get_ScaleFactor(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 			  double SF_Err = eTrgSF->get_ScaleFactorError(tlv_firstLepton.Pt(), tlv_firstLepton.Eta());
 			  trigSF = SF;
 			  trigSF_ele_up   = SF + 1. * SF_Err;
@@ -3280,24 +3282,24 @@ int main (int argc, char** argv)
 			}
 		} // end if(applytriggers)
 
-	  theSmallTree.m_trigSF				= (isMC ? trigSF : 1.0);
-	  theSmallTree.m_trigSF_ele_up		= (isMC ? trigSF_ele_up : 1.0);
-	  theSmallTree.m_trigSF_mu_up		= (isMC ? trigSF_mu_up : 1.0);
-	  theSmallTree.m_trigSF_DM0_up		= (isMC ? trigSF_DM0_up : 1.0);
-	  theSmallTree.m_trigSF_DM1_up		= (isMC ? trigSF_DM1_up : 1.0);
-	  theSmallTree.m_trigSF_DM10_up		= (isMC ? trigSF_DM10_up : 1.0);
-	  theSmallTree.m_trigSF_DM11_up		= (isMC ? trigSF_DM11_up : 1.0);
-	  theSmallTree.m_trigSF_ele_down	= (isMC ? trigSF_ele_down : 1.0);
-	  theSmallTree.m_trigSF_mu_down		= (isMC ? trigSF_mu_down : 1.0);
-	  theSmallTree.m_trigSF_DM0_down	= (isMC ? trigSF_DM0_down : 1.0);
-	  theSmallTree.m_trigSF_DM1_down	= (isMC ? trigSF_DM1_down : 1.0);
-	  theSmallTree.m_trigSF_DM10_down	= (isMC ? trigSF_DM10_down : 1.0);
-	  theSmallTree.m_trigSF_DM11_down	= (isMC ? trigSF_DM11_down : 1.0);
-	  theSmallTree.m_trigSF_cross		= (isMC ? trigSF_cross : 1.0);
-	  theSmallTree.m_trigSF_met_up		= (isMC ? trigSF_met_up : 1.0);
-	  theSmallTree.m_trigSF_met_down	= (isMC ? trigSF_met_down : 1.0);
-	  theSmallTree.m_trigSF_stau_up		= (isMC ? trigSF_stau_up : 1.0);
-	  theSmallTree.m_trigSF_stau_down	= (isMC ? trigSF_stau_down : 1.0);
+	  theSmallTree.m_trigSF			  = isMC ? trigSF           : 1.0;
+	  theSmallTree.m_trigSF_ele_up	  = isMC ? trigSF_ele_up    : 1.0;
+	  theSmallTree.m_trigSF_mu_up	  = isMC ? trigSF_mu_up     : 1.0;
+	  theSmallTree.m_trigSF_DM0_up	  = isMC ? trigSF_DM0_up    : 1.0;
+	  theSmallTree.m_trigSF_DM1_up	  = isMC ? trigSF_DM1_up    : 1.0;
+	  theSmallTree.m_trigSF_DM10_up	  = isMC ? trigSF_DM10_up   : 1.0;
+	  theSmallTree.m_trigSF_DM11_up	  = isMC ? trigSF_DM11_up   : 1.0;
+	  theSmallTree.m_trigSF_ele_down  = isMC ? trigSF_ele_down  : 1.0;
+	  theSmallTree.m_trigSF_mu_down	  = isMC ? trigSF_mu_down   : 1.0;
+	  theSmallTree.m_trigSF_DM0_down  = isMC ? trigSF_DM0_down  : 1.0;
+	  theSmallTree.m_trigSF_DM1_down  = isMC ? trigSF_DM1_down  : 1.0;
+	  theSmallTree.m_trigSF_DM10_down = isMC ? trigSF_DM10_down : 1.0;
+	  theSmallTree.m_trigSF_DM11_down = isMC ? trigSF_DM11_down : 1.0;
+	  theSmallTree.m_trigSF_cross	  = isMC ? trigSF_cross     : 1.0;
+	  theSmallTree.m_trigSF_met_up	  = isMC ? trigSF_met_up    : 1.0;
+	  theSmallTree.m_trigSF_met_down  = isMC ? trigSF_met_down  : 1.0;
+	  theSmallTree.m_trigSF_stau_up	  = isMC ? trigSF_stau_up   : 1.0;
+	  theSmallTree.m_trigSF_stau_down = isMC ? trigSF_stau_down : 1.0;
 
 	  theSmallTree.m_totalWeight = (isMC? (59970./7.20811e+10) * theSmallTree.m_MC_weight * theSmallTree.m_PUReweight *
 									trigSF * theSmallTree.m_IdFakeSF_deep_2d: 1.0);


### PR DESCRIPTION
The trigger scale factors in the analysis "legacy" region (single + cross-lepton triggers) were being wrongly applied for events that belonged to the kinematic phase-space of only one of the two triggers (for instance, single-muon and cross-muon-tau):
- pT thresholds between the two regions were outdated
- eta thresholds were not being applied (the bug was introduced when updating the trigger strategy), which implied that events with eta>2.1 (and thus fired by a single-lepton trigger) were being corrected by the OR of two scale factors.

The bug was found due to a warning present in ```src/ScaleFactor.cc```, which was being thrown often since mutau events with pt<26 were trying to access single-muon SFs.

I took this chance to remove some variables that were not being used, and to create a class that encapsulates the definition of trigger regions. The latter avoids the repetition of threshold pT and Eta values in multiple places.