### PR TITLE
Remove formula check for speed-up.

### DIFF
--- a/src/BTagCalibrationStandalone.cc
+++ b/src/BTagCalibrationStandalone.cc
@@ -64,13 +64,6 @@ BTagEntry::BTagEntry(const std::string &csvLine)
 
   // make formula
   formula = vec[10];
-  TF1 f1("", formula.c_str());  // compile formula to check validity
-  if (f1.IsZombie()) {
-    std::cerr << "ERROR in BTagCalibration: "
-	      << "Invalid csv line; formula does not compile: "
-	      << csvLine;
-    throw std::exception();
-  }
 
   // make parameters
   unsigned op = stoi(vec[0]);


### PR DESCRIPTION
Remove very expensive ```TF1``` call to speed-up the reading of bTag SFs. The code was responsible for verifying the correctness of each formula. The latter have been kept unchanged for years, and we are quite confident they are correctly defined.