### PR TITLE
Adjust muon ID WPs.

### DIFF
--- a/interface/OfflineProducerHelper.h
+++ b/interface/OfflineProducerHelper.h
@@ -119,7 +119,7 @@ public:
   bool pairPassBaseline (bigTree* tree, int iPair, TString whatApply = "All", bool debug=false);
   bool eleBaseline (bigTree* tree, int iDau, float ptMin, float relIso,  int MVAIDflag = 0, TString whatApply = "All", bool debug=false); // return true if leptons passes the baseline selections
   bool eleBaseline (bigTree* tree, int iDau, float ptMin, float etaMax, float relIso,  int MVAIDflag = 0, TString whatApply = "All", bool debug=false); // version with eta cut
-  bool muBaseline (bigTree* tree, int iDau, float ptMin, float etaMax, float relIsopf, int muIDWPpf, float relIsotk, int muIDWPtk, TString whatApply = "All", bool debug=false);
+  bool muBaseline (bigTree* tree, int iDau, float ptMin, float etaMax, float relIsopf, int muIDWPpf, TString whatApply = "All", bool debug=false);
   bool tauBaseline (bigTree* tree, int iDau, float ptMin, float etaMax, int againstEleWP, int againstMuWP, float isoRaw3Hits, TString whatApply = "All",bool debug=false);
   bool tightEleMVAID (float BDT, float fSCeta); // compute tight ele MVA id WP, but isBDT in ntuples has been fixed --> this will be soon deprecated
 

