### PR TITLE
Remove MET branch without applied threshold.

### DIFF
--- a/interface/smallTree_HHbtag.h
+++ b/interface/smallTree_HHbtag.h
@@ -162,7 +162,6 @@ struct smallTree
 
       m_isLeptrigger = 0;
       m_isMETtrigger = 0;
-	  m_isMETtriggerNoThresh = 0;
       m_isSingleTautrigger = 0;
 
       m_genDecMode1 = -1;
@@ -1111,7 +1110,6 @@ struct smallTree
 
       m_smallT->Branch ("isLeptrigger", &m_isLeptrigger, "isLeptrigger/I") ;
       m_smallT->Branch ("isMETtrigger", &m_isMETtrigger, "isMETtrigger/I") ;
-	  m_smallT->Branch ("isMETtriggerNoThresh", &m_isMETtriggerNoThresh, "isMETtriggerNoThresh/I") ;
       m_smallT->Branch ("isSingleTautrigger", &m_isSingleTautrigger, "isSingleTautrigger/I") ;
 
       m_smallT->Branch("genDecMode1", &m_genDecMode1, "genDecMode1/I");
@@ -2042,7 +2040,6 @@ struct smallTree
 
   Int_t m_isLeptrigger;
   Int_t m_isMETtrigger;
-  Int_t m_isMETtriggerNoThresh;
   Int_t m_isSingleTautrigger;
 
   Int_t m_genDecMode1 ;

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -549,6 +549,7 @@ int main (int argc, char** argv)
   }
   bTagSF bTagSFHelper(bTag_SFFile, bTag_effFile, "", wpyear, wpset, isMC);
 
+
   // ------------------------------
   std::string PUjetID_SF_directory = home + gConfigParser->readStringOption("PUjetIDScaleFactors::files");
   cout << "** INFO: PU jet ID SF directory: " << PUjetID_SF_directory << std::endl;
@@ -1954,7 +1955,7 @@ int main (int argc, char** argv)
 	  bool passTrg = false;
 
 	  // NEW TRIGGERS
-	  bool passMETTrg = false, passMETTrgNoThresh=false;
+	  bool passMETTrg = false;
 	  bool passSingleTau = false;
 
 	  // Twiki (UL SFs not available as of September 2023)
@@ -1984,8 +1985,7 @@ int main (int argc, char** argv)
 										tlv_firstLepton.Pt(), tlv_firstLepton.Eta(),
 										tlv_secondLepton.Pt(), tlv_secondLepton.Eta()) ; // check only lepton triggers
 
-		  passMETTrg         = trigReader.checkMET(triggerbit, &pass_triggerbit, vMETnoMu.Mod(), met_thresh);
-		  passMETTrgNoThresh = trigReader.checkMET(triggerbit, &pass_triggerbit, vMETnoMu.Mod(), 0.);
+		  passMETTrg = trigReader.checkMET(triggerbit, &pass_triggerbit, vMETnoMu.Mod(), met_thresh);
 
 		  passSingleTau = trigReader.checkSingleTau(triggerbit, matchFlag1, matchFlag2, trgNotOverlapFlag,
 													goodTriggerType1, goodTriggerType2,
@@ -2031,9 +2031,9 @@ int main (int argc, char** argv)
 														fabs(tlv_secondLepton.Eta()),
 														eleEtaMax, muEtaMax, tau_thresh);
 
-		  bool legacyAccept    = passTrg            and trgRegions["legacy"];
-		  bool metAccept       = passMETTrgNoThresh and trgRegions["met"]; 
-		  bool singletauAccept = passSingleTau      and trgRegions["tau"];
+		  bool legacyAccept    = passTrg       and trgRegions["legacy"];
+		  bool metAccept       = passMETTrg    and trgRegions["met"]; 
+		  bool singletauAccept = passSingleTau and trgRegions["tau"];
 		  if (!isMC) {
 			legacyAccept    = legacyAccept    and !isMETDataset;
 			metAccept       = metAccept       and isMETDataset;
@@ -2081,7 +2081,6 @@ int main (int argc, char** argv)
 
 		  theSmallTree.m_isLeptrigger = passTrg;
 		  theSmallTree.m_isMETtrigger = passMETTrg;
-		  theSmallTree.m_isMETtriggerNoThresh = passMETTrgNoThresh;
 		  theSmallTree.m_isSingleTautrigger = passSingleTau;
 		} // end if applyTriggers
 


### PR DESCRIPTION
Given that the MET SFs are derived in a specific range, starting from 150GeV, any event having MET-no\mu below 150GeV will be corrected by an incorrect scale factor, which is current taken from the SF curve at 150GeV. To avoid wrongly using those events, I've simply removed the branch that was making the mistake possible. Now it is guaranteed that all selected events have a MET-no\mu above 150GeV. The branch had been introduce for debugging the MET SFs, and it is now not needed anymore.

This change *does* affect the skimmed files, but not the histograms, plots and limits, given that we are not using events with MET-no\mu below 150GeV. A re-skimming is thus not needed.