### PR TITLE
Acceptance times efficiency event counting.

### DIFF
--- a/scripts/submit_skims.sh
+++ b/scripts/submit_skims.sh
@@ -459,7 +459,7 @@ for ds in ${DATA_LIST[@]}; do
 		else
 			[[ ${NO_LISTS} -eq 0 ]] && produce_list --kind Sig --sample ${sample} --outtxt ${REGEX_MAP[${sample}]}
 			echo ${sample}
-			run_skim -n 5 -i ${SIG_DIR} --sample ${REGEX_MAP[${sample}]} -x 1. -q short
+			run_skim -n 5 -i ${SIG_DIR} --sample ${REGEX_MAP[${sample}]} -x 1. -q short --ishhsignal
 		fi
 	done
 done


### PR DESCRIPTION
Support the counting of signal events passing channel and trigger conditions in order to plot channel-dependent acceptance x efficiency curves. 
The plotting will be done in a separate script stored [here](https://github.com/bfonta/inclusion/blob/main/tests/acceptanceTimesEfficiency.py). I did not store it under this repository since the CMSSW version we are using (```CMSSW_11_1_9```) prevents the usage of many modern python packages.

------------------

The plots below show the result for the four relevant channels in the full mass range:

![AccEff_MuTau](https://github.com/LLRCMS/KLUBAnalysis/assets/20703947/3ea3eaa9-24eb-4948-a11e-a105beba95ec)
![AccEff_ETau](https://github.com/LLRCMS/KLUBAnalysis/assets/20703947/68bbd49b-a502-4eee-908e-36312d31b504)
![AccEff_TauTau](https://github.com/LLRCMS/KLUBAnalysis/assets/20703947/49a25e57-6dc5-44a4-b2f8-c3ecc9abc62e)
alysis/assets/20703947/b541c07a-1f37-47e7-9b60-f06342b94262)
![AccEff_MuMu](https://github.com/LLRCMS/KLUBAnalysis/assets/20703947/289af1e1-ae14-4aba-a58b-6cd48c50a83a)

------------------

The plots below show the result for the four relevant channels in a restricted mass range, to enable an easier comparison with the [ATLAS non-resonant result](https://arxiv.org/abs/2209.10910) (page 13). Notice that etau and mutau were merged to reflect ATLAS' strategy.

![AccEff_LepTau_comp](https://github.com/LLRCMS/KLUBAnalysis/assets/20703947/b11e8f63-665b-4c6a-80da-0f11a7c0a8aa)
![AccEff_TauTau_comp](https://github.com/LLRCMS/KLUBAnalysis/assets/20703947/4e8f5c7d-24ec-4de0-8c4a-c5038d9085d6)
![AccEff_MuMu_comp](https://github.com/LLRCMS/KLUBAnalysis/assets/20703947/1e5fa966-013d-4688-9826-c5252b7cc660)

