### PR TITLE
16 & 16APV skim cfg with new "home" parameter

### DIFF
--- a/config/skim_UL16.cfg
+++ b/config/skim_UL16.cfg
@@ -72,7 +72,7 @@ SingleTau   = HLT_VLooseIsoPFTau120_Trk50_eta2p1_v, HLT_VLooseIsoPFTau140_Trk50_
 
 
 [bTagScaleFactors]
-SFFileDeepFlavor  = KLUBAnalysis/weights/bTagWeights_UL/UL16preVFP/merged_deepJet.legacyFormat.csv
+SFFileDeepFlavor  = KLUBAnalysis/weights/bTagWeights_UL/UL16postVFP/merged_deepJet.legacyFormat.csv
 effFileDeepFlavor = KLUBAnalysis/weights/bTagWeights/bTagEfficiencies_DeepFlavor_Legacy2016_1June2020.root
 
 [PUjetIDScaleFactors]

--- a/config/skim_UL16APV.cfg
+++ b/config/skim_UL16APV.cfg
@@ -72,7 +72,7 @@ SingleTau   = HLT_VLooseIsoPFTau120_Trk50_eta2p1_v, HLT_VLooseIsoPFTau140_Trk50_
 
 
 [bTagScaleFactors]
-SFFileDeepFlavor  = KLUBAnalysis/weights/bTagWeights_UL/UL16postVFP/merged_deepJet.legacyFormat.csv
+SFFileDeepFlavor  = KLUBAnalysis/weights/bTagWeights_UL/UL16preVFP/merged_deepJet.legacyFormat.csv
 effFileDeepFlavor = KLUBAnalysis/weights/bTagWeights/bTagEfficiencies_DeepFlavor_Legacy2016_1June2020.root
 
 [PUjetIDScaleFactors]

--- a/config/skim_UL16APV.cfg
+++ b/config/skim_UL16APV.cfg
@@ -3,7 +3,7 @@
 onlyFinalChannels = true
 
 [parameters]
-home = /grid_mnt/vol_home/llr/cms/alves/CMSSW_11_1_9/src/
+home = /grid_mnt/vol_home/llr/cms/portales/hhbbtautau/KLUB_UL_20230830/CMSSW_11_1_9/src/
 # for 2016, bits are inverted for the loose wp, https://twiki.cern.ch/twiki/bin/view/CMS/PileupJetIDUL#Recommendations_for_2016_UL_data
 PUjetIDWP           = 0 # 2:tight - 1:medium - 0:loose
 PFjetIDWP           = 1 # 0:don't pass - 1:tight - 2:tightLeptonVeto
@@ -72,7 +72,7 @@ SingleTau   = HLT_VLooseIsoPFTau120_Trk50_eta2p1_v, HLT_VLooseIsoPFTau140_Trk50_
 
 
 [bTagScaleFactors]
-SFFileDeepFlavor  = KLUBAnalysis/weights/bTagWeights_UL/UL16preVFP/merged_deepJet.legacyFormat.csv
+SFFileDeepFlavor  = KLUBAnalysis/weights/bTagWeights_UL/UL16postVFP/merged_deepJet.legacyFormat.csv
 effFileDeepFlavor = KLUBAnalysis/weights/bTagWeights/bTagEfficiencies_DeepFlavor_Legacy2016_1June2020.root
 
 [PUjetIDScaleFactors]

--- a/scripts/submit_skims.sh
+++ b/scripts/submit_skims.sh
@@ -100,10 +100,10 @@ elif [ ${DATA_PERIOD} == "UL17" ]; then
 	YEAR="2017"
 elif [ ${DATA_PERIOD} == "UL16" ]; then
 	PU_DIR="weights/PUreweight/UL_Run2_PU_SF/2016/PU_UL2016_SF.txt"
-	YEAR="2016preVFP"
+	YEAR="2016postVFP"
 elif [ ${DATA_PERIOD} == "UL16APV" ]; then
 	PU_DIR="weights/PUreweight/UL_Run2_PU_SF/2016APV/PU_UL2016APV_SF.txt"
-	YEAR="2016postVFP"
+	YEAR="2016preVFP"
 fi
 
 AYEAR=${YEAR:0:4}


### PR DESCRIPTION
- Add UL16APV skimming configuration
- **Bugfix**: we were mixing UL16 with UL16APV. To be clear, the correct mapping is the following:
  - preVFP -> UL16APV
  - postVFP -> UL16