--- a/src/OfflineProducerHelper.cc
+++ b/src/OfflineProducerHelper.cc
@@ -188,7 +188,7 @@ bool OfflineProducerHelper::pairPassBaseline (bigTree* tree, int iPair, TString 
   if (pairType == MuHad)
   {
     float tauIso = whatApply.Contains("TauRlxIzo") ? 7.0 : 3.0 ;
-    leg1 = muBaseline  (tree, dau1index, 15., muEtaMax, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
+    leg1 = muBaseline  (tree, dau1index, 15., muEtaMax, 0.15, MuTight, whatApply, debug);
     leg2 = tauBaseline (tree, dau2index, 20., tauEtaMax, aeleVVLoose, amuTight, tauIso, whatApply, debug);
   }
 
@@ -210,7 +210,7 @@ bool OfflineProducerHelper::pairPassBaseline (bigTree* tree, int iPair, TString 
   if (pairType == EMu)
   {
     leg1 = eleBaseline (tree, dau1index, 10., eleEtaMax, 0.15, EMVAMedium, whatApply, debug);
-    leg2 = muBaseline  (tree, dau2index, 15., muEtaMax, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
+    leg2 = muBaseline  (tree, dau2index, 15., muEtaMax, 0.15, MuTight, whatApply, debug);
   }
 
   if (pairType == EE)
@@ -221,8 +221,8 @@ bool OfflineProducerHelper::pairPassBaseline (bigTree* tree, int iPair, TString 
 
   if (pairType == MuMu)
   {
-    leg1 = muBaseline (tree, dau1index, 15., muEtaMax, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
-    leg2 = muBaseline (tree, dau2index, 15., muEtaMax, 0.15, MuTight, 0.15, MuHighPt, whatApply, debug);
+    leg1 = muBaseline (tree, dau1index, 15., muEtaMax, 0.15, MuTight, whatApply, debug);
+    leg2 = muBaseline (tree, dau2index, 15., muEtaMax, 0.15, MuTight, whatApply, debug);
   }
 
   bool result = (leg1 && leg2);
@@ -332,7 +332,7 @@ OfflineProducerHelper::eleBaseline (bigTree* tree, int iDau,
 
 bool OfflineProducerHelper::muBaseline (
   bigTree* tree, int iDau, float ptMin,
-  float etaMax, float relIsopf, int muIDWPpf, float relIsotk, int muIDWPtk, TString whatApply, bool debug)
+  float etaMax, float relIsopf, int muIDWPpf, TString whatApply, bool debug)
 {
   float px = tree->daughters_px->at(iDau);
   float py = tree->daughters_py->at(iDau);
@@ -364,20 +364,17 @@ bool OfflineProducerHelper::muBaseline (
     if (whatApply.Contains("etaMax")) byp_etaS = false;
   }
 
-  if (muIDWPpf < 0 || muIDWPpf > 3 || muIDWPtk < 0 || muIDWPtk > 4)
+  if (muIDWPpf < 0 || muIDWPpf > 3)
   {
-	std::string mes = " ** OfflineProducerHelper::muBaseline: muIDWPpf=" + std::to_string(muIDWPpf) + " must be between 0 and 3 and muIDWPtk=" + std::to_string(muIDWPtk) + " must be between 0 and 4.";
+	std::string mes = " ** OfflineProducerHelper::muBaseline: muIDWPpf=" + std::to_string(muIDWPpf) + " must be between 0 and 3.";
 	throw std::invalid_argument(mes);
   }
 
   bool vertexS = (fabs(tree->dxy->at(iDau)) < 0.045 && fabs(tree->dz->at(iDau)) < 0.2) || byp_vertexS;
 
   bool idpfS = checkBit (discr, muIDWPpf) || byp_idS;
-  bool idtkS = checkBit (discr, muIDWPtk) || byp_idS;
   bool isopfS = (tree->combreliso->at(iDau) < relIsopf) || byp_isoS;
-  bool isotkS = (tree->tkRelIso->at(iDau) < relIsotk) || byp_isoS;
-  bool idS = (idpfS && isopfS) || (idtkS && isotkS);
-			  
+  bool idS = (idpfS && isopfS);
   bool ptS = (p4.Pt() > ptMin) || byp_ptS;
   bool etaS = (fabs(p4.Eta()) < etaMax) || byp_etaS;
 

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -1306,10 +1306,10 @@ int main (int argc, char** argv)
 			{
 			  bool passMu   = oph.muBaseline (&theBigTree, idau, 15., muEtaMax,
 											  0.15, OfflineProducerHelper::MuTight,
-											  0.15, OfflineProducerHelper::MuHighPt, string("All"), (DEBUG ? true : false));
+											  string("All"), (DEBUG ? true : false));
 			  bool passMu10 = oph.muBaseline (&theBigTree, idau, 15., muEtaMax,
 											  0.30, OfflineProducerHelper::MuTight,
-											  0.30, OfflineProducerHelper::MuHighPt, string("All"), (DEBUG ? true : false));
+											  string("All"), (DEBUG ? true : false));
 
 			  if (passMu) ++nmu;
 			  else if (passMu10) ++nmu10;
@@ -3752,9 +3752,13 @@ int main (int argc, char** argv)
 			  // For muon, Tight does not imply Medium. However, the difference is minimal.
 			  // https://cms-talk.web.cern.ch/t/medium-vs-tight-muon-identification/42605/2
 			  bool passMedium = oph.muBaseline (&theBigTree, iLep, 10., muEtaMax,
-												0.3, OfflineProducerHelper::MuMedium,
-												0.3, OfflineProducerHelper::MuHighPt);
-			  if (!passMedium) continue; // if it passes medium --> the "if" is false and the lepton is saved as an extra lepton
+												0.3, OfflineProducerHelper::MuMedium);
+			  bool passTight = oph.muBaseline (&theBigTree, iLep, 10., muEtaMax,
+											   0.3, OfflineProducerHelper::MuTight);
+			  if (!passMedium and !passTight) {
+				// if it passes one of the two: the "if" is false and the lepton is saved as an extra lepton
+				continue;
+			  }
 			}
 		  else if (theBigTree.particleType->at (iLep) == 1) // electrons
 			{


### PR DESCRIPTION
This PR takes care of two details related to muon ID WPs:
- revert #380, as it was understood that the answer to [this thread](https://cms-talk.web.cern.ch/t/medium-vs-tight-muon-identification/42605/2) did not take into account that I was talking about the veto ID cut, not the main analysis ID cut, and also that:
  - Medium does not imply Tight, so considering both recovers a small fraction of events
  - We do not apply any veto SFs, so the OR between Medium and Tight does not complicate the analysis
- drop highPt requirements everywhere, since the Muon POG conveners recommend using a single muon ID in our analysis
  - choosing Tight is the easiest approach, given that, in the code, all SFs (trigger and ID/Iso) already take Tight into account