### PR TITLE
Fix 2016 paths + TF1 range bugfix.

### DIFF
--- a/scripts/submit_skims.sh
+++ b/scripts/submit_skims.sh
@@ -285,7 +285,11 @@ LIST_SCRIPT="scripts/makeListOnStorage.py"
 LIST_DIR="root://eos.grif.fr//eos/grif/cms/llr/store/user/${DATA_USER}/"
 
 EXEC_FILE="${EXEC_FILE}/skimNtuple_HHbtag.exe"
-LIST_DIR=${LIST_DIR}"HHNtuples_res/"${DATA_PERIOD}"/"
+if [ ${DATA_PERIOD} == "UL16" ] || [ ${DATA_PERIOD} == "UL16APV" ]; then
+	LIST_DIR=${LIST_DIR}"HHNtuples_res/UL16/"
+else
+	LIST_DIR=${LIST_DIR}"HHNtuples_res/"${DATA_PERIOD}"/"
+fi
 
 ### Check if the voms command was run
 eval `scram unsetenv -sh` # unset CMSSW environment

--- a/src/ScaleFactorMET.cc
+++ b/src/ScaleFactorMET.cc
@@ -27,8 +27,8 @@ ScaleFactorMET::ScaleFactorMET(std::string period): mPeriod(period)
   funcMC   = fileIn->Get<TF1>("SigmoidFuncMC");
 
   // sanity check
-  assert(funcSF->GetMinimumX() == mRange.at(mPeriod).first);
-  assert(funcSF->GetMaximumX() == mRange.at(mPeriod).second);
+  assert(funcSF->GetXmin() == mRange.at(mPeriod).first);
+  assert(funcSF->GetXmax() == mRange.at(mPeriod).second);
 }
 
 ScaleFactorMET::~ScaleFactorMET() {


### PR DESCRIPTION
Besides fixing the paths for 2016 big ntuples, this PR fixes a tricky bug related to the function checking the TF1 ranges. It should be ```TF1::GetXmin/max()``` instead of  ```TF1::GetMinimum/MinimumX()```. The latter returns the x value for which the function is minimal/maximal. So far the two functions returned the same result because the SFs TF1 was monotonically increasing. In 2016 this is no longer the case, as for larger MET values the function is essentially constant, but exhibits a maximum for a value different than its maximum x range.