### PR TITLE
Fix eta and pT lepton cuts.

### DIFF
--- a/interface/OfflineProducerHelper.h
+++ b/interface/OfflineProducerHelper.h
@@ -143,7 +143,7 @@ public:
   static bool pairSort (const tauPair_t& pA, const tauPair_t& pB);
   static bool pairSortRawIso (const tauPair_t& pA, const tauPair_t& pB);
   float DeltaRDau(bigTree* tree, int dau1idx, int dau2idx);
-
+  const float getEtaCut(string);
 
   // --------------------------------
   // gen related functions
@@ -158,7 +158,7 @@ public:
 private:
   std::vector<TString> triggerlist;
   std::vector<TString> tauidlist;
-  float eleEtaMax=2.5, muEtaMax=2.4, tauEtaMax=2.3;
+  const float eleEtaMax=2.5, muEtaMax=2.4, tauEtaMax=2.3;
 };
 
 #endif

--- a/src/OfflineProducerHelper.cc
+++ b/src/OfflineProducerHelper.cc
@@ -209,20 +209,20 @@ bool OfflineProducerHelper::pairPassBaseline (bigTree* tree, int iPair, TString 
 
   if (pairType == EMu)
   {
-    leg1 = eleBaseline (tree, dau1index, 13., eleEtaMax, 0.15, EMVAMedium, whatApply, debug);
-    leg2 = muBaseline  (tree, dau2index, 13., muEtaMax, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
+    leg1 = eleBaseline (tree, dau1index, 10., eleEtaMax, 0.15, EMVAMedium, whatApply, debug);
+    leg2 = muBaseline  (tree, dau2index, 15., muEtaMax, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
   }
 
   if (pairType == EE)
   {
-    leg1 = eleBaseline (tree, dau1index, 25., eleEtaMax, 0.15, EMVAMedium, whatApply, debug);
-    leg2 = eleBaseline (tree, dau2index, 25., eleEtaMax, 0.15, EMVAMedium, whatApply, debug);
+    leg1 = eleBaseline (tree, dau1index, 10., eleEtaMax, 0.15, EMVAMedium, whatApply, debug);
+    leg2 = eleBaseline (tree, dau2index, 10., eleEtaMax, 0.15, EMVAMedium, whatApply, debug);
   }
 
   if (pairType == MuMu)
   {
-    leg1 = muBaseline (tree, dau1index, 10., muEtaMax, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
-    leg2 = muBaseline (tree, dau2index, 10., muEtaMax, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
+    leg1 = muBaseline (tree, dau1index, 15., muEtaMax, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
+    leg2 = muBaseline (tree, dau2index, 15., muEtaMax, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
   }
 
   bool result = (leg1 && leg2);
@@ -239,6 +239,20 @@ bool OfflineProducerHelper::pairPassBaseline (bigTree* tree, int iPair, TString 
   result = (result && drMin);
 
   return result;
+}
+
+const float getEtaCut(string lepton)
+{
+  if (lepton == "tau")
+	return tauEtaMax;
+  else if (lepton == "mu")
+	return muEtaMax;
+  else if (lepton == "ele")
+	return eleEtaMax;
+  else {
+	std::cout << "[OfflineProducerHelper::getEtaCut] ERROR: Wrong lepton type." << std::endl;
+	std::exit(1);
+  }
 }
 
 bool

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -899,7 +899,8 @@ int main (int argc, char** argv)
 		}
 	}
 
-  const float eleEtaMax=2.5, muEtaMax=2.4;
+  const float eleEtaMax = oph.getEtaCut("ele");
+  const float muEtaMax  = oph.getEtaCut("muon");
   
   // loop over events
   // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
@@ -1453,7 +1454,7 @@ int main (int argc, char** argv)
 			  bool passMu   = oph.muBaseline (&theBigTree, idau, 15., muEtaMax,
 											  0.15, OfflineProducerHelper::MuTight,
 											  0.15, OfflineProducerHelper::MuHighPt, string("All"), (DEBUG ? true : false));
-			  bool passMu10 = oph.muBaseline (&theBigTree, idau, 10., muEtaMax,
+			  bool passMu10 = oph.muBaseline (&theBigTree, idau, 15., muEtaMax,
 											  0.30, OfflineProducerHelper::MuTight,
 											  0.30, OfflineProducerHelper::MuHighPt, string("All"), (DEBUG ? true : false));
 


### PR DESCRIPTION
A comment from Valeria made me realize we were using muons with 10 < pT(muon) < 15GeV in the mumu channel. This is wrong given the absence of scale factors on this range. I've corrected it, taking the chance to ensure we specify lepton eta cuts only in one place (instead of two).
This bug might also explain, together with the HH-bTag bug fixed in #340, the weird distributions we saw in mumu.