### PR TITLE
Fix wrong deallocation.

### DIFF
--- a/interface/bTagSF.h
+++ b/interface/bTagSF.h
@@ -36,7 +36,7 @@ private:
   BTagCalibrationReader m_readers [m_nWP+1]; // [loose, medium, tight, reshaping]
 
   // related to b tag efficiency
-  TFile* m_fileEff;
+  TFile* m_fileEff = nullptr;
   TH1F* m_hEff [m_nWP][3][4]; // [0: loose, 1: medium, 2: tight] [0: b, 1: c 2: udsg] [0: MuTau, 1: EleTau, :2: TauTau, 3: ALL]
 
   double _WPtag[m_nWP]; // loose, medium, tight WP

--- a/src/bTagSF.cc
+++ b/src/bTagSF.cc
@@ -75,7 +75,9 @@ void bTagSF::m_initialize(std::string SFfilename, std::string effFileName, std::
 
 bTagSF::~bTagSF()
 {
-  if (m_fileEff) delete m_fileEff;
+  if (m_isMC and m_fileEff) {
+	delete m_fileEff;
+  }
 }
 
 void bTagSF::SetWPset(std::string WPset)


### PR DESCRIPTION
This PR addresses the error message that was being observed for data samples in 2016 and 2017. I currently have no way to test what I say in the following fixes the error, but it is an educated guess.

When processing data the destructor of the ```bTagSF``` class tries to delete a pointer that never had memory allocated with new (since the allocation is done by only for MC samples). The pointer is not initialized, and so its state is not well defined. My guess is that the check before the delete statement can thus fail, since an uninitialized pointer is not enforced to point to ```nullptr``` (this might be compiler specific, for instance).

The above explains why the error happens only for data and why it is observed only for some data periods.

Let me know if the fix works for you. Since the crash happens after the files have been written (during cleanup), I think the data skims we already produced are good.