### PR TITLE
Require Medium WP only for vetoed muons.

### DIFF
--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -3749,14 +3749,12 @@ int main (int argc, char** argv)
 			continue;
 		  else if (theBigTree.particleType->at (iLep) == 0) // muons
 			{
-			  // Fra Mar2020: for muon, Tight does not imply Medium so we check both
-			  bool passMed = oph.muBaseline (&theBigTree, iLep, 10., muEtaMax,
-											 0.3, OfflineProducerHelper::MuMedium,
-											 0.3, OfflineProducerHelper::MuHighPt);
-			  bool passTig = oph.muBaseline (&theBigTree, iLep, 10., muEtaMax,
-											 0.3, OfflineProducerHelper::MuTight,
-											 0.3, OfflineProducerHelper::MuHighPt);
-			  if (!passMed && !passTig) continue; // if it passes one of the two --> the "if" is false and the lepton is saved as an extra lepton
+			  // For muon, Tight does not imply Medium. However, the difference is minimal.
+			  // https://cms-talk.web.cern.ch/t/medium-vs-tight-muon-identification/42605/2
+			  bool passMedium = oph.muBaseline (&theBigTree, iLep, 10., muEtaMax,
+												0.3, OfflineProducerHelper::MuMedium,
+												0.3, OfflineProducerHelper::MuHighPt);
+			  if (!passMedium) continue; // if it passes medium --> the "if" is false and the lepton is saved as an extra lepton
 			}
 		  else if (theBigTree.particleType->at (iLep) == 1) // electrons
 			{


### PR DESCRIPTION
We are currently requiring the logical OR between the Medium and Tight muon identificaton WPs for the third lepton veto. This is a feature inherited from the non-resonant analysis, which used Legacy datasets.
According to [this thread](https://cms-talk.web.cern.ch/t/medium-vs-tight-muon-identification/42605/2), requiring only the Medium WP is enough. Note that we are not applying the SFs mentioned in the thread (SFs to correct for hypothetical differences between data and MC that would impact the veto), as the effect is thought to be completely negligible.