### PR TITLE
Add ele reco SFs(+unc), Id/Iso SF unc and electron ecal gap veto

### DIFF
--- a/config/skim_UL16.cfg
+++ b/config/skim_UL16.cfg
@@ -28,7 +28,7 @@ PUReweighttarget    = 999
 # skipping the isolation
 #lepSelections       = Vertex-LepID-pTMin-etaMax-againstEle-againstMu
 #lepSelections       = Vertex-LepID-pTMin-etaMax
-lepSelections       = Vertex-LepID-pTMin-etaMax-againstEle-againstMu-Iso
+lepSelections       = Vertex-LepID-pTMin-etaMax-againstEle-againstMu-Iso-etaGapVeto
 # default selections
 # lepSelections       = All
 # invert isolation

--- a/config/skim_UL16.cfg
+++ b/config/skim_UL16.cfg
@@ -101,26 +101,3 @@ inputFile = KLUBAnalysis/weights/allHHnodeMap_5DdiffRew_2016.root
 histoName = allHHNodeMap
 coeffFileNLO = KLUBAnalysis/weights/coefficients_pm_pw_NLO_Ais_13TeV_V2.txt
 coeffFileLO = KLUBAnalysis/weights/coefficients_pm_pw_LO_Ais_13TeV_V2.txt
-
-[outPutter]
-nMaxEvts   = -1 # use -1 to analyze all events
-useTmpFile = false
-
-doMT2       = true
-doKinFit    = true
-doSVfit     = true
-doPropSVfit = false
-doDNN       = true
-doBDT       = false
-doMult      = true
-
-doNominal  = false
-doMES      = true
-doEES      = true
-doTES      = true
-doSplitJES = true
-doTotalJES = true
-
-kl       = 1
-year     = 2016
-analysis = 2     # 0:radion, 1:graviton, 2:nonres

--- a/config/skim_UL16APV.cfg
+++ b/config/skim_UL16APV.cfg
@@ -28,7 +28,7 @@ PUReweighttarget    = 999
 # skipping the isolation
 #lepSelections       = Vertex-LepID-pTMin-etaMax-againstEle-againstMu
 #lepSelections       = Vertex-LepID-pTMin-etaMax
-lepSelections       = Vertex-LepID-pTMin-etaMax-againstEle-againstMu-Iso
+lepSelections       = Vertex-LepID-pTMin-etaMax-againstEle-againstMu-Iso-etaGapVeto
 # default selections
 # lepSelections       = All
 # invert isolation

--- a/config/skim_UL16APV.cfg
+++ b/config/skim_UL16APV.cfg
@@ -101,26 +101,3 @@ inputFile = KLUBAnalysis/weights/allHHnodeMap_5DdiffRew_2016.root
 histoName = allHHNodeMap
 coeffFileNLO = KLUBAnalysis/weights/coefficients_pm_pw_NLO_Ais_13TeV_V2.txt
 coeffFileLO = KLUBAnalysis/weights/coefficients_pm_pw_LO_Ais_13TeV_V2.txt
-
-[outPutter]
-nMaxEvts   = -1 # use -1 to analyze all events
-useTmpFile = false
-
-doMT2       = true
-doKinFit    = true
-doSVfit     = true
-doPropSVfit = false
-doDNN       = true
-doBDT       = false
-doMult      = true
-
-doNominal  = false
-doMES      = true
-doEES      = true
-doTES      = true
-doSplitJES = true
-doTotalJES = true
-
-kl       = 1
-year     = 2016
-analysis = 2     # 0:radion, 1:graviton, 2:nonres

--- a/config/skim_UL17.cfg
+++ b/config/skim_UL17.cfg
@@ -97,24 +97,3 @@ inputFile    = KLUBAnalysis/weights/allHHnodeMap_5DdiffRew_2017.root
 histoName    = allHHNodeMap
 coeffFileNLO = KLUBAnalysis/weights/coefficients_pm_pw_NLO_Ais_13TeV_V2.txt
 coeffFileLO  = KLUBAnalysis/weights/coefficients_pm_pw_LO_Ais_13TeV_V2.txt
-
-[outPutter]
-nMaxEvts    = -1  # use -1 to analyze all events
-kl          = 1
-year        = 2017
-analysis    = 2  # 0:radion, 1:graviton, 2:nonres
-useTmpFile  = false
-doMT2       = true
-doKinFit    = true
-doSVfit     = true
-doPropSVfit = false
-doDNN       = true
-doBDT       = false
-doMult      = true
-doVBFtrig   = false
-doNominal   = false
-doMES       = true
-doEES       = true
-doTES       = true
-doSplitJES  = true
-doTotalJES  = true

--- a/config/skim_UL17.cfg
+++ b/config/skim_UL17.cfg
@@ -27,7 +27,7 @@ PUReweighttarget = 999
 # skipping the isolation
 #lepSelections = Vertex-LepID-pTMin-etaMax-againstEle-againstMu
 #lepSelections = Vertex-LepID-pTMin-etaMax
-lepSelections = Vertex-LepID-pTMin-etaMax-againstEle-againstMu-Iso
+lepSelections = Vertex-LepID-pTMin-etaMax-againstEle-againstMu-Iso-etaGapVeto
 # default selections
 # lepSelections = All
 # invert isolation

--- a/config/skim_UL18.cfg
+++ b/config/skim_UL18.cfg
@@ -27,7 +27,7 @@ PUReweighttarget    = 999
 # skipping the isolation
 #lepSelections       = Vertex-LepID-pTMin-etaMax-againstEle-againstMu
 #lepSelections       = Vertex-LepID-pTMin-etaMax
-lepSelections       = Vertex-LepID-pTMin-etaMax-againstEle-againstMu-Iso
+lepSelections       = Vertex-LepID-pTMin-etaMax-againstEle-againstMu-Iso-etaGapVeto
 # default selections
 # lepSelections       = All
 # invert isolation

--- a/config/skim_UL18.cfg
+++ b/config/skim_UL18.cfg
@@ -97,24 +97,3 @@ inputFile = KLUBAnalysis/weights/allHHnodeMap_5DdiffRew_2018.root
 histoName = allHHNodeMap
 coeffFileNLO = KLUBAnalysis/weights/coefficients_pm_pw_NLO_Ais_13TeV_V2.txt
 coeffFileLO = KLUBAnalysis/weights/coefficients_pm_pw_LO_Ais_13TeV_V2.txt
-
-[outPutter]
-nMaxEvts	= -1 # use -1 to analyze all events
-kl			= 1
-year		= 2018
-analysis	= 2     # 0:radion, 1:graviton, 2:nonres
-useTmpFile	= false
-doMT2       = true
-doKinFit    = true
-doSVfit     = true
-doPropSVfit = false
-doDNN       = true
-doBDT       = false
-doMult      = true
-doVBFtrig	= false
-doNominal	= false
-doMES		= true
-doEES		= true
-doTES		= true
-doSplitJES	= true
-doTotalJES	= true

--- a/interface/ScaleFactor.h
+++ b/interface/ScaleFactor.h
@@ -42,6 +42,8 @@ public:
   double get_EfficiencyMCError(double, double, int);
   double get_ScaleFactorError(double, double, double, double); // effData, effMC, errData, errMC
   double get_ScaleFactorError(double, double, int);
+  double get_direct_ScaleFactorError(double, double, int);
+
 
 };
 

--- a/interface/smallTree_HHbtag.h
+++ b/interface/smallTree_HHbtag.h
@@ -186,6 +186,14 @@ struct smallTree
       m_idFakeSF_etauFR_barrel_down       = -99.;
       m_idFakeSF_etauFR_endcap_down       = -99.;
 
+      m_idFakeSF_muID_up                  = -99.;
+      m_idFakeSF_muID_down                = -99.;
+      m_idFakeSF_muIso_up                 = -99.;
+      m_idFakeSF_muIso_down               = -99.;
+
+      m_idFakeSF_eleID_up                 = -99.;
+      m_idFakeSF_eleID_down               = -99.;
+
       m_jetFakeSF = 1.;
       m_lheNOutPartons = -1;
       m_lheNOutB = -1;
@@ -1181,6 +1189,13 @@ struct smallTree
       m_smallT->Branch ("idFakeSF_etauFR_barrel_down"      , &m_idFakeSF_etauFR_barrel_down      , "idFakeSF_etauFR_barrel_down/F");
       m_smallT->Branch ("idFakeSF_etauFR_endcap_down"      , &m_idFakeSF_etauFR_endcap_down      , "idFakeSF_etauFR_endcap_down/F");
 
+      m_smallT->Branch ("idFakeSF_muID_up   ", &m_idFakeSF_muID_up   , "idFakeSF_muID_up/F");
+      m_smallT->Branch ("idFakeSF_muID_down ", &m_idFakeSF_muID_down , "idFakeSF_muID_down/F");
+      m_smallT->Branch ("idFakeSF_muIso_up  ", &m_idFakeSF_muIso_up  , "idFakeSF_muIso_up/F");
+      m_smallT->Branch ("idFakeSF_muIso_down", &m_idFakeSF_muIso_down, "idFakeSF_muIso_down/F");
+      m_smallT->Branch ("idFakeSF_eleID_up  ", &m_idFakeSF_eleID_up  , "idFakeSF_eleID_up/F");
+      m_smallT->Branch ("idFakeSF_eleID_down", &m_idFakeSF_eleID_down, "idFakeSF_eleID_down/F");
+
       m_smallT->Branch ("lheNOutPartons", &m_lheNOutPartons, "lheNOutPartons/I");
       m_smallT->Branch ("lheNOutB", &m_lheNOutB, "lheNOutB/I");
       m_smallT->Branch ("EventNumber", &m_EventNumber, "EventNumber/l") ;
@@ -2134,6 +2149,14 @@ struct smallTree
   Float_t m_idFakeSF_etauFR_endcap_up        ;
   Float_t m_idFakeSF_etauFR_barrel_down      ;
   Float_t m_idFakeSF_etauFR_endcap_down      ;
+
+  Float_t m_idFakeSF_muID_up;
+  Float_t m_idFakeSF_muID_down;
+  Float_t m_idFakeSF_muIso_up;
+  Float_t m_idFakeSF_muIso_down;
+
+  Float_t m_idFakeSF_eleID_up;
+  Float_t m_idFakeSF_eleID_down;
 
   Int_t m_lheNOutPartons ;
   Int_t m_lheNOutB ;

--- a/interface/smallTree_HHbtag.h
+++ b/interface/smallTree_HHbtag.h
@@ -111,83 +111,83 @@ struct smallTree
       m_trigSF_tau_DM1_down = -1.;
       m_trigSF_tau_DM10_down = -1.;
       m_trigSF_tau_DM11_down = -1.;
-	  m_trigSF_met_up = -1.;
-	  m_trigSF_met_down = -1.;
-	  m_trigSF_stau_up = -1.;
-	  m_trigSF_stau_down = -1.;
+      m_trigSF_met_up = -1.;
+      m_trigSF_met_down = -1.;
+      m_trigSF_stau_up = -1.;
+      m_trigSF_stau_down = -1.;
 
-	  m_IdSF_deep_2d			= -99.;
-	  m_IdSF_leg1_deep_vsJet_2d = -99.;
-	  m_IdSF_leg2_deep_vsJet_2d = -99.;
-	  m_IdFakeSF_deep_2d		= -99.;
-      m_FakeRateSF_deep			= -99.;
+      m_IdSF_deep_2d = -99.;
+      m_IdSF_leg1_deep_vsJet_2d = -99.;
+      m_IdSF_leg2_deep_vsJet_2d = -99.;
+      m_dauSFs = -99.;
+      m_FakeRateSF_deep = -99.;
 
-	  m_idFakeSF_tauid_2d_stat0_DM0_up              = -99.;
-	  m_idFakeSF_tauid_2d_stat0_DM0_down			= -99.;
-	  m_idFakeSF_tauid_2d_stat1_DM0_up				= -99.;
-	  m_idFakeSF_tauid_2d_stat1_DM0_down			= -99.;
-	  m_idFakeSF_tauid_2d_systuncorrdmeras_DM0_up	= -99.;
-	  m_idFakeSF_tauid_2d_systuncorrdmeras_DM0_down = -99.;
+      m_dauSFs_tauid_2d_stat0_DM0_up = -99.;
+      m_dauSFs_tauid_2d_stat0_DM0_down = -99.;
+      m_dauSFs_tauid_2d_stat1_DM0_up = -99.;
+      m_dauSFs_tauid_2d_stat1_DM0_down = -99.;
+      m_dauSFs_tauid_2d_systuncorrdmeras_DM0_up = -99.;
+      m_dauSFs_tauid_2d_systuncorrdmeras_DM0_down = -99.;
 
-	  m_idFakeSF_tauid_2d_stat0_DM1_up              = -99.;
-	  m_idFakeSF_tauid_2d_stat0_DM1_down			= -99.;
-	  m_idFakeSF_tauid_2d_stat1_DM1_up				= -99.;
-	  m_idFakeSF_tauid_2d_stat1_DM1_down			= -99.;
-	  m_idFakeSF_tauid_2d_systuncorrdmeras_DM1_up	= -99.;
-	  m_idFakeSF_tauid_2d_systuncorrdmeras_DM1_down = -99.;
+      m_dauSFs_tauid_2d_stat0_DM1_up = -99.;
+      m_dauSFs_tauid_2d_stat0_DM1_down = -99.;
+      m_dauSFs_tauid_2d_stat1_DM1_up = -99.;
+      m_dauSFs_tauid_2d_stat1_DM1_down = -99.;
+      m_dauSFs_tauid_2d_systuncorrdmeras_DM1_up = -99.;
+      m_dauSFs_tauid_2d_systuncorrdmeras_DM1_down = -99.;
 
-	  m_idFakeSF_tauid_2d_stat0_DM10_up              = -99.;
-	  m_idFakeSF_tauid_2d_stat0_DM10_down			 = -99.;
-	  m_idFakeSF_tauid_2d_stat1_DM10_up				 = -99.;
-	  m_idFakeSF_tauid_2d_stat1_DM10_down			 = -99.;
-	  m_idFakeSF_tauid_2d_systuncorrdmeras_DM10_up	 = -99.;
-	  m_idFakeSF_tauid_2d_systuncorrdmeras_DM10_down = -99.;
+      m_dauSFs_tauid_2d_stat0_DM10_up = -99.;
+      m_dauSFs_tauid_2d_stat0_DM10_down = -99.;
+      m_dauSFs_tauid_2d_stat1_DM10_up = -99.;
+      m_dauSFs_tauid_2d_stat1_DM10_down = -99.;
+      m_dauSFs_tauid_2d_systuncorrdmeras_DM10_up = -99.;
+      m_dauSFs_tauid_2d_systuncorrdmeras_DM10_down = -99.;
 
-	  m_idFakeSF_tauid_2d_stat0_DM11_up              = -99.;
-	  m_idFakeSF_tauid_2d_stat0_DM11_down			 = -99.;
-	  m_idFakeSF_tauid_2d_stat1_DM11_up				 = -99.;
-	  m_idFakeSF_tauid_2d_stat1_DM11_down			 = -99.;
-	  m_idFakeSF_tauid_2d_systuncorrdmeras_DM11_up	 = -99.;
-	  m_idFakeSF_tauid_2d_systuncorrdmeras_DM11_down = -99.;
+      m_dauSFs_tauid_2d_stat0_DM11_up = -99.;
+      m_dauSFs_tauid_2d_stat0_DM11_down = -99.;
+      m_dauSFs_tauid_2d_stat1_DM11_up = -99.;
+      m_dauSFs_tauid_2d_stat1_DM11_down = -99.;
+      m_dauSFs_tauid_2d_systuncorrdmeras_DM11_up = -99.;
+      m_dauSFs_tauid_2d_systuncorrdmeras_DM11_down = -99.;
 
-	  m_idFakeSF_tauid_2d_systcorrdmeras_up         = -99.;
-	  m_idFakeSF_tauid_2d_systcorrdmeras_down       = -99.;
-	  m_idFakeSF_tauid_2d_systcorrdmuncorreras_up   = -99.;
-	  m_idFakeSF_tauid_2d_systcorrdmuncorreras_down = -99.;
-	  m_idFakeSF_tauid_2d_systcorrerasgt140_up		= -99.;
-	  m_idFakeSF_tauid_2d_systcorrerasgt140_down	= -99.;
-	  m_idFakeSF_tauid_2d_stat0gt140_up				= -99.;
-	  m_idFakeSF_tauid_2d_stat0gt140_down			= -99.;
-	  m_idFakeSF_tauid_2d_stat1gt140_up				= -99.;
-	  m_idFakeSF_tauid_2d_stat1gt140_down			= -99.;
-	  m_idFakeSF_tauid_2d_extrapgt140_up			= -99.;
-	  m_idFakeSF_tauid_2d_extrapgt140_down			= -99.;
-	  
-      m_idFakeSF_mutauFR_etaLt0p4_up      = -99.;
-      m_idFakeSF_mutauFR_eta0p4to0p8_up   = -99.;
-      m_idFakeSF_mutauFR_eta0p8to1p2_up   = -99.;
-      m_idFakeSF_mutauFR_eta1p2to1p7_up   = -99.;
-      m_idFakeSF_mutauFR_etaGt1p7_up      = -99.;
-      m_idFakeSF_mutauFR_etaLt0p4_down    = -99.;
-      m_idFakeSF_mutauFR_eta0p4to0p8_down = -99.;
-      m_idFakeSF_mutauFR_eta0p8to1p2_down = -99.;
-      m_idFakeSF_mutauFR_eta1p2to1p7_down = -99.;
-      m_idFakeSF_mutauFR_etaGt1p7_down    = -99.;
+      m_dauSFs_tauid_2d_systcorrdmeras_up = -99.;
+      m_dauSFs_tauid_2d_systcorrdmeras_down = -99.;
+      m_dauSFs_tauid_2d_systcorrdmuncorreras_up = -99.;
+      m_dauSFs_tauid_2d_systcorrdmuncorreras_down = -99.;
+      m_dauSFs_tauid_2d_systcorrerasgt140_up = -99.;
+      m_dauSFs_tauid_2d_systcorrerasgt140_down = -99.;
+      m_dauSFs_tauid_2d_stat0gt140_up = -99.;
+      m_dauSFs_tauid_2d_stat0gt140_down = -99.;
+      m_dauSFs_tauid_2d_stat1gt140_up = -99.;
+      m_dauSFs_tauid_2d_stat1gt140_down = -99.;
+      m_dauSFs_tauid_2d_extrapgt140_up = -99.;
+      m_dauSFs_tauid_2d_extrapgt140_down = -99.;
 
-      m_idFakeSF_etauFR_barrel_up         = -99.;
-      m_idFakeSF_etauFR_endcap_up         = -99.;
-      m_idFakeSF_etauFR_barrel_down       = -99.;
-      m_idFakeSF_etauFR_endcap_down       = -99.;
+      m_dauSFs_mutauFR_etaLt0p4_up = -99.;
+      m_dauSFs_mutauFR_eta0p4to0p8_up = -99.;
+      m_dauSFs_mutauFR_eta0p8to1p2_up = -99.;
+      m_dauSFs_mutauFR_eta1p2to1p7_up = -99.;
+      m_dauSFs_mutauFR_etaGt1p7_up = -99.;
+      m_dauSFs_mutauFR_etaLt0p4_down = -99.;
+      m_dauSFs_mutauFR_eta0p4to0p8_down = -99.;
+      m_dauSFs_mutauFR_eta0p8to1p2_down = -99.;
+      m_dauSFs_mutauFR_eta1p2to1p7_down = -99.;
+      m_dauSFs_mutauFR_etaGt1p7_down = -99.;
 
-      m_idFakeSF_muID_up                  = -99.;
-      m_idFakeSF_muID_down                = -99.;
-      m_idFakeSF_muIso_up                 = -99.;
-      m_idFakeSF_muIso_down               = -99.;
+      m_dauSFs_etauFR_barrel_up = -99.;
+      m_dauSFs_etauFR_endcap_up = -99.;
+      m_dauSFs_etauFR_barrel_down = -99.;
+      m_dauSFs_etauFR_endcap_down = -99.;
 
-      m_idFakeSF_eleID_up                 = -99.;
-      m_idFakeSF_eleID_down               = -99.;
-      m_idFakeSF_eleReco_up               = -99.;
-      m_idFakeSF_eleReco_down             = -99.;
+      m_dauSFs_muID_up = -99.;
+      m_dauSFs_muID_down = -99.;
+      m_dauSFs_muIso_up = -99.;
+      m_dauSFs_muIso_down = -99.;
+
+      m_dauSFs_eleID_up = -99.;
+      m_dauSFs_eleID_down = -99.;
+      m_dauSFs_eleReco_up = -99.;
+      m_dauSFs_eleReco_down = -99.;
 
       m_jetFakeSF = 1.;
       m_lheNOutPartons = -1;
@@ -1087,111 +1087,111 @@ struct smallTree
 					   "IdSF_leg1_deep_vsJet_2d/F") ;
 	  m_smallT->Branch("IdSF_leg2_deep_vsJet_2d", &m_IdSF_leg2_deep_vsJet_2d,
 					   "IdSF_leg2_deep_vsJet_2d/F") ;
-	  m_smallT->Branch ("IdFakeSF_deep_2d", &m_IdFakeSF_deep_2d, "IdFakeSF_deep_2d/F") ;
+      m_smallT->Branch ("dauSFs", &m_dauSFs, "dauSFs/F") ;
       m_smallT->Branch ("FakeRateSF_deep", &m_FakeRateSF_deep, "FakeRateSF_deep/F") ;
 
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat0_DM0_up", &m_idFakeSF_tauid_2d_stat0_DM0_up,
-					   "idFakeSF_tauid_2d_stat0_DM0_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat0_DM0_down", &m_idFakeSF_tauid_2d_stat0_DM0_down,
-					   "idFakeSF_tauid_2d_stat0_DM0_down/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat1_DM0_up", &m_idFakeSF_tauid_2d_stat1_DM0_up,
-					   "idFakeSF_tauid_2d_stat1_DM0_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat1_DM0_down", &m_idFakeSF_tauid_2d_stat1_DM0_down,
-					   "idFakeSF_tauid_2d_stat1_DM0_down/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_systuncorrdmeras_DM0_up", &m_idFakeSF_tauid_2d_systuncorrdmeras_DM0_up,
-					   "idFakeSF_tauid_2d_systuncorrdmeras_DM0_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_systuncorrdmeras_DM0_down", &m_idFakeSF_tauid_2d_systuncorrdmeras_DM0_down,
-					   "idFakeSF_tauid_2d_systuncorrdmeras_DM0_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat0_DM0_up", &m_dauSFs_tauid_2d_stat0_DM0_up,
+        "dauSFs_tauid_2d_stat0_DM0_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat0_DM0_down", &m_dauSFs_tauid_2d_stat0_DM0_down,
+        "dauSFs_tauid_2d_stat0_DM0_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat1_DM0_up", &m_dauSFs_tauid_2d_stat1_DM0_up,
+        "dauSFs_tauid_2d_stat1_DM0_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat1_DM0_down", &m_dauSFs_tauid_2d_stat1_DM0_down,
+        "dauSFs_tauid_2d_stat1_DM0_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_systuncorrdmeras_DM0_up", &m_dauSFs_tauid_2d_systuncorrdmeras_DM0_up,
+        "dauSFs_tauid_2d_systuncorrdmeras_DM0_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_systuncorrdmeras_DM0_down", &m_dauSFs_tauid_2d_systuncorrdmeras_DM0_down,
+        "dauSFs_tauid_2d_systuncorrdmeras_DM0_down/F");
 
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat0_DM1_up", &m_idFakeSF_tauid_2d_stat0_DM1_up,
-					   "idFakeSF_tauid_2d_stat0_DM1_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat0_DM1_down", &m_idFakeSF_tauid_2d_stat0_DM1_down,
-					   "idFakeSF_tauid_2d_stat0_DM1_down/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat1_DM1_up", &m_idFakeSF_tauid_2d_stat1_DM1_up,
-					   "idFakeSF_tauid_2d_stat1_DM1_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat1_DM1_down", &m_idFakeSF_tauid_2d_stat1_DM1_down,
-					   "idFakeSF_tauid_2d_stat1_DM1_down/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_systuncorrdmeras_DM1_up", &m_idFakeSF_tauid_2d_systuncorrdmeras_DM1_up,
-					   "idFakeSF_tauid_2d_systuncorrdmeras_DM1_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_systuncorrdmeras_DM1_down", &m_idFakeSF_tauid_2d_systuncorrdmeras_DM1_down,
-					   "idFakeSF_tauid_2d_systuncorrdmeras_DM1_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat0_DM1_up", &m_dauSFs_tauid_2d_stat0_DM1_up,
+        "dauSFs_tauid_2d_stat0_DM1_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat0_DM1_down", &m_dauSFs_tauid_2d_stat0_DM1_down,
+        "dauSFs_tauid_2d_stat0_DM1_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat1_DM1_up", &m_dauSFs_tauid_2d_stat1_DM1_up,
+        "dauSFs_tauid_2d_stat1_DM1_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat1_DM1_down", &m_dauSFs_tauid_2d_stat1_DM1_down,
+        "dauSFs_tauid_2d_stat1_DM1_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_systuncorrdmeras_DM1_up", &m_dauSFs_tauid_2d_systuncorrdmeras_DM1_up,
+        "dauSFs_tauid_2d_systuncorrdmeras_DM1_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_systuncorrdmeras_DM1_down", &m_dauSFs_tauid_2d_systuncorrdmeras_DM1_down,
+        "dauSFs_tauid_2d_systuncorrdmeras_DM1_down/F");
 
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat0_DM10_up", &m_idFakeSF_tauid_2d_stat0_DM10_up,
-					   "idFakeSF_tauid_2d_stat0_DM10_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat0_DM10_down", &m_idFakeSF_tauid_2d_stat0_DM10_down,
-					   "idFakeSF_tauid_2d_stat0_DM10_down/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat1_DM10_up", &m_idFakeSF_tauid_2d_stat1_DM10_up,
-					   "idFakeSF_tauid_2d_stat1_DM10_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat1_DM10_down", &m_idFakeSF_tauid_2d_stat1_DM10_down,
-					   "idFakeSF_tauid_2d_stat1_DM10_down/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_systuncorrdmeras_DM10_up", &m_idFakeSF_tauid_2d_systuncorrdmeras_DM10_up,
-					   "idFakeSF_tauid_2d_systuncorrdmeras_DM10_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_systuncorrdmeras_DM10_down", &m_idFakeSF_tauid_2d_systuncorrdmeras_DM10_down,
-					   "idFakeSF_tauid_2d_systuncorrdmeras_DM10_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat0_DM10_up", &m_dauSFs_tauid_2d_stat0_DM10_up,
+        "dauSFs_tauid_2d_stat0_DM10_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat0_DM10_down", &m_dauSFs_tauid_2d_stat0_DM10_down,
+        "dauSFs_tauid_2d_stat0_DM10_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat1_DM10_up", &m_dauSFs_tauid_2d_stat1_DM10_up,
+        "dauSFs_tauid_2d_stat1_DM10_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat1_DM10_down", &m_dauSFs_tauid_2d_stat1_DM10_down,
+        "dauSFs_tauid_2d_stat1_DM10_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_systuncorrdmeras_DM10_up", &m_dauSFs_tauid_2d_systuncorrdmeras_DM10_up,
+        "dauSFs_tauid_2d_systuncorrdmeras_DM10_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_systuncorrdmeras_DM10_down", &m_dauSFs_tauid_2d_systuncorrdmeras_DM10_down,
+        "dauSFs_tauid_2d_systuncorrdmeras_DM10_down/F");
 
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat0_DM11_up", &m_idFakeSF_tauid_2d_stat0_DM11_up,
-					   "idFakeSF_tauid_2d_stat0_DM11_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat0_DM11_down", &m_idFakeSF_tauid_2d_stat0_DM11_down,
-					   "idFakeSF_tauid_2d_stat0_DM11_down/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat1_DM11_up", &m_idFakeSF_tauid_2d_stat1_DM11_up,
-					   "idFakeSF_tauid_2d_stat1_DM11_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat1_DM11_down", &m_idFakeSF_tauid_2d_stat1_DM11_down,
-					   "idFakeSF_tauid_2d_stat1_DM11_down/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_systuncorrdmeras_DM11_up", &m_idFakeSF_tauid_2d_systuncorrdmeras_DM11_up,
-					   "idFakeSF_tauid_2d_systuncorrdmeras_DM11_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_systuncorrdmeras_DM11_down", &m_idFakeSF_tauid_2d_systuncorrdmeras_DM11_down,
-					   "idFakeSF_tauid_2d_systuncorrdmeras_DM11_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat0_DM11_up", &m_dauSFs_tauid_2d_stat0_DM11_up,
+        "dauSFs_tauid_2d_stat0_DM11_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat0_DM11_down", &m_dauSFs_tauid_2d_stat0_DM11_down,
+        "dauSFs_tauid_2d_stat0_DM11_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat1_DM11_up", &m_dauSFs_tauid_2d_stat1_DM11_up,
+        "dauSFs_tauid_2d_stat1_DM11_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat1_DM11_down", &m_dauSFs_tauid_2d_stat1_DM11_down,
+        "dauSFs_tauid_2d_stat1_DM11_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_systuncorrdmeras_DM11_up", &m_dauSFs_tauid_2d_systuncorrdmeras_DM11_up,
+        "dauSFs_tauid_2d_systuncorrdmeras_DM11_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_systuncorrdmeras_DM11_down", &m_dauSFs_tauid_2d_systuncorrdmeras_DM11_down,
+        "dauSFs_tauid_2d_systuncorrdmeras_DM11_down/F");
 
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat0gt140_up", &m_idFakeSF_tauid_2d_stat0gt140_up,
-					   "idFakeSF_tauid_2d_stat0gt140_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat0gt140_down", &m_idFakeSF_tauid_2d_stat0gt140_down,
-					   "idFakeSF_tauid_2d_stat0gt140_down/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat1gt140_up", &m_idFakeSF_tauid_2d_stat1gt140_up,
-					   "idFakeSF_tauid_2d_stat1gt140_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_stat1gt140_down", &m_idFakeSF_tauid_2d_stat1gt140_down,
-					   "idFakeSF_tauid_2d_stat1gt140_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat0gt140_up", &m_dauSFs_tauid_2d_stat0gt140_up,
+        "dauSFs_tauid_2d_stat0gt140_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat0gt140_down", &m_dauSFs_tauid_2d_stat0gt140_down,
+        "dauSFs_tauid_2d_stat0gt140_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat1gt140_up", &m_dauSFs_tauid_2d_stat1gt140_up,
+        "dauSFs_tauid_2d_stat1gt140_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_stat1gt140_down", &m_dauSFs_tauid_2d_stat1gt140_down,
+        "dauSFs_tauid_2d_stat1gt140_down/F");
 
-	  m_smallT->Branch("idFakeSF_tauid_2d_systcorrdmeras_up", &m_idFakeSF_tauid_2d_systcorrdmeras_up,
-					   "idFakeSF_tauid_2d_systcorrdmeras_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_systcorrdmeras_down", &m_idFakeSF_tauid_2d_systcorrdmeras_down,
-					   "idFakeSF_tauid_2d_systcorrdmeras_down/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_systcorrdmuncorreras_up", &m_idFakeSF_tauid_2d_systcorrdmuncorreras_up,
-					   "idFakeSF_tauid_2d_systcorrdmuncorreras_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_systcorrdmuncorreras_down", &m_idFakeSF_tauid_2d_systcorrdmuncorreras_down,
-					   "idFakeSF_tauid_2d_systcorrdmuncorreras_down/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_systcorrerasgt140_up", &m_idFakeSF_tauid_2d_systcorrerasgt140_up,
-					   "idFakeSF_tauid_2d_systcorrerasgt140_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_systcorrerasgt140_down", &m_idFakeSF_tauid_2d_systcorrerasgt140_down,
-					   "idFakeSF_tauid_2d_systcorrerasgt140_down/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_extrapgt140_up", &m_idFakeSF_tauid_2d_extrapgt140_up,
-					   "idFakeSF_tauid_2d_extrapgt140_up/F");
-	  m_smallT->Branch("idFakeSF_tauid_2d_extrapgt140_down", &m_idFakeSF_tauid_2d_extrapgt140_down,
-					   "idFakeSF_tauid_2d_extrapgt140_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_systcorrdmeras_up", &m_dauSFs_tauid_2d_systcorrdmeras_up,
+        "dauSFs_tauid_2d_systcorrdmeras_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_systcorrdmeras_down", &m_dauSFs_tauid_2d_systcorrdmeras_down,
+        "dauSFs_tauid_2d_systcorrdmeras_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_systcorrdmuncorreras_up", &m_dauSFs_tauid_2d_systcorrdmuncorreras_up,
+        "dauSFs_tauid_2d_systcorrdmuncorreras_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_systcorrdmuncorreras_down", &m_dauSFs_tauid_2d_systcorrdmuncorreras_down,
+        "dauSFs_tauid_2d_systcorrdmuncorreras_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_systcorrerasgt140_up", &m_dauSFs_tauid_2d_systcorrerasgt140_up,
+        "dauSFs_tauid_2d_systcorrerasgt140_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_systcorrerasgt140_down", &m_dauSFs_tauid_2d_systcorrerasgt140_down,
+        "dauSFs_tauid_2d_systcorrerasgt140_down/F");
+      m_smallT->Branch("dauSFs_tauid_2d_extrapgt140_up", &m_dauSFs_tauid_2d_extrapgt140_up,
+        "dauSFs_tauid_2d_extrapgt140_up/F");
+      m_smallT->Branch("dauSFs_tauid_2d_extrapgt140_down", &m_dauSFs_tauid_2d_extrapgt140_down,
+        "dauSFs_tauid_2d_extrapgt140_down/F");
   
-      m_smallT->Branch ("idFakeSF_mutauFR_etaLt0p4_up"     , &m_idFakeSF_mutauFR_etaLt0p4_up     , "idFakeSF_mutauFR_etaLt0p4_up/F");
-      m_smallT->Branch ("idFakeSF_mutauFR_eta0p4to0p8_up"  , &m_idFakeSF_mutauFR_eta0p4to0p8_up  , "idFakeSF_mutauFR_eta0p4to0p8_up/F");
-      m_smallT->Branch ("idFakeSF_mutauFR_eta0p8to1p2_up"  , &m_idFakeSF_mutauFR_eta0p8to1p2_up  , "idFakeSF_mutauFR_eta0p8to1p2_up/F");
-      m_smallT->Branch ("idFakeSF_mutauFR_eta1p2to1p7_up"  , &m_idFakeSF_mutauFR_eta1p2to1p7_up  , "idFakeSF_mutauFR_eta1p2to1p7_up/F");
-      m_smallT->Branch ("idFakeSF_mutauFR_etaGt1p7_up"     , &m_idFakeSF_mutauFR_etaGt1p7_up     , "idFakeSF_mutauFR_etaGt1p7_up/F");
-      m_smallT->Branch ("idFakeSF_mutauFR_etaLt0p4_down"   , &m_idFakeSF_mutauFR_etaLt0p4_down   , "idFakeSF_mutauFR_etaLt0p4_down/F");
-      m_smallT->Branch ("idFakeSF_mutauFR_eta0p4to0p8_down", &m_idFakeSF_mutauFR_eta0p4to0p8_down, "idFakeSF_mutauFR_eta0p4to0p8_down/F");
-      m_smallT->Branch ("idFakeSF_mutauFR_eta0p8to1p2_down", &m_idFakeSF_mutauFR_eta0p8to1p2_down, "idFakeSF_mutauFR_eta0p8to1p2_down/F");
-      m_smallT->Branch ("idFakeSF_mutauFR_eta1p2to1p7_down", &m_idFakeSF_mutauFR_eta1p2to1p7_down, "idFakeSF_mutauFR_eta1p2to1p7_down/F");
-      m_smallT->Branch ("idFakeSF_mutauFR_etaGt1p7_down"   , &m_idFakeSF_mutauFR_etaGt1p7_down   , "idFakeSF_mutauFR_etaGt1p7_down/F");
+      m_smallT->Branch ("dauSFs_mutauFR_etaLt0p4_up", &m_dauSFs_mutauFR_etaLt0p4_up, "dauSFs_mutauFR_etaLt0p4_up/F");
+      m_smallT->Branch ("dauSFs_mutauFR_eta0p4to0p8_up", &m_dauSFs_mutauFR_eta0p4to0p8_up, "dauSFs_mutauFR_eta0p4to0p8_up/F");
+      m_smallT->Branch ("dauSFs_mutauFR_eta0p8to1p2_up", &m_dauSFs_mutauFR_eta0p8to1p2_up, "dauSFs_mutauFR_eta0p8to1p2_up/F");
+      m_smallT->Branch ("dauSFs_mutauFR_eta1p2to1p7_up", &m_dauSFs_mutauFR_eta1p2to1p7_up, "dauSFs_mutauFR_eta1p2to1p7_up/F");
+      m_smallT->Branch ("dauSFs_mutauFR_etaGt1p7_up", &m_dauSFs_mutauFR_etaGt1p7_up, "dauSFs_mutauFR_etaGt1p7_up/F");
+      m_smallT->Branch ("dauSFs_mutauFR_etaLt0p4_down", &m_dauSFs_mutauFR_etaLt0p4_down, "dauSFs_mutauFR_etaLt0p4_down/F");
+      m_smallT->Branch ("dauSFs_mutauFR_eta0p4to0p8_down", &m_dauSFs_mutauFR_eta0p4to0p8_down, "dauSFs_mutauFR_eta0p4to0p8_down/F");
+      m_smallT->Branch ("dauSFs_mutauFR_eta0p8to1p2_down", &m_dauSFs_mutauFR_eta0p8to1p2_down, "dauSFs_mutauFR_eta0p8to1p2_down/F");
+      m_smallT->Branch ("dauSFs_mutauFR_eta1p2to1p7_down", &m_dauSFs_mutauFR_eta1p2to1p7_down, "dauSFs_mutauFR_eta1p2to1p7_down/F");
+      m_smallT->Branch ("dauSFs_mutauFR_etaGt1p7_down", &m_dauSFs_mutauFR_etaGt1p7_down, "dauSFs_mutauFR_etaGt1p7_down/F");
 
-	  m_smallT->Branch ("idFakeSF_etauFR_barrel_up"        , &m_idFakeSF_etauFR_barrel_up        , "idFakeSF_etauFR_barrel_up/F");
-      m_smallT->Branch ("idFakeSF_etauFR_endcap_up"        , &m_idFakeSF_etauFR_endcap_up        , "idFakeSF_etauFR_endcap_up/F");
-      m_smallT->Branch ("idFakeSF_etauFR_barrel_down"      , &m_idFakeSF_etauFR_barrel_down      , "idFakeSF_etauFR_barrel_down/F");
-      m_smallT->Branch ("idFakeSF_etauFR_endcap_down"      , &m_idFakeSF_etauFR_endcap_down      , "idFakeSF_etauFR_endcap_down/F");
+      m_smallT->Branch ("dauSFs_etauFR_barrel_up", &m_dauSFs_etauFR_barrel_up, "dauSFs_etauFR_barrel_up/F");
+      m_smallT->Branch ("dauSFs_etauFR_endcap_up", &m_dauSFs_etauFR_endcap_up, "dauSFs_etauFR_endcap_up/F");
+      m_smallT->Branch ("dauSFs_etauFR_barrel_down", &m_dauSFs_etauFR_barrel_down, "dauSFs_etauFR_barrel_down/F");
+      m_smallT->Branch ("dauSFs_etauFR_endcap_down", &m_dauSFs_etauFR_endcap_down, "dauSFs_etauFR_endcap_down/F");
 
-      m_smallT->Branch ("idFakeSF_muID_up   ", &m_idFakeSF_muID_up   , "idFakeSF_muID_up/F");
-      m_smallT->Branch ("idFakeSF_muID_down ", &m_idFakeSF_muID_down , "idFakeSF_muID_down/F");
-      m_smallT->Branch ("idFakeSF_muIso_up  ", &m_idFakeSF_muIso_up  , "idFakeSF_muIso_up/F");
-      m_smallT->Branch ("idFakeSF_muIso_down", &m_idFakeSF_muIso_down, "idFakeSF_muIso_down/F");
-      m_smallT->Branch ("idFakeSF_eleID_up  ", &m_idFakeSF_eleID_up  , "idFakeSF_eleID_up/F");
-      m_smallT->Branch ("idFakeSF_eleID_down", &m_idFakeSF_eleID_down, "idFakeSF_eleID_down/F");
-      m_smallT->Branch ("idFakeSF_eleReco_up", &m_idFakeSF_eleReco_up, "idFakeSF_eleReco_up/F");
-      m_smallT->Branch ("idFakeSF_eleReco_down", &m_idFakeSF_eleReco_down, "idFakeSF_eleReco_down/F");
+      m_smallT->Branch ("dauSFs_muID_up", &m_dauSFs_muID_up   , "dauSFs_muID_up/F");
+      m_smallT->Branch ("dauSFs_muID_down", &m_dauSFs_muID_down , "dauSFs_muID_down/F");
+      m_smallT->Branch ("dauSFs_muIso_up", &m_dauSFs_muIso_up  , "dauSFs_muIso_up/F");
+      m_smallT->Branch ("dauSFs_muIso_down", &m_dauSFs_muIso_down, "dauSFs_muIso_down/F");
+      m_smallT->Branch ("dauSFs_eleID_up", &m_dauSFs_eleID_up  , "dauSFs_eleID_up/F");
+      m_smallT->Branch ("dauSFs_eleID_down", &m_dauSFs_eleID_down, "dauSFs_eleID_down/F");
+      m_smallT->Branch ("dauSFs_eleReco_up", &m_dauSFs_eleReco_up, "dauSFs_eleReco_up/F");
+      m_smallT->Branch ("dauSFs_eleReco_down", &m_dauSFs_eleReco_down, "dauSFs_eleReco_down/F");
 
       m_smallT->Branch ("lheNOutPartons", &m_lheNOutPartons, "lheNOutPartons/I");
       m_smallT->Branch ("lheNOutB", &m_lheNOutB, "lheNOutB/I");
@@ -2087,75 +2087,75 @@ struct smallTree
   Float_t m_IdSF_deep_2d ;
   Float_t m_IdSF_leg1_deep_vsJet_2d;
   Float_t m_IdSF_leg2_deep_vsJet_2d;
-  Float_t m_IdFakeSF_deep_2d ;
+  Float_t m_dauSFs ;
   Float_t m_FakeRateSF_deep;
 
-  Float_t m_idFakeSF_tauid_2d_stat0_DM0_up;
-  Float_t m_idFakeSF_tauid_2d_stat0_DM0_down;
-  Float_t m_idFakeSF_tauid_2d_stat1_DM0_up;
-  Float_t m_idFakeSF_tauid_2d_stat1_DM0_down;
-  Float_t m_idFakeSF_tauid_2d_systuncorrdmeras_DM0_up;
-  Float_t m_idFakeSF_tauid_2d_systuncorrdmeras_DM0_down;
+  Float_t m_dauSFs_tauid_2d_stat0_DM0_up;
+  Float_t m_dauSFs_tauid_2d_stat0_DM0_down;
+  Float_t m_dauSFs_tauid_2d_stat1_DM0_up;
+  Float_t m_dauSFs_tauid_2d_stat1_DM0_down;
+  Float_t m_dauSFs_tauid_2d_systuncorrdmeras_DM0_up;
+  Float_t m_dauSFs_tauid_2d_systuncorrdmeras_DM0_down;
 
-  Float_t m_idFakeSF_tauid_2d_stat0_DM1_up;
-  Float_t m_idFakeSF_tauid_2d_stat0_DM1_down;
-  Float_t m_idFakeSF_tauid_2d_stat1_DM1_up;
-  Float_t m_idFakeSF_tauid_2d_stat1_DM1_down;
-  Float_t m_idFakeSF_tauid_2d_systuncorrdmeras_DM1_up;
-  Float_t m_idFakeSF_tauid_2d_systuncorrdmeras_DM1_down;
+  Float_t m_dauSFs_tauid_2d_stat0_DM1_up;
+  Float_t m_dauSFs_tauid_2d_stat0_DM1_down;
+  Float_t m_dauSFs_tauid_2d_stat1_DM1_up;
+  Float_t m_dauSFs_tauid_2d_stat1_DM1_down;
+  Float_t m_dauSFs_tauid_2d_systuncorrdmeras_DM1_up;
+  Float_t m_dauSFs_tauid_2d_systuncorrdmeras_DM1_down;
 
-  Float_t m_idFakeSF_tauid_2d_stat0_DM10_up;
-  Float_t m_idFakeSF_tauid_2d_stat0_DM10_down;
-  Float_t m_idFakeSF_tauid_2d_stat1_DM10_up;
-  Float_t m_idFakeSF_tauid_2d_stat1_DM10_down;
-  Float_t m_idFakeSF_tauid_2d_systuncorrdmeras_DM10_up;
-  Float_t m_idFakeSF_tauid_2d_systuncorrdmeras_DM10_down;
+  Float_t m_dauSFs_tauid_2d_stat0_DM10_up;
+  Float_t m_dauSFs_tauid_2d_stat0_DM10_down;
+  Float_t m_dauSFs_tauid_2d_stat1_DM10_up;
+  Float_t m_dauSFs_tauid_2d_stat1_DM10_down;
+  Float_t m_dauSFs_tauid_2d_systuncorrdmeras_DM10_up;
+  Float_t m_dauSFs_tauid_2d_systuncorrdmeras_DM10_down;
 
-  Float_t m_idFakeSF_tauid_2d_stat0_DM11_up;
-  Float_t m_idFakeSF_tauid_2d_stat0_DM11_down;
-  Float_t m_idFakeSF_tauid_2d_stat1_DM11_up;
-  Float_t m_idFakeSF_tauid_2d_stat1_DM11_down;
-  Float_t m_idFakeSF_tauid_2d_systuncorrdmeras_DM11_up;
-  Float_t m_idFakeSF_tauid_2d_systuncorrdmeras_DM11_down;
+  Float_t m_dauSFs_tauid_2d_stat0_DM11_up;
+  Float_t m_dauSFs_tauid_2d_stat0_DM11_down;
+  Float_t m_dauSFs_tauid_2d_stat1_DM11_up;
+  Float_t m_dauSFs_tauid_2d_stat1_DM11_down;
+  Float_t m_dauSFs_tauid_2d_systuncorrdmeras_DM11_up;
+  Float_t m_dauSFs_tauid_2d_systuncorrdmeras_DM11_down;
 
-  Float_t m_idFakeSF_tauid_2d_systcorrdmeras_up;
-  Float_t m_idFakeSF_tauid_2d_systcorrdmeras_down;
-  Float_t m_idFakeSF_tauid_2d_systcorrdmuncorreras_up;
-  Float_t m_idFakeSF_tauid_2d_systcorrdmuncorreras_down;
-  Float_t m_idFakeSF_tauid_2d_systcorrerasgt140_up;
-  Float_t m_idFakeSF_tauid_2d_systcorrerasgt140_down;
-  Float_t m_idFakeSF_tauid_2d_stat0gt140_up;
-  Float_t m_idFakeSF_tauid_2d_stat0gt140_down;
-  Float_t m_idFakeSF_tauid_2d_stat1gt140_up;
-  Float_t m_idFakeSF_tauid_2d_stat1gt140_down;
-  Float_t m_idFakeSF_tauid_2d_extrapgt140_up;
-  Float_t m_idFakeSF_tauid_2d_extrapgt140_down;
+  Float_t m_dauSFs_tauid_2d_systcorrdmeras_up;
+  Float_t m_dauSFs_tauid_2d_systcorrdmeras_down;
+  Float_t m_dauSFs_tauid_2d_systcorrdmuncorreras_up;
+  Float_t m_dauSFs_tauid_2d_systcorrdmuncorreras_down;
+  Float_t m_dauSFs_tauid_2d_systcorrerasgt140_up;
+  Float_t m_dauSFs_tauid_2d_systcorrerasgt140_down;
+  Float_t m_dauSFs_tauid_2d_stat0gt140_up;
+  Float_t m_dauSFs_tauid_2d_stat0gt140_down;
+  Float_t m_dauSFs_tauid_2d_stat1gt140_up;
+  Float_t m_dauSFs_tauid_2d_stat1gt140_down;
+  Float_t m_dauSFs_tauid_2d_extrapgt140_up;
+  Float_t m_dauSFs_tauid_2d_extrapgt140_down;
 
-  Float_t m_idFakeSF_mutauFR_etaLt0p4_up     ;
-  Float_t m_idFakeSF_mutauFR_eta0p4to0p8_up  ;
-  Float_t m_idFakeSF_mutauFR_eta0p8to1p2_up  ;
-  Float_t m_idFakeSF_mutauFR_eta1p2to1p7_up  ;
-  Float_t m_idFakeSF_mutauFR_etaGt1p7_up     ;
-  Float_t m_idFakeSF_mutauFR_etaLt0p4_down   ;
-  Float_t m_idFakeSF_mutauFR_eta0p4to0p8_down;
-  Float_t m_idFakeSF_mutauFR_eta0p8to1p2_down;
-  Float_t m_idFakeSF_mutauFR_eta1p2to1p7_down;
-  Float_t m_idFakeSF_mutauFR_etaGt1p7_down   ;
+  Float_t m_dauSFs_mutauFR_etaLt0p4_up;
+  Float_t m_dauSFs_mutauFR_eta0p4to0p8_up;
+  Float_t m_dauSFs_mutauFR_eta0p8to1p2_up;
+  Float_t m_dauSFs_mutauFR_eta1p2to1p7_up;
+  Float_t m_dauSFs_mutauFR_etaGt1p7_up;
+  Float_t m_dauSFs_mutauFR_etaLt0p4_down;
+  Float_t m_dauSFs_mutauFR_eta0p4to0p8_down;
+  Float_t m_dauSFs_mutauFR_eta0p8to1p2_down;
+  Float_t m_dauSFs_mutauFR_eta1p2to1p7_down;
+  Float_t m_dauSFs_mutauFR_etaGt1p7_down;
 
-  Float_t m_idFakeSF_etauFR_barrel_up        ;
-  Float_t m_idFakeSF_etauFR_endcap_up        ;
-  Float_t m_idFakeSF_etauFR_barrel_down      ;
-  Float_t m_idFakeSF_etauFR_endcap_down      ;
+  Float_t m_dauSFs_etauFR_barrel_up;
+  Float_t m_dauSFs_etauFR_endcap_up;
+  Float_t m_dauSFs_etauFR_barrel_down;
+  Float_t m_dauSFs_etauFR_endcap_down;
 
-  Float_t m_idFakeSF_muID_up;
-  Float_t m_idFakeSF_muID_down;
-  Float_t m_idFakeSF_muIso_up;
-  Float_t m_idFakeSF_muIso_down;
+  Float_t m_dauSFs_muID_up;
+  Float_t m_dauSFs_muID_down;
+  Float_t m_dauSFs_muIso_up;
+  Float_t m_dauSFs_muIso_down;
 
-  Float_t m_idFakeSF_eleID_up;
-  Float_t m_idFakeSF_eleID_down;
-  Float_t m_idFakeSF_eleReco_up;
-  Float_t m_idFakeSF_eleReco_down;
+  Float_t m_dauSFs_eleID_up;
+  Float_t m_dauSFs_eleID_down;
+  Float_t m_dauSFs_eleReco_up;
+  Float_t m_dauSFs_eleReco_down;
 
   Int_t m_lheNOutPartons ;
   Int_t m_lheNOutB ;

--- a/interface/smallTree_HHbtag.h
+++ b/interface/smallTree_HHbtag.h
@@ -193,6 +193,8 @@ struct smallTree
 
       m_idFakeSF_eleID_up                 = -99.;
       m_idFakeSF_eleID_down               = -99.;
+      m_idFakeSF_eleReco_up               = -99.;
+      m_idFakeSF_eleReco_down             = -99.;
 
       m_jetFakeSF = 1.;
       m_lheNOutPartons = -1;
@@ -1195,6 +1197,8 @@ struct smallTree
       m_smallT->Branch ("idFakeSF_muIso_down", &m_idFakeSF_muIso_down, "idFakeSF_muIso_down/F");
       m_smallT->Branch ("idFakeSF_eleID_up  ", &m_idFakeSF_eleID_up  , "idFakeSF_eleID_up/F");
       m_smallT->Branch ("idFakeSF_eleID_down", &m_idFakeSF_eleID_down, "idFakeSF_eleID_down/F");
+      m_smallT->Branch ("idFakeSF_eleReco_up", &m_idFakeSF_eleReco_up, "idFakeSF_eleReco_up/F");
+      m_smallT->Branch ("idFakeSF_eleReco_down", &m_idFakeSF_eleReco_down, "idFakeSF_eleReco_down/F");
 
       m_smallT->Branch ("lheNOutPartons", &m_lheNOutPartons, "lheNOutPartons/I");
       m_smallT->Branch ("lheNOutB", &m_lheNOutB, "lheNOutB/I");
@@ -2157,6 +2161,8 @@ struct smallTree
 
   Float_t m_idFakeSF_eleID_up;
   Float_t m_idFakeSF_eleID_down;
+  Float_t m_idFakeSF_eleReco_up;
+  Float_t m_idFakeSF_eleReco_down;
 
   Int_t m_lheNOutPartons ;
   Int_t m_lheNOutB ;

--- a/interface/smallTree_HHbtag.h
+++ b/interface/smallTree_HHbtag.h
@@ -143,13 +143,6 @@ struct smallTree
 	  m_idFakeSF_tauid_2d_systuncorrdmeras_DM10_up	 = -99.;
 	  m_idFakeSF_tauid_2d_systuncorrdmeras_DM10_down = -99.;
 
-	  m_idFakeSF_tauid_2d_stat0_DM10_up              = -99.;
-	  m_idFakeSF_tauid_2d_stat0_DM10_down			 = -99.;
-	  m_idFakeSF_tauid_2d_stat1_DM10_up				 = -99.;
-	  m_idFakeSF_tauid_2d_stat1_DM10_down			 = -99.;
-	  m_idFakeSF_tauid_2d_systuncorrdmeras_DM10_up	 = -99.;
-	  m_idFakeSF_tauid_2d_systuncorrdmeras_DM10_down = -99.;
-
 	  m_idFakeSF_tauid_2d_stat0_DM11_up              = -99.;
 	  m_idFakeSF_tauid_2d_stat0_DM11_down			 = -99.;
 	  m_idFakeSF_tauid_2d_stat1_DM11_up				 = -99.;

--- a/src/OfflineProducerHelper.cc
+++ b/src/OfflineProducerHelper.cc
@@ -298,6 +298,10 @@ OfflineProducerHelper::eleBaseline (bigTree* tree, int iDau,
   bool isoS = (tree->combreliso->at(iDau) < relIso) || byp_isoS;
   bool idS = false;
   bool nISOidS = false;
+
+  // veto events with electrons in ECAL barrel-endcap transition region
+  //TODO: should be super cluster eta (not available in bigntuples at the moment)
+  bool etaGap = fabs(p4.Eta()) > 1.44 && fabs(p4.Eta()) < 1.57 && whatApply.Contains("etaGapVeto");
   if (MVAIDflag == 0) // Tight = 80%
   {
     idS = tree->daughters_iseleWP80->at(iDau) || byp_idS ;
@@ -314,7 +318,7 @@ OfflineProducerHelper::eleBaseline (bigTree* tree, int iDau,
     nISOidS = tree->daughters_iseleNoIsoWPLoose->at(iDau) || byp_noISOidS;
   }
 
-  bool totalS = (vertexS && idS && ptS && etaS && isoS && nISOidS);
+  bool totalS = (vertexS && idS && ptS && etaS && isoS && nISOidS && !etaGap);
 
   if (debug)
   {

--- a/src/OfflineProducerHelper.cc
+++ b/src/OfflineProducerHelper.cc
@@ -301,7 +301,7 @@ OfflineProducerHelper::eleBaseline (bigTree* tree, int iDau,
 
   // veto events with electrons in ECAL barrel-endcap transition region
   //TODO: should be super cluster eta (not available in bigntuples at the moment)
-  bool etaGap = fabs(p4.Eta()) > 1.44 && fabs(p4.Eta()) < 1.57 && whatApply.Contains("etaGapVeto");
+  bool isInEtaGap = fabs(p4.Eta()) > 1.44 && fabs(p4.Eta()) < 1.57 && whatApply.Contains("etaGapVeto");
   if (MVAIDflag == 0) // Tight = 80%
   {
     idS = tree->daughters_iseleWP80->at(iDau) || byp_idS ;
@@ -318,7 +318,7 @@ OfflineProducerHelper::eleBaseline (bigTree* tree, int iDau,
     nISOidS = tree->daughters_iseleNoIsoWPLoose->at(iDau) || byp_noISOidS;
   }
 
-  bool totalS = (vertexS && idS && ptS && etaS && isoS && nISOidS && !etaGap);
+  bool totalS = (vertexS && idS && ptS && etaS && isoS && nISOidS && !isInEtaGap);
 
   if (debug)
   {

--- a/src/ScaleFactor.cc
+++ b/src/ScaleFactor.cc
@@ -1,4 +1,5 @@
 // https://github.com/CMS-HTT/LeptonEff-interface.git
+#include <sstream>
 #include "ScaleFactor.h"
 
 void ScaleFactor::init_EG_ScaleFactor(TString inputRootFile, bool isTriggerSF) {
@@ -273,13 +274,14 @@ int ScaleFactor::FindPtPoint(std::map<std::string, TGraphAsymmErrors*> eff_map,
   if (Pt >= ptMAX) { // if pt is overflow, return last pt point
 	return Npoints-1;
   }
-  else if (Pt < ptMIN) { // if pt is underflow, return nonsense number and warning
-    std::cout << "WARNING in ScaleFactor::get_EfficiencyData(double pt, double eta, int pType) from src/ScaleFactor.cc: "
-			  << "pT too low (pt=" << Pt << ", "
-			  << "eta=" << Eta << "), min value is " << ptMIN
-			  << " (pType = " << pType << "). "
-			  << "Returned efficiency = 1. Weight will be 1. " << std::endl;
-    return -99;
+  else if (Pt < ptMIN) { // if pt is underflow, throw exception
+    std::stringstream mes;
+    mes << "ERROR in ScaleFactor::FindPtPoint(std::map<std::string, TGraphAsymmErrors*> eff_map, ";
+    mes << "std::string EtaLabel, double Pt, double Eta, int pType) from src/ScaleFactor.cc: ";
+    mes << "pT too low (pt=" << Pt << ", ";
+    mes << "eta=" << Eta << "), min value is " << ptMIN;
+    mes << " (pType = " << pType << ").";
+    throw std::runtime_error(mes.str());
   }
   else { // if pt is in range
     for (int graphPoint=0; graphPoint < Npoints; graphPoint++) {

--- a/src/ScaleFactor.cc
+++ b/src/ScaleFactor.cc
@@ -423,3 +423,17 @@ double ScaleFactor::get_ScaleFactorError(double pt, double eta, int pType) {
 
   return get_ScaleFactorError(effData, effMC, errData, errMC);
 }
+
+double ScaleFactor::get_direct_ScaleFactorError(double pt, double eta, int pType){
+
+  std::string label = FindEtaLabel(eta, "data");
+  int pt_point = FindPtPoint(eff_data, label, pt, eta, pType); // when available, SF stored in eff_data (lazy implementation that should be improved)
+  double SF_error;
+
+  if (pt_point == -99){SF_error = 0;} // if pt is underflow
+  else SF_error= eff_data[label]->GetErrorYhigh(pt_point);
+  // errors are supposed to be symmetric, can use GetErrorYhigh or GetErrorYlow
+
+  return SF_error;
+
+}

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -1571,6 +1571,8 @@ int main (int argc, char** argv)
 											theBigTree.daughters_pz->at (firstDaughterIndex),
 											theBigTree.daughters_e->at (firstDaughterIndex)
 											);
+	  // veto events with electrons in ECAL barrel-endcap transition region
+	  if((pairType == 1) && fabs(tlv_firstLepton.Eta()) > 1.44 && fabs(tlv_firstLepton.Eta()) < 1.57) continue;
 
 	  const TLorentzVector tlv_secondLepton (theBigTree.daughters_px->at (secondDaughterIndex),
 											 theBigTree.daughters_py->at (secondDaughterIndex),

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -610,8 +610,8 @@ int main (int argc, char** argv)
   }
     
   // electron/muon IdAndIso SF
-  ScaleFactor * lepSFs[4]; // [0: muID, 1: muISO , 2:eleReco, 3:eleID]
-  for (int i=0; i<4; i++) {
+  ScaleFactor * lepSFs[5]; // [0: muID, 1: muISO, 2: eleReco < 20 GeV, 3:eleReco > 20GeV, 4:eleID]
+  for (int i=0; i<5; i++) {
     lepSFs[i] = new ScaleFactor();
   }
   if (PERIOD == "2018") {
@@ -619,32 +619,36 @@ int main (int argc, char** argv)
                                                "NUM_TightID_DEN_TrackerMuons_abseta_pt", true);
 	lepSFs[1] -> init_ScaleFactor("weights/MuPogSF_UL/2018/Efficiencies_muon_generalTracks_Z_Run2018_UL_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
-	lepSFs[2] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi_ptAbove20.txt_EGM2D_UL2018.root", false);
-	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi.txt_Ele_wp80iso_EGM2D.root", false);
+	lepSFs[2] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi_ptBelow20.txt_EGM2D_UL2018.root", false);
+	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi_ptAbove20.txt_EGM2D_UL2018.root", false);
+	lepSFs[4] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi.txt_Ele_wp80iso_EGM2D.root", false);
   }
   else if (PERIOD == "2017") {
 	lepSFs[0] -> init_ScaleFactor("weights/MuPogSF_UL/2017/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.root",
 												 "NUM_TightID_DEN_TrackerMuons_abseta_pt", true);
 	lepSFs[1] -> init_ScaleFactor("weights/MuPogSF_UL/2017/Efficiencies_muon_generalTracks_Z_Run2017_UL_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
-	lepSFs[2] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi_ptAbove20.txt_EGM2D_UL2017.root", false);
-	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi.txt_EGM2D_MVA80iso_UL17.root", false);
+	lepSFs[2] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi_ptBelow20.txt_EGM2D_UL2017.root", false);
+	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi_ptAbove20.txt_EGM2D_UL2017.root", false);
+	lepSFs[4] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi.txt_EGM2D_MVA80iso_UL17.root", false);
   }
   else if (PERIOD == "2016preVFP") {
 	lepSFs[0] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ID.root",
 												 "NUM_TightID_DEN_TrackerMuons_abseta_pt", true);
 	lepSFs[1] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
-	lepSFs[2] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptAbove20.txt_EGM2D_UL2016preVFP.root", false);
-	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi.txt_Ele_wp80iso_preVFP_EGM2D.root",false);
+	lepSFs[2] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptBelow20.txt_EGM2D_UL2016preVFP.root", false);
+	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptAbove20.txt_EGM2D_UL2016preVFP.root", false);
+	lepSFs[4] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi.txt_Ele_wp80iso_preVFP_EGM2D.root",false);
   }
   else if (PERIOD == "2016postVFP") {
 	lepSFs[0] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_ID.root",
 												 "NUM_TightID_DEN_TrackerMuons_abseta_pt", true);
 	lepSFs[1] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
-	lepSFs[2] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptAbove20.txt_EGM2D_UL2016postVFP.root", false);
-	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi.txt_Ele_wp80iso_postVFP_EGM2D.root", false);
+	lepSFs[2] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptBelow20.txt_EGM2D_UL2016postVFP.root", false);
+	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptAbove20.txt_EGM2D_UL2016postVFP.root", false);
+	lepSFs[4] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi.txt_Ele_wp80iso_postVFP_EGM2D.root", false);
   }
   
   // tau IdAndIso SF
@@ -2632,10 +2636,20 @@ int main (int argc, char** argv)
 
 			else if (pType == 1) {
 				//TODO: should be super cluster eta (not available in bigntuples at the moment)
-				float leg1_eleReco_SF = lepSFs[2]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
-				float leg1_eleReco_SFerr = lepSFs[2]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
-				float leg1_eleID_SF = lepSFs[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
-				float leg1_eleID_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+				float leg1_eleReco_SF;
+				float leg1_eleReco_SFerr;
+				// ele RECO SFs are split into two categories: pt <= 20 and pt > 20
+				if(leg1pt <= 20){
+					leg1_eleReco_SF = lepSFs[2]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+					leg1_eleReco_SFerr = lepSFs[2]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+				}
+				else{
+					leg1_eleReco_SF = lepSFs[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+					leg1_eleReco_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+				}
+
+				float leg1_eleID_SF = lepSFs[4]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+				float leg1_eleID_SFerr = lepSFs[4]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
 
 				idSF_leg1 = leg1_eleID_SF * leg1_eleReco_SF;
 				idSF_leg1_eleID_up = (leg1_eleID_SF + leg1_eleID_SFerr) * leg1_eleReco_SF;
@@ -2674,8 +2688,18 @@ int main (int argc, char** argv)
 		}
 		else if(pType == 4) { //EleEle
 			//TODO: should be super cluster eta (not available in bigntuples at the moment)
-			float leg1_eleReco_SF = lepSFs[2]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
-			float leg1_eleReco_SFerr = lepSFs[2]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+			float leg1_eleReco_SF;
+			float leg1_eleReco_SFerr;
+			// ele RECO SFs are split into two categories: pt <= 20 and pt > 20
+			if(leg1pt <= 20){
+				leg1_eleReco_SF = lepSFs[2]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+				leg1_eleReco_SFerr = lepSFs[2]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+			}
+			else{
+				leg1_eleReco_SF = lepSFs[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+				leg1_eleReco_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+			}
+
 			float leg1_eleID_SF = lepSFs[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
 			float leg1_eleID_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
 
@@ -2687,8 +2711,19 @@ int main (int argc, char** argv)
 			idSF_leg1_eleReco_down = (leg1_eleReco_SF - leg1_eleReco_SFerr) * leg1_eleID_SF;
 
 			//TODO: should be super cluster eta (not available in bigntuples at the moment)
-			float leg2_eleReco_SF = lepSFs[2]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
-			float leg2_eleReco_SFerr = lepSFs[2]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
+			float leg2_eleReco_SF;
+			float leg2_eleReco_SFerr;
+			// ele RECO SFs are split into two categories: pt <= 20 and pt > 20
+			if(leg2pt <= 20){
+				leg2_eleReco_SF = lepSFs[2]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
+				leg2_eleReco_SFerr = lepSFs[2]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
+			}
+			else{
+				leg2_eleReco_SF = lepSFs[3]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
+				leg2_eleReco_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
+			}
+
+
 			float leg2_eleID_SF = lepSFs[3]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
 			float leg2_eleID_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
 

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -2497,6 +2497,14 @@ int main (int argc, char** argv)
 	  float idFakeSF_etauFR_barrel_down = -99.0;
 	  float idFakeSF_etauFR_endcap_down = -99.0;
 
+	  float idFakeSF_muID_up = -99.0;
+	  float idFakeSF_muID_down = -99.0;
+	  float idFakeSF_muIso_up = -99.0;
+	  float idFakeSF_muIso_down = -99.0;
+
+	  float idFakeSF_eleID_up = -99.0;
+	  float idFakeSF_eleID_down = -99.0;
+
 	  // bool helpers for tauID syst bins
 	  vector<bool> isthisPt_IDbin_first = { // 20, 25, 30, 35, 40, infty
 		((theSmallTree.m_dau1_pt >= 20 && theSmallTree.m_dau1_pt < 25) ? true : false),
@@ -2558,6 +2566,22 @@ int main (int argc, char** argv)
 	  float idSF_leg2_deep_vsEle	= -99.f;
 	  float idSF_leg2_deep_vsMu		= -99.f;
 
+	  float idSF_leg1_muID_up       = -99.f;
+	  float idSF_leg1_muID_down     = -99.f;
+	  float idSF_leg1_muIso_up      = -99.f;
+	  float idSF_leg1_muIso_down    = -99.f;
+
+	  float idSF_leg1_eleID_up      = -99.f;
+	  float idSF_leg1_eleID_down    = -99.f;
+
+	  float idSF_leg2_muID_up       = -99.f;
+	  float idSF_leg2_muID_down     = -99.f;
+	  float idSF_leg2_muIso_up      = -99.f;
+	  float idSF_leg2_muIso_down    = -99.f;
+
+	  float idSF_leg2_eleID_up      = -99.f;
+	  float idSF_leg2_eleID_down    = -99.f;
+
 	  bool isFakeJet1 = true;
 	  bool isFakeJet2 = true;
 	  if (tau1Genmatch<6) {
@@ -2567,22 +2591,88 @@ int main (int argc, char** argv)
 		isFakeJet2 = false;
 	  }
 
-	  // only TauTau has a tau as the first leg
-	  if (isMC and pType==2)
-		{
-		  idSF_leg1_deep_vsJet_2d = Deep_antiJet_2d->getSFvsDMandPT(leg1pt, tau1DM, tau1Genmatch);
-		  idSF_leg1_deep_vsEle    = Deep_antiEle_vvloose->getSFvsEta(leg1eta, tau1Genmatch);
-		  idSF_leg1_deep_vsMu     = Deep_antiMu_tight->getSFvsEta(leg1eta, tau1Genmatch);
-		}
+	  if(isMC) {
+		// all channels with one tau in the second leg
+		if (pType<3) {
+			idSF_leg2_deep_vsJet_2d = Deep_antiJet_2d->getSFvsDMandPT(leg2pt, tau2DM, tau2Genmatch);
+			idSF_leg2_deep_vsEle = Deep_antiEle_vvloose->getSFvsEta(leg2eta, tau2Genmatch);
+			idSF_leg2_deep_vsMu  = Deep_antiMu_tight->getSFvsEta(leg2eta, tau2Genmatch);
 
-	  // all channels with one tau in the second leg
-	  if (isMC and pType<3)
-		{
-		  idSF_leg2_deep_vsJet_2d = Deep_antiJet_2d->getSFvsDMandPT(leg2pt, tau2DM, tau2Genmatch);
-		  idSF_leg2_deep_vsEle = Deep_antiEle_vvloose->getSFvsEta(leg2eta, tau2Genmatch);
-		  idSF_leg2_deep_vsMu  = Deep_antiMu_tight->getSFvsEta(leg2eta, tau2Genmatch);
+			// only TauTau has a tau as the first leg
+			if (pType==2) {
+				idSF_leg1_deep_vsJet_2d = Deep_antiJet_2d->getSFvsDMandPT(leg1pt, tau1DM, tau1Genmatch);
+				idSF_leg1_deep_vsEle    = Deep_antiEle_vvloose->getSFvsEta(leg1eta, tau1Genmatch);
+				idSF_leg1_deep_vsMu     = Deep_antiMu_tight->getSFvsEta(leg1eta, tau1Genmatch);
+			}
+
+			else if (pType == 0) {
+			// use absolute value of eta for muons, because the SFs are given from 0 to 2.4
+			float leg1_muID_SF = myIDandISOScaleFactor[0]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
+			float leg1_muID_SFerr = myIDandISOScaleFactor[0]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
+			float leg1_muIso_SF = myIDandISOScaleFactor[2]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
+			float leg1_muIso_SFerr = myIDandISOScaleFactor[2]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
+
+			idSF_leg1 = leg1_muID_SF * leg1_muIso_SF;
+			idSF_leg1_muID_up = (leg1_muID_SF + leg1_muID_SFerr) * leg1_muIso_SF;
+			idSF_leg1_muID_down = (leg1_muID_SF - leg1_muID_SFerr) * leg1_muIso_SF;
+
+			idSF_leg1_muIso_up = leg1_muID_SF * (leg1_muIso_SF + leg1_muIso_SFerr);
+			idSF_leg1_muIso_down = leg1_muID_SF * (leg1_muIso_SF - leg1_muIso_SFerr);
+			}
+
+			else if (pType == 1) {
+				float leg1_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+				float leg1_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+
+				idSF_leg1 = leg1_eleID_SF;
+				idSF_leg1_eleID_up = leg1_eleID_SF + leg1_eleID_SFerr;
+				idSF_leg1_eleID_down = leg1_eleID_SF - leg1_eleID_SFerr;
+			}
 		}
-	  
+		else if(pType == 3) { //MuMu
+			// use absolute value of eta for muons, because the SFs are given from 0 to 2.4
+			float leg1_muID_SF = myIDandISOScaleFactor[0]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
+			float leg1_muID_SFerr = myIDandISOScaleFactor[0]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
+			float leg1_muIso_SF = myIDandISOScaleFactor[2]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
+			float leg1_muIso_SFerr = myIDandISOScaleFactor[2]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
+
+			idSF_leg1 = leg1_muID_SF * leg1_muIso_SF;
+			idSF_leg1_muID_up = (leg1_muID_SF + leg1_muID_SFerr) * leg1_muIso_SF;
+			idSF_leg1_muID_down = (leg1_muID_SF - leg1_muID_SFerr) * leg1_muIso_SF;
+
+			idSF_leg1_muIso_up = leg1_muID_SF * (leg1_muIso_SF + leg1_muIso_SFerr);
+			idSF_leg1_muIso_down = leg1_muID_SF * (leg1_muIso_SF - leg1_muIso_SFerr);
+
+			// use absolute value of eta for muons, because the SFs are given from 0 to 2.4
+			float leg2_muID_SF = myIDandISOScaleFactor[0]->get_ScaleFactor(leg2pt, fabs(leg2eta), pType);
+			float leg2_muID_SFerr = myIDandISOScaleFactor[0]->get_ScaleFactorError(leg2pt, fabs(leg2eta), pType);
+			float leg2_muIso_SF = myIDandISOScaleFactor[2]->get_ScaleFactor(leg2pt, fabs(leg2eta), pType);
+			float leg2_muIso_SFerr = myIDandISOScaleFactor[2]->get_ScaleFactorError(leg2pt, fabs(leg2eta), pType);
+
+			idSF_leg2 = leg2_muID_SF * leg2_muIso_SF;
+			idSF_leg2_muID_up = (leg2_muID_SF + leg2_muID_SFerr) * leg2_muIso_SF;
+			idSF_leg2_muID_down = (leg2_muID_SF - leg2_muID_SFerr) * leg2_muIso_SF;
+
+			idSF_leg2_muIso_up = leg2_muID_SF * (leg2_muIso_SF + leg2_muIso_SFerr);
+			idSF_leg2_muIso_down = leg2_muID_SF * (leg2_muIso_SF - leg2_muIso_SFerr);
+		}
+		else if(pType == 4) { //EleEle
+				float leg1_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+				float leg1_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+
+				idSF_leg1 = leg1_eleID_SF;
+				idSF_leg1_eleID_up = leg1_eleID_SF + leg1_eleID_SFerr;
+				idSF_leg1_eleID_down = leg1_eleID_SF - leg1_eleID_SFerr;
+
+				float leg2_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
+				float leg2_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
+
+				idSF_leg2 = leg2_eleID_SF;
+				idSF_leg2_eleID_up = leg2_eleID_SF + leg2_eleID_SFerr;
+				idSF_leg2_eleID_down = leg2_eleID_SF - leg2_eleID_SFerr;
+		}
+	  }
+
 	  Float_t idSF_leg1_deep_vsJet_2d_stat0_DM0_up				= idSF_leg1_deep_vsJet_2d;
 	  Float_t idSF_leg1_deep_vsJet_2d_stat0_DM0_down			= idSF_leg1_deep_vsJet_2d;
 	  Float_t idSF_leg1_deep_vsJet_2d_stat1_DM0_up				= idSF_leg1_deep_vsJet_2d;
@@ -2623,7 +2713,7 @@ int main (int argc, char** argv)
 	  Float_t idSF_leg1_deep_vsJet_2d_stat1gt140_down			= idSF_leg1_deep_vsJet_2d;
 	  Float_t idSF_leg1_deep_vsJet_2d_extrapgt140_up            = idSF_leg1_deep_vsJet_2d;
 	  Float_t idSF_leg1_deep_vsJet_2d_extrapgt140_down          = idSF_leg1_deep_vsJet_2d;
-		  
+
 	  Float_t idSF_leg2_deep_vsJet_2d_stat0_DM0_up				= idSF_leg2_deep_vsJet_2d;
 	  Float_t idSF_leg2_deep_vsJet_2d_stat0_DM0_down			= idSF_leg2_deep_vsJet_2d;
 	  Float_t idSF_leg2_deep_vsJet_2d_stat1_DM0_up				= idSF_leg2_deep_vsJet_2d;
@@ -2664,13 +2754,13 @@ int main (int argc, char** argv)
 	  Float_t idSF_leg2_deep_vsJet_2d_stat1gt140_down			= idSF_leg2_deep_vsJet_2d;
 	  Float_t idSF_leg2_deep_vsJet_2d_extrapgt140_up			= idSF_leg2_deep_vsJet_2d;
 	  Float_t idSF_leg2_deep_vsJet_2d_extrapgt140_down			= idSF_leg2_deep_vsJet_2d;
-	  
+
 	  // up and down variations of the ID and isolation of the first leg (only relevant when it is a tau)
 	  vector<float> idSF_leg1_deep_vsEle_up      (2, idSF_leg1_deep_vsEle);    // in bins of eta: barrel, endcap
 	  vector<float> idSF_leg1_deep_vsMu_up       (5, idSF_leg1_deep_vsMu);     // in bins of eta, edges at 0, 0.4, 0.8, 1.2, 1.7, infty
 	  vector<float> idSF_leg1_deep_vsEle_down    (2, idSF_leg1_deep_vsEle);    // in bins of eta: barrel, endcap
 	  vector<float> idSF_leg1_deep_vsMu_down     (5, idSF_leg1_deep_vsMu);     // in bins of eta, edges at 0, 0.4, 0.8, 1.2, 1.7, infty
-	  
+
 	  // only TauTau has a tau as the first leg
 	  if (isMC and pType==2) {	
 		for (int bin = 0; bin < (int) isthisEta_IDbin_first.size(); bin++) {
@@ -2821,24 +2911,6 @@ int main (int argc, char** argv)
 		idSF_leg2_deep_vsJet_2d_extrapgt140_up            = Deep_antiJet_2d->getSFvsDMandPT(leg2pt, tau2DM, tau2Genmatch, "Gt140ExtrapUp");
 		idSF_leg2_deep_vsJet_2d_extrapgt140_down          = Deep_antiJet_2d->getSFvsDMandPT(leg2pt, tau2DM, tau2Genmatch, "Gt140ExtrapDown");
 	  }
-	
-	  if (isMC) {
-		if (pType == 0 or pType == 3) {
-		  // use absolute value of eta for muons, because the SFs are given from 0 to 2.4
-		  idSF_leg1 = myIDandISOScaleFactor[0]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType) * myIDandISOScaleFactor[2]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
-		}
-		else if (pType == 1 or pType == 4) {
-		  idSF_leg1 = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
-		}
-	  }
-
-	  if(isMC and pType == 3) { //MuMu
-		// use absolute value of eta for muons, because the SFs are given from 0 to 2.4
-		idSF_leg2 = myIDandISOScaleFactor[0]->get_ScaleFactor(leg2pt, fabs(leg2eta), pType) * myIDandISOScaleFactor[2]->get_ScaleFactor(leg2pt, fabs(leg2eta), pType);
-	  }
-	  else if(isMC and pType == 4) { //EleEle
-		idSF_leg2 = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
-	  }
 
 	  float except_VsJet, except_vsMu, except_vsEle;
 	  // EleTau and MuTau
@@ -2850,7 +2922,8 @@ int main (int argc, char** argv)
 		  except_VsJet = idSF_leg1 * idSF_leg2_deep_vsEle    * idSF_leg2_deep_vsMu;
 		  except_vsMu  = idSF_leg1 * idSF_leg2_deep_vsJet_2d * idSF_leg2_deep_vsEle;
 		  except_vsEle = idSF_leg1 * idSF_leg2_deep_vsJet_2d * idSF_leg2_deep_vsMu;
-		
+		  float except_leg1 = idSF_leg2_deep_vsJet_2d * idSF_leg2_deep_vsEle * idSF_leg2_deep_vsMu;
+
 		  idFakeSF_deep_2d = except_VsJet * idSF_leg2_deep_vsJet_2d;
 
 		  idFakeSF_tauid_2d_stat0_DM0_up				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM0_up;
@@ -2893,7 +2966,7 @@ int main (int argc, char** argv)
 		  idFakeSF_tauid_2d_stat1gt140_down				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat1gt140_down;
 		  idFakeSF_tauid_2d_extrapgt140_up 		        = except_VsJet * idSF_leg2_deep_vsJet_2d_extrapgt140_up;
 		  idFakeSF_tauid_2d_extrapgt140_down	        = except_VsJet * idSF_leg2_deep_vsJet_2d_extrapgt140_down;
-		
+
 		  idFakeSF_mutauFR_etaLt0p4_up      = except_vsMu * idSF_leg2_deep_vsMu_up[0];
 		  idFakeSF_mutauFR_eta0p4to0p8_up   = except_vsMu * idSF_leg2_deep_vsMu_up[1];
 		  idFakeSF_mutauFR_eta0p8to1p2_up   = except_vsMu * idSF_leg2_deep_vsMu_up[2];
@@ -2904,11 +2977,30 @@ int main (int argc, char** argv)
 		  idFakeSF_mutauFR_eta0p8to1p2_down = except_vsMu * idSF_leg2_deep_vsMu_down[2];
 		  idFakeSF_mutauFR_eta1p2to1p7_down = except_vsMu * idSF_leg2_deep_vsMu_down[3];
 		  idFakeSF_mutauFR_etaGt1p7_down    = except_vsMu * idSF_leg2_deep_vsMu_down[4];
-	
+
 		  idFakeSF_etauFR_barrel_up		= except_vsEle * idSF_leg2_deep_vsEle_up[0];
 		  idFakeSF_etauFR_endcap_up		= except_vsEle * idSF_leg2_deep_vsEle_up[1];  
 		  idFakeSF_etauFR_barrel_down	= except_vsEle * idSF_leg2_deep_vsEle_down[0];
 		  idFakeSF_etauFR_endcap_down	= except_vsEle * idSF_leg2_deep_vsEle_down[1];
+
+		  if(pType==0){
+			idFakeSF_muID_up = except_leg1 * idSF_leg1_muID_up;
+			idFakeSF_muID_down = except_leg1 * idSF_leg1_muID_down;
+			idFakeSF_muIso_up = except_leg1 * idSF_leg1_muIso_up;
+			idFakeSF_muIso_down = except_leg1 * idSF_leg1_muIso_down;
+
+			idFakeSF_eleID_up = except_leg1 * idSF_leg1
+			idFakeSF_eleID_down = except_leg1 * idSF_leg1
+		  }
+		  else{
+			idFakeSF_muID_up = except_leg1 * idSF_leg1;
+			idFakeSF_muID_down = except_leg1 * idSF_leg1;
+			idFakeSF_muIso_up = except_leg1 * idSF_leg1;
+			idFakeSF_muIso_down = except_leg1 * idSF_leg1;
+
+			idFakeSF_eleID_up = except_leg1 * idSF_leg1_eleID_up;
+			idFakeSF_eleID_down = except_leg1 * idSF_leg1_eleID_down;
+		  }
 		}
 	  else if (isMC and pType == 2) // TauTau
 		{
@@ -2977,6 +3069,14 @@ int main (int argc, char** argv)
 		  idFakeSF_etauFR_endcap_up   = except_vsEle * idSF_leg1_deep_vsEle_up[1]   * idSF_leg2_deep_vsEle_up[1];
 		  idFakeSF_etauFR_barrel_down = except_vsEle * idSF_leg1_deep_vsEle_down[0] * idSF_leg2_deep_vsEle_down[0];
 		  idFakeSF_etauFR_endcap_down = except_vsEle * idSF_leg1_deep_vsEle_down[1] * idSF_leg2_deep_vsEle_down[1];
+
+		  idFakeSF_muID_up = idFakeSF_deep_2d;
+		  idFakeSF_muID_down = idFakeSF_deep_2d;
+		  idFakeSF_muIso_up = idFakeSF_deep_2d;
+		  idFakeSF_muIso_down = idFakeSF_deep_2d;
+
+		  idFakeSF_eleID_up = idFakeSF_deep_2d;
+		  idFakeSF_eleID_down = idFakeSF_deep_2d;
 		}
 	  else if(isMC and (pType == 3 or pType == 4))  // MuMu and EleEle channels
 		{
@@ -3059,6 +3159,14 @@ int main (int argc, char** argv)
 	  theSmallTree.m_idFakeSF_etauFR_endcap_up			= idFakeSF_etauFR_endcap_up;		
 	  theSmallTree.m_idFakeSF_etauFR_barrel_down		= idFakeSF_etauFR_barrel_down;		
 	  theSmallTree.m_idFakeSF_etauFR_endcap_down		= idFakeSF_etauFR_endcap_down;
+
+	  theSmallTree.m_idFakeSF_muID_up		= idFakeSF_muID_up;
+	  theSmallTree.m_idFakeSF_muID_down		= idFakeSF_muID_down;
+	  theSmallTree.m_idFakeSF_muIso_up		= idFakeSF_muIso_up;
+	  theSmallTree.m_idFakeSF_muIso_down	= idFakeSF_muIso_down;
+
+	  theSmallTree.m_idFakeSF_eleID_up		= idFakeSF_eleID_up;
+	  theSmallTree.m_idFakeSF_eleID_down	= idFakeSF_eleID_down;
 	  
 	  //Jet faking Tau SF
 	  //derived from WJet sideband: http://camendol.web.cern.ch/camendol/HH2017/plotsHH2017MuTau/31Oct2018_DYNLO_ctrlWJets_SS/antiB_jets30_tau30_SStight/

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -2940,7 +2940,7 @@ int main (int argc, char** argv)
 		idSF_leg2_deep_vsJet_2d_extrapgt140_down          = Deep_antiJet_2d->getSFvsDMandPT(leg2pt, tau2DM, tau2Genmatch, "Gt140ExtrapDown");
 	  }
 
-	  float except_VsJet, except_vsMu, except_vsEle;
+	  float except_VsJet, except_vsMu, except_vsEle, except_leg1;
 	  // EleTau and MuTau
 	  if (isMC and (pType == 0 or pType == 1))
 		{
@@ -2950,7 +2950,7 @@ int main (int argc, char** argv)
 		  except_VsJet = idSF_leg1 * idSF_leg2_deep_vsEle    * idSF_leg2_deep_vsMu;
 		  except_vsMu  = idSF_leg1 * idSF_leg2_deep_vsJet_2d * idSF_leg2_deep_vsEle;
 		  except_vsEle = idSF_leg1 * idSF_leg2_deep_vsJet_2d * idSF_leg2_deep_vsMu;
-		  float except_leg1 = idSF_leg2_deep_vsJet_2d * idSF_leg2_deep_vsEle * idSF_leg2_deep_vsMu;
+		  except_leg1 = idSF_leg2_deep_vsJet_2d * idSF_leg2_deep_vsEle * idSF_leg2_deep_vsMu;
 
 		  idFakeSF_deep_2d = except_VsJet * idSF_leg2_deep_vsJet_2d;
 

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -1571,8 +1571,6 @@ int main (int argc, char** argv)
 											theBigTree.daughters_pz->at (firstDaughterIndex),
 											theBigTree.daughters_e->at (firstDaughterIndex)
 											);
-	  // veto events with electrons in ECAL barrel-endcap transition region
-	  if((pairType == 1) && fabs(tlv_firstLepton.Eta()) > 1.44 && fabs(tlv_firstLepton.Eta()) < 1.57) continue;
 
 	  const TLorentzVector tlv_secondLepton (theBigTree.daughters_px->at (secondDaughterIndex),
 											 theBigTree.daughters_py->at (secondDaughterIndex),
@@ -2633,6 +2631,7 @@ int main (int argc, char** argv)
 			}
 
 			else if (pType == 1) {
+				//TODO: should be super cluster eta (not available in bigntuples at the moment)
 				float leg1_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
 				float leg1_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
 				float leg1_eleReco_SF = myIDandISOScaleFactor[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
@@ -2674,6 +2673,7 @@ int main (int argc, char** argv)
 			idSF_leg2_muIso_down = leg2_muID_SF * (leg2_muIso_SF - leg2_muIso_SFerr);
 		}
 		else if(pType == 4) { //EleEle
+				//TODO: should be super cluster eta (not available in bigntuples at the moment)
 				float leg1_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
 				float leg1_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
 				float leg1_eleReco_SF = myIDandISOScaleFactor[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
@@ -2686,6 +2686,7 @@ int main (int argc, char** argv)
 				idSF_leg1_eleReco_up = leg1_eleID_SF * (leg1_eleReco_SF + leg1_eleReco_SFerr);
 				idSF_leg1_eleReco_down = leg1_eleID_SF * (leg1_eleReco_SF - leg1_eleReco_SFerr);
 
+				//TODO: should be super cluster eta (not available in bigntuples at the moment)
 				float leg2_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
 				float leg2_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
 				float leg2_eleReco_SF = myIDandISOScaleFactor[3]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -610,41 +610,41 @@ int main (int argc, char** argv)
   }
     
   // electron/muon IdAndIso SF
-  ScaleFactor * lepSFs[4]; // [0: muID, 1: eleID, 2:muISO, 3:eleReco]
+  ScaleFactor * lepSFs[4]; // [0: muID, 1: muISO , 2:eleReco, 3:eleID]
   for (int i=0; i<4; i++) {
     lepSFs[i] = new ScaleFactor();
   }
   if (PERIOD == "2018") {
 	lepSFs[0]->init_ScaleFactor("weights/MuPogSF_UL/2018/Efficiencies_muon_generalTracks_Z_Run2018_UL_ID.root",
                                                "NUM_TightID_DEN_TrackerMuons_abseta_pt", true);
-	lepSFs[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi.txt_Ele_wp80iso_EGM2D.root", false);
-	lepSFs[2] -> init_ScaleFactor("weights/MuPogSF_UL/2018/Efficiencies_muon_generalTracks_Z_Run2018_UL_ISO.root",
+	lepSFs[1] -> init_ScaleFactor("weights/MuPogSF_UL/2018/Efficiencies_muon_generalTracks_Z_Run2018_UL_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
-	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi_ptAbove20.txt_EGM2D_UL2018.root", false);
+	lepSFs[2] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi_ptAbove20.txt_EGM2D_UL2018.root", false);
+	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi.txt_Ele_wp80iso_EGM2D.root", false);
   }
   else if (PERIOD == "2017") {
 	lepSFs[0] -> init_ScaleFactor("weights/MuPogSF_UL/2017/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.root",
 												 "NUM_TightID_DEN_TrackerMuons_abseta_pt", true);
-	lepSFs[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi.txt_EGM2D_MVA80iso_UL17.root", false);
-	lepSFs[2] -> init_ScaleFactor("weights/MuPogSF_UL/2017/Efficiencies_muon_generalTracks_Z_Run2017_UL_ISO.root",
+	lepSFs[1] -> init_ScaleFactor("weights/MuPogSF_UL/2017/Efficiencies_muon_generalTracks_Z_Run2017_UL_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
-	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi_ptAbove20.txt_EGM2D_UL2017.root", false);
+	lepSFs[2] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi_ptAbove20.txt_EGM2D_UL2017.root", false);
+	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi.txt_EGM2D_MVA80iso_UL17.root", false);
   }
   else if (PERIOD == "2016preVFP") {
 	lepSFs[0] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ID.root",
 												 "NUM_TightID_DEN_TrackerMuons_abseta_pt", true);
-	lepSFs[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi.txt_Ele_wp80iso_preVFP_EGM2D.root",false);
-	lepSFs[2] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ISO.root",
+	lepSFs[1] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
-	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptAbove20.txt_EGM2D_UL2016preVFP.root", false);
+	lepSFs[2] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptAbove20.txt_EGM2D_UL2016preVFP.root", false);
+	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi.txt_Ele_wp80iso_preVFP_EGM2D.root",false);
   }
   else if (PERIOD == "2016postVFP") {
 	lepSFs[0] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_ID.root",
 												 "NUM_TightID_DEN_TrackerMuons_abseta_pt", true);
-	lepSFs[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi.txt_Ele_wp80iso_postVFP_EGM2D.root", false);
-	lepSFs[2] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_ISO.root",
+	lepSFs[1] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
-	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptAbove20.txt_EGM2D_UL2016postVFP.root", false);
+	lepSFs[2] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptAbove20.txt_EGM2D_UL2016postVFP.root", false);
+	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi.txt_Ele_wp80iso_postVFP_EGM2D.root", false);
   }
   
   // tau IdAndIso SF
@@ -2619,8 +2619,8 @@ int main (int argc, char** argv)
 				// use absolute value of eta for muons, because the SFs are given from 0 to 2.4
 				float leg1_muID_SF = lepSFs[0]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
 				float leg1_muID_SFerr = lepSFs[0]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
-				float leg1_muIso_SF = lepSFs[2]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
-				float leg1_muIso_SFerr = lepSFs[2]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
+				float leg1_muIso_SF = lepSFs[1]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
+				float leg1_muIso_SFerr = lepSFs[1]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
 
 				idSF_leg1 = leg1_muID_SF * leg1_muIso_SF;
 				idSF_leg1_muID_up = (leg1_muID_SF + leg1_muID_SFerr) * leg1_muIso_SF;
@@ -2632,10 +2632,10 @@ int main (int argc, char** argv)
 
 			else if (pType == 1) {
 				//TODO: should be super cluster eta (not available in bigntuples at the moment)
-				float leg1_eleID_SF = lepSFs[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
-				float leg1_eleID_SFerr = lepSFs[1]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
-				float leg1_eleReco_SF = lepSFs[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
-				float leg1_eleReco_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+				float leg1_eleReco_SF = lepSFs[2]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+				float leg1_eleReco_SFerr = lepSFs[2]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+				float leg1_eleID_SF = lepSFs[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+				float leg1_eleID_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
 
 				idSF_leg1 = leg1_eleID_SF * leg1_eleReco_SF;
 				idSF_leg1_eleID_up = (leg1_eleID_SF + leg1_eleID_SFerr) * leg1_eleReco_SF;
@@ -2649,8 +2649,8 @@ int main (int argc, char** argv)
 			// use absolute value of eta for muons, because the SFs are given from 0 to 2.4
 			float leg1_muID_SF = lepSFs[0]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
 			float leg1_muID_SFerr = lepSFs[0]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
-			float leg1_muIso_SF = lepSFs[2]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
-			float leg1_muIso_SFerr = lepSFs[2]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
+			float leg1_muIso_SF = lepSFs[1]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
+			float leg1_muIso_SFerr = lepSFs[1]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
 
 			idSF_leg1 = leg1_muID_SF * leg1_muIso_SF;
 			idSF_leg1_muID_up = (leg1_muID_SF + leg1_muID_SFerr) * leg1_muIso_SF;
@@ -2662,8 +2662,8 @@ int main (int argc, char** argv)
 			// use absolute value of eta for muons, because the SFs are given from 0 to 2.4
 			float leg2_muID_SF = lepSFs[0]->get_ScaleFactor(leg2pt, fabs(leg2eta), pType);
 			float leg2_muID_SFerr = lepSFs[0]->get_ScaleFactorError(leg2pt, fabs(leg2eta), pType);
-			float leg2_muIso_SF = lepSFs[2]->get_ScaleFactor(leg2pt, fabs(leg2eta), pType);
-			float leg2_muIso_SFerr = lepSFs[2]->get_ScaleFactorError(leg2pt, fabs(leg2eta), pType);
+			float leg2_muIso_SF = lepSFs[1]->get_ScaleFactor(leg2pt, fabs(leg2eta), pType);
+			float leg2_muIso_SFerr = lepSFs[1]->get_ScaleFactorError(leg2pt, fabs(leg2eta), pType);
 
 			idSF_leg2 = leg2_muID_SF * leg2_muIso_SF;
 			idSF_leg2_muID_up = (leg2_muID_SF + leg2_muID_SFerr) * leg2_muIso_SF;
@@ -2674,10 +2674,10 @@ int main (int argc, char** argv)
 		}
 		else if(pType == 4) { //EleEle
 			//TODO: should be super cluster eta (not available in bigntuples at the moment)
-			float leg1_eleID_SF = lepSFs[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
-			float leg1_eleID_SFerr = lepSFs[1]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
-			float leg1_eleReco_SF = lepSFs[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
-			float leg1_eleReco_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+			float leg1_eleReco_SF = lepSFs[2]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+			float leg1_eleReco_SFerr = lepSFs[2]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+			float leg1_eleID_SF = lepSFs[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+			float leg1_eleID_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
 
 			idSF_leg1 = leg1_eleID_SF;
 			idSF_leg1_eleID_up = leg1_eleID_SF + leg1_eleID_SFerr;
@@ -2687,10 +2687,10 @@ int main (int argc, char** argv)
 			idSF_leg1_eleReco_down = leg1_eleID_SF * (leg1_eleReco_SF - leg1_eleReco_SFerr);
 
 			//TODO: should be super cluster eta (not available in bigntuples at the moment)
-			float leg2_eleID_SF = lepSFs[1]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
-			float leg2_eleID_SFerr = lepSFs[1]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
-			float leg2_eleReco_SF = lepSFs[3]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
-			float leg2_eleReco_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
+			float leg2_eleReco_SF = lepSFs[2]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
+			float leg2_eleReco_SFerr = lepSFs[2]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
+			float leg2_eleID_SF = lepSFs[3]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
+			float leg2_eleID_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
 
 			idSF_leg2 = leg2_eleID_SF;
 			idSF_leg2_eleID_up = leg2_eleID_SF + leg2_eleID_SFerr;

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -610,8 +610,8 @@ int main (int argc, char** argv)
   }
     
   // electron/muon IdAndIso SF
-  ScaleFactor * myIDandISOScaleFactor[3]; // [0: muID, 1: eleID, 2:muISO,]
-  for (int i=0; i<3; i++) {
+  ScaleFactor * myIDandISOScaleFactor[3]; // [0: muID, 1: eleID, 2:muISO, 3:eleReco]
+  for (int i=0; i<4; i++) {
     myIDandISOScaleFactor[i] = new ScaleFactor();
   }
   if (PERIOD == "2018") {
@@ -620,6 +620,7 @@ int main (int argc, char** argv)
 	myIDandISOScaleFactor[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi.txt_Ele_wp80iso_EGM2D.root", false);
 	myIDandISOScaleFactor[2] -> init_ScaleFactor("weights/MuPogSF_UL/2018/Efficiencies_muon_generalTracks_Z_Run2018_UL_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
+	myIDandISOScaleFactor[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi_ptAbove20.txt_EGM2D_UL2018.root", false);
   }
   else if (PERIOD == "2017") {
 	myIDandISOScaleFactor[0] -> init_ScaleFactor("weights/MuPogSF_UL/2017/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.root",
@@ -627,6 +628,7 @@ int main (int argc, char** argv)
 	myIDandISOScaleFactor[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi.txt_EGM2D_MVA80iso_UL17.root", false);
 	myIDandISOScaleFactor[2] -> init_ScaleFactor("weights/MuPogSF_UL/2017/Efficiencies_muon_generalTracks_Z_Run2017_UL_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
+	myIDandISOScaleFactor[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi_ptAbove20.txt_EGM2D_UL2017.root", false);
   }
   else if (PERIOD == "2016preVFP") {
 	myIDandISOScaleFactor[0] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ID.root",
@@ -634,6 +636,7 @@ int main (int argc, char** argv)
 	myIDandISOScaleFactor[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi.txt_Ele_wp80iso_preVFP_EGM2D.root",false);
 	myIDandISOScaleFactor[2] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
+	myIDandISOScaleFactor[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptAbove20.txt_EGM2D_UL2016preVFP.root", false);
   }
   else if (PERIOD == "2016postVFP") {
 	myIDandISOScaleFactor[0] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_ID.root",
@@ -641,6 +644,7 @@ int main (int argc, char** argv)
 	myIDandISOScaleFactor[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi.txt_Ele_wp80iso_postVFP_EGM2D.root", false);
 	myIDandISOScaleFactor[2] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
+	myIDandISOScaleFactor[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptAbove20.txt_EGM2D_UL2016postVFP.root", false);
   }
   
   // tau IdAndIso SF
@@ -2504,6 +2508,8 @@ int main (int argc, char** argv)
 
 	  float idFakeSF_eleID_up = -99.0;
 	  float idFakeSF_eleID_down = -99.0;
+	  float idFakeSF_eleReco_up = -99.0;
+	  float idFakeSF_eleReco_down = -99.0;
 
 	  // bool helpers for tauID syst bins
 	  vector<bool> isthisPt_IDbin_first = { // 20, 25, 30, 35, 40, infty
@@ -2573,6 +2579,8 @@ int main (int argc, char** argv)
 
 	  float idSF_leg1_eleID_up      = -99.f;
 	  float idSF_leg1_eleID_down    = -99.f;
+	  float idSF_leg1_eleReco_up	= -99.f;
+	  float idSF_leg1_eleReco_down	= -99.f;
 
 	  float idSF_leg2_muID_up       = -99.f;
 	  float idSF_leg2_muID_down     = -99.f;
@@ -2581,6 +2589,8 @@ int main (int argc, char** argv)
 
 	  float idSF_leg2_eleID_up      = -99.f;
 	  float idSF_leg2_eleID_down    = -99.f;
+	  float idSF_leg2_eleReco_up	= -99.f;
+	  float idSF_leg2_eleReco_down	= -99.f;
 
 	  bool isFakeJet1 = true;
 	  bool isFakeJet2 = true;
@@ -2623,10 +2633,15 @@ int main (int argc, char** argv)
 			else if (pType == 1) {
 				float leg1_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
 				float leg1_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+				float leg1_eleReco_SF = myIDandISOScaleFactor[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+				float leg1_eleReco_SFerr = myIDandISOScaleFactor[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
 
-				idSF_leg1 = leg1_eleID_SF;
-				idSF_leg1_eleID_up = leg1_eleID_SF + leg1_eleID_SFerr;
-				idSF_leg1_eleID_down = leg1_eleID_SF - leg1_eleID_SFerr;
+				idSF_leg1 = leg1_eleID_SF * leg1_eleReco_SF;
+				idSF_leg1_eleID_up = (leg1_eleID_SF + leg1_eleID_SFerr) * leg1_eleReco_SF;
+				idSF_leg1_eleID_down = (leg1_eleID_SF - leg1_eleID_SFerr) * leg1_eleReco_SF;
+
+				idSF_leg1_eleReco_up = leg1_eleID_SF * (leg1_eleReco_SF + leg1_eleReco_SFerr);
+				idSF_leg1_eleReco_down = leg1_eleID_SF * (leg1_eleReco_SF - leg1_eleReco_SFerr);
 			}
 		}
 		else if(pType == 3) { //MuMu
@@ -2659,17 +2674,27 @@ int main (int argc, char** argv)
 		else if(pType == 4) { //EleEle
 				float leg1_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
 				float leg1_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+				float leg1_eleReco_SF = myIDandISOScaleFactor[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+				float leg1_eleReco_SFerr = myIDandISOScaleFactor[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
 
 				idSF_leg1 = leg1_eleID_SF;
 				idSF_leg1_eleID_up = leg1_eleID_SF + leg1_eleID_SFerr;
 				idSF_leg1_eleID_down = leg1_eleID_SF - leg1_eleID_SFerr;
 
+				idSF_leg1_eleReco_up = leg1_eleID_SF * (leg1_eleReco_SF + leg1_eleReco_SFerr);
+				idSF_leg1_eleReco_down = leg1_eleID_SF * (leg1_eleReco_SF - leg1_eleReco_SFerr);
+
 				float leg2_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
 				float leg2_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
+				float leg2_eleReco_SF = myIDandISOScaleFactor[3]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
+				float leg2_eleReco_SFerr = myIDandISOScaleFactor[3]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
 
 				idSF_leg2 = leg2_eleID_SF;
 				idSF_leg2_eleID_up = leg2_eleID_SF + leg2_eleID_SFerr;
 				idSF_leg2_eleID_down = leg2_eleID_SF - leg2_eleID_SFerr;
+
+				idSF_leg2_eleReco_up = leg2_eleID_SF * (leg2_eleReco_SF + leg2_eleReco_SFerr);
+				idSF_leg2_eleReco_down = leg2_eleID_SF * (leg2_eleReco_SF - leg2_eleReco_SFerr);
 		}
 	  }
 
@@ -2989,8 +3014,10 @@ int main (int argc, char** argv)
 			idFakeSF_muIso_up = except_leg1 * idSF_leg1_muIso_up;
 			idFakeSF_muIso_down = except_leg1 * idSF_leg1_muIso_down;
 
-			idFakeSF_eleID_up = except_leg1 * idSF_leg1
-			idFakeSF_eleID_down = except_leg1 * idSF_leg1
+			idFakeSF_eleID_up = except_leg1 * idSF_leg1;
+			idFakeSF_eleID_down = except_leg1 * idSF_leg1;
+			idFakeSF_eleReco_up = except_leg1 * idSF_leg1;
+			idFakeSF_eleReco_down = except_leg1 * idSF_leg1;
 		  }
 		  else{
 			idFakeSF_muID_up = except_leg1 * idSF_leg1;
@@ -3000,6 +3027,8 @@ int main (int argc, char** argv)
 
 			idFakeSF_eleID_up = except_leg1 * idSF_leg1_eleID_up;
 			idFakeSF_eleID_down = except_leg1 * idSF_leg1_eleID_down;
+			idFakeSF_eleReco_up = except_leg1 * idSF_leg1_eleReco_up;
+			idFakeSF_eleReco_down = except_leg1 * idSF_leg1_eleReco_down;
 		  }
 		}
 	  else if (isMC and pType == 2) // TauTau
@@ -3077,6 +3106,8 @@ int main (int argc, char** argv)
 
 		  idFakeSF_eleID_up = idFakeSF_deep_2d;
 		  idFakeSF_eleID_down = idFakeSF_deep_2d;
+		  idFakeSF_eleReco_up = idFakeSF_deep_2d;
+		  idFakeSF_eleReco_down = idFakeSF_deep_2d;
 		}
 	  else if(isMC and (pType == 3 or pType == 4))  // MuMu and EleEle channels
 		{
@@ -3167,6 +3198,8 @@ int main (int argc, char** argv)
 
 	  theSmallTree.m_idFakeSF_eleID_up		= idFakeSF_eleID_up;
 	  theSmallTree.m_idFakeSF_eleID_down	= idFakeSF_eleID_down;
+	  theSmallTree.m_idFakeSF_eleReco_up	= idFakeSF_eleReco_up;
+	  theSmallTree.m_idFakeSF_eleReco_down	= idFakeSF_eleReco_down;
 	  
 	  //Jet faking Tau SF
 	  //derived from WJet sideband: http://camendol.web.cern.ch/camendol/HH2017/plotsHH2017MuTau/31Oct2018_DYNLO_ctrlWJets_SS/antiB_jets30_tau30_SStight/

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -4039,7 +4039,7 @@ int main (int argc, char** argv)
 			  // Fra Mar2020: for electron, we check (mvaEleID-Fall17-iso-V2-wp90 OR (mvaEleID-Fall17-noIso-V2-wp90 AND pfRelIso < 0.3))
 			  if (DEBUG) std::cout << "--- Debug for extra electrons:" << std::endl;
 			  bool passIsoMVA = oph.eleBaseline(&theBigTree, iLep, 10., eleEtaMax, 0.3,
-												OfflineProducerHelper::EMVAMedium, string("Vertex-LepID-pTMin-etaMax"), (DEBUG ? true : false));
+												OfflineProducerHelper::EMVAMedium, string("Vertex-LepID-pTMin-etaMax-etaGapVeto"), (DEBUG ? true : false));
 			  //bool passNonIsoMVA = oph.eleBaseline (&theBigTree, iLep, 10., eleEtaMax, 0.3,
 			  //                     OfflineProducerHelper::EMVAMedium, string("Vertex-pTMin-etaMax-thirdLep"), (DEBUG ? true : false));
 			  if (!passIsoMVA) // if it passes --> the "if" is false and the lepton is saved as an extra lepton

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -2632,6 +2632,7 @@ int main (int argc, char** argv)
 
 				idSF_leg1_muIso_up = leg1_muID_SF * (leg1_muIso_SF + leg1_muIso_SFerr);
 				idSF_leg1_muIso_down = leg1_muID_SF * (leg1_muIso_SF - leg1_muIso_SFerr);
+
 			}
 
 			else if (pType == 1) {
@@ -2685,6 +2686,15 @@ int main (int argc, char** argv)
 
 			idSF_leg2_muIso_up = leg2_muID_SF * (leg2_muIso_SF + leg2_muIso_SFerr);
 			idSF_leg2_muIso_down = leg2_muID_SF * (leg2_muIso_SF - leg2_muIso_SFerr);
+
+			idSF_leg2_eleID_up = idSF_leg2;
+			idSF_leg2_eleID_down = idSF_leg2;
+
+			idSF_leg2_eleReco_up = idSF_leg2;
+			idSF_leg2_eleReco_down = idSF_leg2;
+
+			idSF_leg1_deep_vsJet_2d = idSF_leg1;
+			idSF_leg2_deep_vsJet_2d = idSF_leg2;
 		}
 		else if(pType == 4) { //EleEle
 			//TODO: should be super cluster eta (not available in bigntuples at the moment)
@@ -2728,11 +2738,21 @@ int main (int argc, char** argv)
 			float leg2_eleID_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
 
 			idSF_leg2 = leg2_eleID_SF;
+
+			idSF_leg2_muID_up = idSF_leg2;
+			idSF_leg2_muID_down = idSF_leg2;
+
+			idSF_leg2_muIso_up = idSF_leg2;
+			idSF_leg2_muIso_down = idSF_leg2;
+
 			idSF_leg2_eleID_up = leg2_eleReco_SF * (leg2_eleID_SF + leg2_eleID_SFerr);
 			idSF_leg2_eleID_down = leg2_eleReco_SF * (leg2_eleID_SF - leg2_eleID_SFerr);
 
 			idSF_leg2_eleReco_up = (leg2_eleReco_SF + leg2_eleReco_SFerr) * leg2_eleID_SF;
 			idSF_leg2_eleReco_down = (leg2_eleReco_SF - leg2_eleReco_SFerr) * leg2_eleID_SF;
+
+			idSF_leg1_deep_vsJet_2d = idSF_leg1;
+			idSF_leg2_deep_vsJet_2d = idSF_leg2;
 		}
 	  }
 
@@ -2825,7 +2845,7 @@ int main (int argc, char** argv)
 	  vector<float> idSF_leg1_deep_vsMu_down     (5, idSF_leg1_deep_vsMu);     // in bins of eta, edges at 0, 0.4, 0.8, 1.2, 1.7, infty
 
 	  // only TauTau has a tau as the first leg
-	  if (isMC and pType==2) {	
+	  if (isMC and pType==2) {
 		for (int bin = 0; bin < (int) isthisEta_IDbin_first.size(); bin++) {
 		  if (isthisEta_IDbin_first[bin])
 			{
@@ -3150,6 +3170,73 @@ int main (int argc, char** argv)
 	  else if(isMC and (pType == 3 or pType == 4))  // MuMu and EleEle channels
 		{
 		  idSF_deep_2d = dauSFs = idSF_leg1 * idSF_leg2;
+
+		  dauSFs_tauid_2d_stat0_DM0_up = dauSFs;
+		  dauSFs_tauid_2d_stat0_DM0_down = dauSFs;
+		  dauSFs_tauid_2d_stat1_DM0_up = dauSFs;
+		  dauSFs_tauid_2d_stat1_DM0_down = dauSFs;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM0_up = dauSFs;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM0_down = dauSFs;
+
+		  dauSFs_tauid_2d_stat0_DM1_up = dauSFs;
+		  dauSFs_tauid_2d_stat0_DM1_down = dauSFs;
+		  dauSFs_tauid_2d_stat1_DM1_up = dauSFs;
+		  dauSFs_tauid_2d_stat1_DM1_down = dauSFs;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM1_up = dauSFs;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM1_down = dauSFs;
+
+		  dauSFs_tauid_2d_stat0_DM10_up = dauSFs;
+		  dauSFs_tauid_2d_stat0_DM10_down = dauSFs;
+		  dauSFs_tauid_2d_stat1_DM10_up = dauSFs;
+		  dauSFs_tauid_2d_stat1_DM10_down = dauSFs;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM10_up = dauSFs;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM10_down = dauSFs;
+
+		  dauSFs_tauid_2d_stat0_DM11_up = dauSFs;
+		  dauSFs_tauid_2d_stat0_DM11_down = dauSFs;
+		  dauSFs_tauid_2d_stat1_DM11_up = dauSFs;
+		  dauSFs_tauid_2d_stat1_DM11_down = dauSFs;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM11_up = dauSFs;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM11_down = dauSFs;
+
+		  dauSFs_tauid_2d_systcorrdmeras_up = dauSFs;
+		  dauSFs_tauid_2d_systcorrdmeras_down = dauSFs;
+		  dauSFs_tauid_2d_systcorrdmuncorreras_up = dauSFs;
+		  dauSFs_tauid_2d_systcorrdmuncorreras_down	= dauSFs;
+		  dauSFs_tauid_2d_systcorrerasgt140_up = dauSFs;
+		  dauSFs_tauid_2d_systcorrerasgt140_down = dauSFs;
+		  dauSFs_tauid_2d_stat0gt140_up = dauSFs;
+		  dauSFs_tauid_2d_stat0gt140_down = dauSFs;
+		  dauSFs_tauid_2d_stat1gt140_up = dauSFs;
+		  dauSFs_tauid_2d_stat1gt140_down = dauSFs;
+		  dauSFs_tauid_2d_extrapgt140_up = dauSFs;
+		  dauSFs_tauid_2d_extrapgt140_down = dauSFs;
+
+		  dauSFs_mutauFR_etaLt0p4_up = dauSFs;
+		  dauSFs_mutauFR_eta0p4to0p8_up = dauSFs;
+		  dauSFs_mutauFR_eta0p8to1p2_up = dauSFs;
+		  dauSFs_mutauFR_eta1p2to1p7_up = dauSFs;
+		  dauSFs_mutauFR_etaGt1p7_up = dauSFs;
+		  dauSFs_mutauFR_etaLt0p4_down = dauSFs;
+		  dauSFs_mutauFR_eta0p4to0p8_down = dauSFs;
+		  dauSFs_mutauFR_eta0p8to1p2_down = dauSFs;
+		  dauSFs_mutauFR_eta1p2to1p7_down = dauSFs;
+		  dauSFs_mutauFR_etaGt1p7_down = dauSFs;
+
+		  dauSFs_etauFR_barrel_up = dauSFs;
+		  dauSFs_etauFR_endcap_up = dauSFs;
+		  dauSFs_etauFR_barrel_down = dauSFs;
+		  dauSFs_etauFR_endcap_down = dauSFs;
+
+		  dauSFs_muID_up = idSF_leg1_muID_up * idSF_leg2_muID_up;
+		  dauSFs_muID_down = idSF_leg1_muID_down * idSF_leg2_muID_down;
+		  dauSFs_muIso_up = idSF_leg1_muIso_up * idSF_leg2_muIso_up;
+		  dauSFs_muIso_down = idSF_leg1_muIso_down * idSF_leg2_muIso_down;
+
+		  dauSFs_eleID_up = idSF_leg1_eleID_up * idSF_leg2_eleID_up;
+		  dauSFs_eleID_down = idSF_leg1_eleID_down * idSF_leg2_eleID_down;
+		  dauSFs_eleReco_up = idSF_leg1_eleReco_up * idSF_leg2_eleReco_up;
+		  dauSFs_eleReco_down = idSF_leg1_eleReco_down * idSF_leg2_eleReco_down;
 		}
 	  
 	  if (DEBUG) {

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -2440,76 +2440,76 @@ int main (int argc, char** argv)
 	  // Still preliminary:
 	  // DeepTauVSele: https://indico.cern.ch/event/865792/contributions/3659828/attachments/1954858/3246751/ETauFR-update2Dec.pdf
 	  // DeepTauVSmu : https://indico.cern.ch/event/866243/contributions/3650016/attachments/1950974/3238736/mutauFRRun2_Yiwen_20191121.pdf
-	  float idSF_deep_2d		= -99.0;  // use this for DeepTauV2p1 DM and pT dependent
-	  float idFakeSF_deep_2d	= -99.0;	// use this for DeepTauV2p1 pt dependent + e/mu->tauh fake SF
-	  float fakeRateSF_deep		= -99.0;  // use this for e/mu->tauh fake SF DeepTau
+	  float idSF_deep_2d = -99.f;  // use this for DeepTauV2p1 DM and pT dependent
+	  float dauSFs = -99.f;	// use this for DeepTauV2p1 pt dependent + e/mu->tauh fake SF
+	  float fakeRateSF_deep = -99.f;  // use this for e/mu->tauh fake SF DeepTau
 
-	  float idFakeSF_tauid_2d_stat0_DM0_up				= -99.f;
-	  float idFakeSF_tauid_2d_stat0_DM0_down			= -99.f;				  
-	  float idFakeSF_tauid_2d_stat1_DM0_up				= -99.f;					
-	  float idFakeSF_tauid_2d_stat1_DM0_down			= -99.f;				  
-	  float idFakeSF_tauid_2d_systuncorrdmeras_DM0_up	= -99.f;
-	  float idFakeSF_tauid_2d_systuncorrdmeras_DM0_down	= -99.f;
+	  float dauSFs_tauid_2d_stat0_DM0_up = -99.f;
+	  float dauSFs_tauid_2d_stat0_DM0_down = -99.f;
+	  float dauSFs_tauid_2d_stat1_DM0_up = -99.f;
+	  float dauSFs_tauid_2d_stat1_DM0_down = -99.f;
+	  float dauSFs_tauid_2d_systuncorrdmeras_DM0_up = -99.f;
+	  float dauSFs_tauid_2d_systuncorrdmeras_DM0_down = -99.f;
 
-	  float idFakeSF_tauid_2d_stat0_DM1_up				= -99.f;
-	  float idFakeSF_tauid_2d_stat0_DM1_down			= -99.f;				  
-	  float idFakeSF_tauid_2d_stat1_DM1_up				= -99.f;					
-	  float idFakeSF_tauid_2d_stat1_DM1_down			= -99.f;				  
-	  float idFakeSF_tauid_2d_systuncorrdmeras_DM1_up   = -99.f;
-	  float idFakeSF_tauid_2d_systuncorrdmeras_DM1_down	= -99.f;	   
+	  float dauSFs_tauid_2d_stat0_DM1_up = -99.f;
+	  float dauSFs_tauid_2d_stat0_DM1_down = -99.f;
+	  float dauSFs_tauid_2d_stat1_DM1_up = -99.f;
+	  float dauSFs_tauid_2d_stat1_DM1_down = -99.f;
+	  float dauSFs_tauid_2d_systuncorrdmeras_DM1_up = -99.f;
+	  float dauSFs_tauid_2d_systuncorrdmeras_DM1_down = -99.f;
 
-	  float idFakeSF_tauid_2d_stat0_DM10_up				 = -99.f;
-	  float idFakeSF_tauid_2d_stat0_DM10_down			 = -99.f;				  
-	  float idFakeSF_tauid_2d_stat1_DM10_up				 = -99.f;					
-	  float idFakeSF_tauid_2d_stat1_DM10_down			 = -99.f;				  
-	  float idFakeSF_tauid_2d_systuncorrdmeras_DM10_up   = -99.f;
-	  float idFakeSF_tauid_2d_systuncorrdmeras_DM10_down = -99.f;	   
+	  float dauSFs_tauid_2d_stat0_DM10_up = -99.f;
+	  float dauSFs_tauid_2d_stat0_DM10_down = -99.f;
+	  float dauSFs_tauid_2d_stat1_DM10_up = -99.f;
+	  float dauSFs_tauid_2d_stat1_DM10_down = -99.f;
+	  float dauSFs_tauid_2d_systuncorrdmeras_DM10_up = -99.f;
+	  float dauSFs_tauid_2d_systuncorrdmeras_DM10_down = -99.f;
 
-	  float idFakeSF_tauid_2d_stat0_DM11_up				 = -99.f;
-	  float idFakeSF_tauid_2d_stat0_DM11_down			 = -99.f;				  
-	  float idFakeSF_tauid_2d_stat1_DM11_up				 = -99.f;					
-	  float idFakeSF_tauid_2d_stat1_DM11_down			 = -99.f;				  
-	  float idFakeSF_tauid_2d_systuncorrdmeras_DM11_up   = -99.f;
-	  float idFakeSF_tauid_2d_systuncorrdmeras_DM11_down = -99.f;	   
+	  float dauSFs_tauid_2d_stat0_DM11_up = -99.f;
+	  float dauSFs_tauid_2d_stat0_DM11_down = -99.f;
+	  float dauSFs_tauid_2d_stat1_DM11_up = -99.f;
+	  float dauSFs_tauid_2d_stat1_DM11_down = -99.f;
+	  float dauSFs_tauid_2d_systuncorrdmeras_DM11_up = -99.f;
+	  float dauSFs_tauid_2d_systuncorrdmeras_DM11_down = -99.f;
 
-	  float idFakeSF_tauid_2d_systcorrdmeras_up			= -99.f;		   
-	  float idFakeSF_tauid_2d_systcorrdmeras_down		= -99.f;		 
-	  float idFakeSF_tauid_2d_systcorrdmuncorreras_up	= -99.f;	 
-	  float idFakeSF_tauid_2d_systcorrdmuncorreras_down	= -99.f; 
-	  float idFakeSF_tauid_2d_systcorrerasgt140_up      = -99.f;
-	  float idFakeSF_tauid_2d_systcorrerasgt140_down	= -99.f;
-	  float idFakeSF_tauid_2d_stat0gt140_up				= -99.f;
-	  float idFakeSF_tauid_2d_stat0gt140_down			= -99.f;
-	  float idFakeSF_tauid_2d_stat1gt140_up				= -99.f;
-	  float idFakeSF_tauid_2d_stat1gt140_down			= -99.f;
-	  float idFakeSF_tauid_2d_extrapgt140_up     		= -99.f;
-	  float idFakeSF_tauid_2d_extrapgt140_down     		= -99.f;
+	  float dauSFs_tauid_2d_systcorrdmeras_up = -99.f;
+	  float dauSFs_tauid_2d_systcorrdmeras_down = -99.f;
+	  float dauSFs_tauid_2d_systcorrdmuncorreras_up = -99.f;
+	  float dauSFs_tauid_2d_systcorrdmuncorreras_down = -99.f;
+	  float dauSFs_tauid_2d_systcorrerasgt140_up = -99.f;
+	  float dauSFs_tauid_2d_systcorrerasgt140_down = -99.f;
+	  float dauSFs_tauid_2d_stat0gt140_up = -99.f;
+	  float dauSFs_tauid_2d_stat0gt140_down = -99.f;
+	  float dauSFs_tauid_2d_stat1gt140_up = -99.f;
+	  float dauSFs_tauid_2d_stat1gt140_down = -99.f;
+	  float dauSFs_tauid_2d_extrapgt140_up = -99.f;
+	  float dauSFs_tauid_2d_extrapgt140_down = -99.f;
 	
-	  float idFakeSF_mutauFR_etaLt0p4_up      = -99.0;
-	  float idFakeSF_mutauFR_eta0p4to0p8_up   = -99.0;
-	  float idFakeSF_mutauFR_eta0p8to1p2_up   = -99.0;
-	  float idFakeSF_mutauFR_eta1p2to1p7_up   = -99.0;
-	  float idFakeSF_mutauFR_etaGt1p7_up      = -99.0;
-	  float idFakeSF_mutauFR_etaLt0p4_down    = -99.0;
-	  float idFakeSF_mutauFR_eta0p4to0p8_down = -99.0;
-	  float idFakeSF_mutauFR_eta0p8to1p2_down = -99.0;
-	  float idFakeSF_mutauFR_eta1p2to1p7_down = -99.0;
-	  float idFakeSF_mutauFR_etaGt1p7_down    = -99.0;
+	  float dauSFs_mutauFR_etaLt0p4_up = -99.f;
+	  float dauSFs_mutauFR_eta0p4to0p8_up = -99.f;
+	  float dauSFs_mutauFR_eta0p8to1p2_up = -99.f;
+	  float dauSFs_mutauFR_eta1p2to1p7_up = -99.f;
+	  float dauSFs_mutauFR_etaGt1p7_up = -99.f;
+	  float dauSFs_mutauFR_etaLt0p4_down = -99.f;
+	  float dauSFs_mutauFR_eta0p4to0p8_down = -99.f;
+	  float dauSFs_mutauFR_eta0p8to1p2_down = -99.f;
+	  float dauSFs_mutauFR_eta1p2to1p7_down = -99.f;
+	  float dauSFs_mutauFR_etaGt1p7_down = -99.f;
 
-	  float idFakeSF_etauFR_barrel_up   = -99.0;
-	  float idFakeSF_etauFR_endcap_up   = -99.0;
-	  float idFakeSF_etauFR_barrel_down = -99.0;
-	  float idFakeSF_etauFR_endcap_down = -99.0;
+	  float dauSFs_etauFR_barrel_up = -99.f;
+	  float dauSFs_etauFR_endcap_up = -99.f;
+	  float dauSFs_etauFR_barrel_down = -99.f;
+	  float dauSFs_etauFR_endcap_down = -99.f;
 
-	  float idFakeSF_muID_up = -99.0;
-	  float idFakeSF_muID_down = -99.0;
-	  float idFakeSF_muIso_up = -99.0;
-	  float idFakeSF_muIso_down = -99.0;
+	  float dauSFs_muID_up = -99.f;
+	  float dauSFs_muID_down = -99.f;
+	  float dauSFs_muIso_up = -99.f;
+	  float dauSFs_muIso_down = -99.f;
 
-	  float idFakeSF_eleID_up = -99.0;
-	  float idFakeSF_eleID_down = -99.0;
-	  float idFakeSF_eleReco_up = -99.0;
-	  float idFakeSF_eleReco_down = -99.0;
+	  float dauSFs_eleID_up = -99.f;
+	  float dauSFs_eleID_down = -99.f;
+	  float dauSFs_eleReco_up = -99.f;
+	  float dauSFs_eleReco_down = -99.f;
 
 	  // bool helpers for tauID syst bins
 	  vector<bool> isthisPt_IDbin_first = { // 20, 25, 30, 35, 40, infty
@@ -2947,180 +2947,180 @@ int main (int argc, char** argv)
 		  idSF_deep_2d = idSF_leg1 * idSF_leg2_deep_vsJet_2d;
 		  fakeRateSF_deep = idSF_leg2_deep_vsEle * idSF_leg2_deep_vsMu;
 
-		  except_VsJet = idSF_leg1 * idSF_leg2_deep_vsEle    * idSF_leg2_deep_vsMu;
+		  except_VsJet = idSF_leg1 * idSF_leg2_deep_vsEle * idSF_leg2_deep_vsMu;
 		  except_vsMu  = idSF_leg1 * idSF_leg2_deep_vsJet_2d * idSF_leg2_deep_vsEle;
 		  except_vsEle = idSF_leg1 * idSF_leg2_deep_vsJet_2d * idSF_leg2_deep_vsMu;
 		  except_leg1 = idSF_leg2_deep_vsJet_2d * idSF_leg2_deep_vsEle * idSF_leg2_deep_vsMu;
 
-		  idFakeSF_deep_2d = except_VsJet * idSF_leg2_deep_vsJet_2d;
+		  dauSFs = except_VsJet * idSF_leg2_deep_vsJet_2d;
 
-		  idFakeSF_tauid_2d_stat0_DM0_up				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM0_up;
-		  idFakeSF_tauid_2d_stat0_DM0_down				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM0_down;
-		  idFakeSF_tauid_2d_stat1_DM0_up				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM0_up;
-		  idFakeSF_tauid_2d_stat1_DM0_down				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM0_down;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM0_up		= except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM0_up;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM0_down	= except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM0_down;
+		  dauSFs_tauid_2d_stat0_DM0_up = except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM0_up;
+		  dauSFs_tauid_2d_stat0_DM0_down = except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM0_down;
+		  dauSFs_tauid_2d_stat1_DM0_up = except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM0_up;
+		  dauSFs_tauid_2d_stat1_DM0_down = except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM0_down;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM0_up = except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM0_up;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM0_down = except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM0_down;
 
-		  idFakeSF_tauid_2d_stat0_DM1_up				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM1_up;
-		  idFakeSF_tauid_2d_stat0_DM1_down				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM1_down;
-		  idFakeSF_tauid_2d_stat1_DM1_up				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM1_up;
-		  idFakeSF_tauid_2d_stat1_DM1_down				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM1_down;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM1_up		= except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM1_up;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM1_down	= except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM1_down;
+		  dauSFs_tauid_2d_stat0_DM1_up = except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM1_up;
+		  dauSFs_tauid_2d_stat0_DM1_down = except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM1_down;
+		  dauSFs_tauid_2d_stat1_DM1_up = except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM1_up;
+		  dauSFs_tauid_2d_stat1_DM1_down = except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM1_down;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM1_up = except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM1_up;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM1_down	= except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM1_down;
 
-		  idFakeSF_tauid_2d_stat0_DM10_up				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM10_up;
-		  idFakeSF_tauid_2d_stat0_DM10_down				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM10_down;
-		  idFakeSF_tauid_2d_stat1_DM10_up				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM10_up;
-		  idFakeSF_tauid_2d_stat1_DM10_down				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM10_down;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM10_up	= except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM10_up;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM10_down	= except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM10_down;
+		  dauSFs_tauid_2d_stat0_DM10_up = except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM10_up;
+		  dauSFs_tauid_2d_stat0_DM10_down = except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM10_down;
+		  dauSFs_tauid_2d_stat1_DM10_up = except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM10_up;
+		  dauSFs_tauid_2d_stat1_DM10_down = except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM10_down;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM10_up = except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM10_up;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM10_down = except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM10_down;
 
-		  idFakeSF_tauid_2d_stat0_DM11_up				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM11_up;
-		  idFakeSF_tauid_2d_stat0_DM11_down				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM11_down;
-		  idFakeSF_tauid_2d_stat1_DM11_up				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM11_up;
-		  idFakeSF_tauid_2d_stat1_DM11_down				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM11_down;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM11_up	= except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM11_up;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM11_down	= except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM11_down;
+		  dauSFs_tauid_2d_stat0_DM11_up = except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM11_up;
+		  dauSFs_tauid_2d_stat0_DM11_down = except_VsJet * idSF_leg2_deep_vsJet_2d_stat0_DM11_down;
+		  dauSFs_tauid_2d_stat1_DM11_up = except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM11_up;
+		  dauSFs_tauid_2d_stat1_DM11_down = except_VsJet * idSF_leg2_deep_vsJet_2d_stat1_DM11_down;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM11_up = except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM11_up;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM11_down = except_VsJet * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM11_down;
 
-		  idFakeSF_tauid_2d_systcorrdmeras_up			= except_VsJet * idSF_leg2_deep_vsJet_2d_systcorrdmeras_up;
-		  idFakeSF_tauid_2d_systcorrdmeras_down			= except_VsJet * idSF_leg2_deep_vsJet_2d_systcorrdmeras_down;
-		  idFakeSF_tauid_2d_systcorrdmuncorreras_up		= except_VsJet * idSF_leg2_deep_vsJet_2d_systcorrdmuncorreras_up;
-		  idFakeSF_tauid_2d_systcorrdmuncorreras_down	= except_VsJet * idSF_leg2_deep_vsJet_2d_systcorrdmuncorreras_down;
-		  idFakeSF_tauid_2d_systcorrerasgt140_up		= except_VsJet * idSF_leg2_deep_vsJet_2d_systcorrerasgt140_up;
-		  idFakeSF_tauid_2d_systcorrerasgt140_down   	= except_VsJet * idSF_leg2_deep_vsJet_2d_systcorrerasgt140_down;
-		  idFakeSF_tauid_2d_stat0gt140_up				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat0gt140_up;
-		  idFakeSF_tauid_2d_stat0gt140_down				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat0gt140_down;
-		  idFakeSF_tauid_2d_stat1gt140_up				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat1gt140_up;
-		  idFakeSF_tauid_2d_stat1gt140_down				= except_VsJet * idSF_leg2_deep_vsJet_2d_stat1gt140_down;
-		  idFakeSF_tauid_2d_extrapgt140_up 		        = except_VsJet * idSF_leg2_deep_vsJet_2d_extrapgt140_up;
-		  idFakeSF_tauid_2d_extrapgt140_down	        = except_VsJet * idSF_leg2_deep_vsJet_2d_extrapgt140_down;
+		  dauSFs_tauid_2d_systcorrdmeras_up = except_VsJet * idSF_leg2_deep_vsJet_2d_systcorrdmeras_up;
+		  dauSFs_tauid_2d_systcorrdmeras_down = except_VsJet * idSF_leg2_deep_vsJet_2d_systcorrdmeras_down;
+		  dauSFs_tauid_2d_systcorrdmuncorreras_up = except_VsJet * idSF_leg2_deep_vsJet_2d_systcorrdmuncorreras_up;
+		  dauSFs_tauid_2d_systcorrdmuncorreras_down	= except_VsJet * idSF_leg2_deep_vsJet_2d_systcorrdmuncorreras_down;
+		  dauSFs_tauid_2d_systcorrerasgt140_up = except_VsJet * idSF_leg2_deep_vsJet_2d_systcorrerasgt140_up;
+		  dauSFs_tauid_2d_systcorrerasgt140_down = except_VsJet * idSF_leg2_deep_vsJet_2d_systcorrerasgt140_down;
+		  dauSFs_tauid_2d_stat0gt140_up = except_VsJet * idSF_leg2_deep_vsJet_2d_stat0gt140_up;
+		  dauSFs_tauid_2d_stat0gt140_down = except_VsJet * idSF_leg2_deep_vsJet_2d_stat0gt140_down;
+		  dauSFs_tauid_2d_stat1gt140_up = except_VsJet * idSF_leg2_deep_vsJet_2d_stat1gt140_up;
+		  dauSFs_tauid_2d_stat1gt140_down = except_VsJet * idSF_leg2_deep_vsJet_2d_stat1gt140_down;
+		  dauSFs_tauid_2d_extrapgt140_up = except_VsJet * idSF_leg2_deep_vsJet_2d_extrapgt140_up;
+		  dauSFs_tauid_2d_extrapgt140_down = except_VsJet * idSF_leg2_deep_vsJet_2d_extrapgt140_down;
 
-		  idFakeSF_mutauFR_etaLt0p4_up      = except_vsMu * idSF_leg2_deep_vsMu_up[0];
-		  idFakeSF_mutauFR_eta0p4to0p8_up   = except_vsMu * idSF_leg2_deep_vsMu_up[1];
-		  idFakeSF_mutauFR_eta0p8to1p2_up   = except_vsMu * idSF_leg2_deep_vsMu_up[2];
-		  idFakeSF_mutauFR_eta1p2to1p7_up   = except_vsMu * idSF_leg2_deep_vsMu_up[3];
-		  idFakeSF_mutauFR_etaGt1p7_up	    = except_vsMu * idSF_leg2_deep_vsMu_up[4];
-		  idFakeSF_mutauFR_etaLt0p4_down    = except_vsMu * idSF_leg2_deep_vsMu_down[0];
-		  idFakeSF_mutauFR_eta0p4to0p8_down = except_vsMu * idSF_leg2_deep_vsMu_down[1];
-		  idFakeSF_mutauFR_eta0p8to1p2_down = except_vsMu * idSF_leg2_deep_vsMu_down[2];
-		  idFakeSF_mutauFR_eta1p2to1p7_down = except_vsMu * idSF_leg2_deep_vsMu_down[3];
-		  idFakeSF_mutauFR_etaGt1p7_down    = except_vsMu * idSF_leg2_deep_vsMu_down[4];
+		  dauSFs_mutauFR_etaLt0p4_up = except_vsMu * idSF_leg2_deep_vsMu_up[0];
+		  dauSFs_mutauFR_eta0p4to0p8_up = except_vsMu * idSF_leg2_deep_vsMu_up[1];
+		  dauSFs_mutauFR_eta0p8to1p2_up = except_vsMu * idSF_leg2_deep_vsMu_up[2];
+		  dauSFs_mutauFR_eta1p2to1p7_up = except_vsMu * idSF_leg2_deep_vsMu_up[3];
+		  dauSFs_mutauFR_etaGt1p7_up = except_vsMu * idSF_leg2_deep_vsMu_up[4];
+		  dauSFs_mutauFR_etaLt0p4_down = except_vsMu * idSF_leg2_deep_vsMu_down[0];
+		  dauSFs_mutauFR_eta0p4to0p8_down = except_vsMu * idSF_leg2_deep_vsMu_down[1];
+		  dauSFs_mutauFR_eta0p8to1p2_down = except_vsMu * idSF_leg2_deep_vsMu_down[2];
+		  dauSFs_mutauFR_eta1p2to1p7_down = except_vsMu * idSF_leg2_deep_vsMu_down[3];
+		  dauSFs_mutauFR_etaGt1p7_down = except_vsMu * idSF_leg2_deep_vsMu_down[4];
 
-		  idFakeSF_etauFR_barrel_up		= except_vsEle * idSF_leg2_deep_vsEle_up[0];
-		  idFakeSF_etauFR_endcap_up		= except_vsEle * idSF_leg2_deep_vsEle_up[1];  
-		  idFakeSF_etauFR_barrel_down	= except_vsEle * idSF_leg2_deep_vsEle_down[0];
-		  idFakeSF_etauFR_endcap_down	= except_vsEle * idSF_leg2_deep_vsEle_down[1];
+		  dauSFs_etauFR_barrel_up = except_vsEle * idSF_leg2_deep_vsEle_up[0];
+		  dauSFs_etauFR_endcap_up = except_vsEle * idSF_leg2_deep_vsEle_up[1];
+		  dauSFs_etauFR_barrel_down = except_vsEle * idSF_leg2_deep_vsEle_down[0];
+		  dauSFs_etauFR_endcap_down = except_vsEle * idSF_leg2_deep_vsEle_down[1];
 
 		  if(pType==0){
-			idFakeSF_muID_up = except_leg1 * idSF_leg1_muID_up;
-			idFakeSF_muID_down = except_leg1 * idSF_leg1_muID_down;
-			idFakeSF_muIso_up = except_leg1 * idSF_leg1_muIso_up;
-			idFakeSF_muIso_down = except_leg1 * idSF_leg1_muIso_down;
+			dauSFs_muID_up = except_leg1 * idSF_leg1_muID_up;
+			dauSFs_muID_down = except_leg1 * idSF_leg1_muID_down;
+			dauSFs_muIso_up = except_leg1 * idSF_leg1_muIso_up;
+			dauSFs_muIso_down = except_leg1 * idSF_leg1_muIso_down;
 
-			idFakeSF_eleID_up = except_leg1 * idSF_leg1;
-			idFakeSF_eleID_down = except_leg1 * idSF_leg1;
-			idFakeSF_eleReco_up = except_leg1 * idSF_leg1;
-			idFakeSF_eleReco_down = except_leg1 * idSF_leg1;
+			dauSFs_eleID_up = except_leg1 * idSF_leg1;
+			dauSFs_eleID_down = except_leg1 * idSF_leg1;
+			dauSFs_eleReco_up = except_leg1 * idSF_leg1;
+			dauSFs_eleReco_down = except_leg1 * idSF_leg1;
 		  }
 		  else{
-			idFakeSF_muID_up = except_leg1 * idSF_leg1;
-			idFakeSF_muID_down = except_leg1 * idSF_leg1;
-			idFakeSF_muIso_up = except_leg1 * idSF_leg1;
-			idFakeSF_muIso_down = except_leg1 * idSF_leg1;
+			dauSFs_muID_up = except_leg1 * idSF_leg1;
+			dauSFs_muID_down = except_leg1 * idSF_leg1;
+			dauSFs_muIso_up = except_leg1 * idSF_leg1;
+			dauSFs_muIso_down = except_leg1 * idSF_leg1;
 
-			idFakeSF_eleID_up = except_leg1 * idSF_leg1_eleID_up;
-			idFakeSF_eleID_down = except_leg1 * idSF_leg1_eleID_down;
-			idFakeSF_eleReco_up = except_leg1 * idSF_leg1_eleReco_up;
-			idFakeSF_eleReco_down = except_leg1 * idSF_leg1_eleReco_down;
+			dauSFs_eleID_up = except_leg1 * idSF_leg1_eleID_up;
+			dauSFs_eleID_down = except_leg1 * idSF_leg1_eleID_down;
+			dauSFs_eleReco_up = except_leg1 * idSF_leg1_eleReco_up;
+			dauSFs_eleReco_down = except_leg1 * idSF_leg1_eleReco_down;
 		  }
 		}
 	  else if (isMC and pType == 2) // TauTau
 		{
-		  idSF_deep_2d	= idSF_leg1_deep_vsJet_2d * idSF_leg2_deep_vsJet_2d;
+		  idSF_deep_2d = idSF_leg1_deep_vsJet_2d * idSF_leg2_deep_vsJet_2d;
 
-		  except_VsJet	= idSF_leg1_deep_vsEle * idSF_leg1_deep_vsMu * idSF_leg2_deep_vsEle * idSF_leg2_deep_vsMu;
-		  except_vsMu	= idSF_leg1_deep_vsJet_2d * idSF_leg1_deep_vsEle * idSF_leg2_deep_vsJet_2d * idSF_leg2_deep_vsEle;
-		  except_vsEle	= idSF_leg1_deep_vsJet_2d * idSF_leg1_deep_vsMu  * idSF_leg2_deep_vsJet_2d * idSF_leg2_deep_vsMu;
+		  except_VsJet = idSF_leg1_deep_vsEle * idSF_leg1_deep_vsMu * idSF_leg2_deep_vsEle * idSF_leg2_deep_vsMu;
+		  except_vsMu = idSF_leg1_deep_vsJet_2d * idSF_leg1_deep_vsEle * idSF_leg2_deep_vsJet_2d * idSF_leg2_deep_vsEle;
+		  except_vsEle = idSF_leg1_deep_vsJet_2d * idSF_leg1_deep_vsMu  * idSF_leg2_deep_vsJet_2d * idSF_leg2_deep_vsMu;
 
-		  idFakeSF_deep_2d	= except_VsJet * idSF_deep_2d;
-		  fakeRateSF_deep	= except_VsJet;
+		  dauSFs = except_VsJet * idSF_deep_2d;
+		  fakeRateSF_deep = except_VsJet;
 
-		  idFakeSF_tauid_2d_stat0_DM0_up			  = except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM0_up				 * idSF_leg2_deep_vsJet_2d_stat0_DM0_up;
-		  idFakeSF_tauid_2d_stat0_DM0_down			  = except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM0_down			 * idSF_leg2_deep_vsJet_2d_stat0_DM0_down;
-		  idFakeSF_tauid_2d_stat1_DM0_up			  = except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM0_up				 * idSF_leg2_deep_vsJet_2d_stat1_DM0_up;
-		  idFakeSF_tauid_2d_stat1_DM0_down			  = except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM0_down			 * idSF_leg2_deep_vsJet_2d_stat1_DM0_down;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM0_up	  = except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM0_up	 * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM0_up;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM0_down = except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM0_down * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM0_down;
+		  dauSFs_tauid_2d_stat0_DM0_up = except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM0_up * idSF_leg2_deep_vsJet_2d_stat0_DM0_up;
+		  dauSFs_tauid_2d_stat0_DM0_down = except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM0_down * idSF_leg2_deep_vsJet_2d_stat0_DM0_down;
+		  dauSFs_tauid_2d_stat1_DM0_up = except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM0_up * idSF_leg2_deep_vsJet_2d_stat1_DM0_up;
+		  dauSFs_tauid_2d_stat1_DM0_down = except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM0_down * idSF_leg2_deep_vsJet_2d_stat1_DM0_down;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM0_up = except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM0_up * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM0_up;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM0_down = except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM0_down * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM0_down;
 
-		  idFakeSF_tauid_2d_stat0_DM1_up			  = except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM1_up				 * idSF_leg2_deep_vsJet_2d_stat0_DM1_up;
-		  idFakeSF_tauid_2d_stat0_DM1_down			  = except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM1_down			 * idSF_leg2_deep_vsJet_2d_stat0_DM1_down;
-		  idFakeSF_tauid_2d_stat1_DM1_up			  = except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM1_up				 * idSF_leg2_deep_vsJet_2d_stat1_DM1_up;
-		  idFakeSF_tauid_2d_stat1_DM1_down			  = except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM1_down			 * idSF_leg2_deep_vsJet_2d_stat1_DM1_down;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM1_up	  = except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM1_up	 * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM1_up;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM1_down = except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM1_down * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM1_down;
+		  dauSFs_tauid_2d_stat0_DM1_up = except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM1_up * idSF_leg2_deep_vsJet_2d_stat0_DM1_up;
+		  dauSFs_tauid_2d_stat0_DM1_down = except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM1_down * idSF_leg2_deep_vsJet_2d_stat0_DM1_down;
+		  dauSFs_tauid_2d_stat1_DM1_up = except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM1_up * idSF_leg2_deep_vsJet_2d_stat1_DM1_up;
+		  dauSFs_tauid_2d_stat1_DM1_down = except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM1_down * idSF_leg2_deep_vsJet_2d_stat1_DM1_down;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM1_up = except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM1_up * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM1_up;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM1_down = except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM1_down * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM1_down;
 
-		  idFakeSF_tauid_2d_stat0_DM10_up				= except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM10_up			    * idSF_leg2_deep_vsJet_2d_stat0_DM10_up;
-		  idFakeSF_tauid_2d_stat0_DM10_down				= except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM10_down		    * idSF_leg2_deep_vsJet_2d_stat0_DM10_down;
-		  idFakeSF_tauid_2d_stat1_DM10_up				= except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM10_up			    * idSF_leg2_deep_vsJet_2d_stat1_DM10_up;
-		  idFakeSF_tauid_2d_stat1_DM10_down				= except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM10_down		    * idSF_leg2_deep_vsJet_2d_stat1_DM10_down;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM10_up	= except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM10_up   * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM10_up;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM10_down	= except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM10_down * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM10_down;
+		  dauSFs_tauid_2d_stat0_DM10_up = except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM10_up * idSF_leg2_deep_vsJet_2d_stat0_DM10_up;
+		  dauSFs_tauid_2d_stat0_DM10_down = except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM10_down * idSF_leg2_deep_vsJet_2d_stat0_DM10_down;
+		  dauSFs_tauid_2d_stat1_DM10_up = except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM10_up * idSF_leg2_deep_vsJet_2d_stat1_DM10_up;
+		  dauSFs_tauid_2d_stat1_DM10_down = except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM10_down * idSF_leg2_deep_vsJet_2d_stat1_DM10_down;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM10_up = except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM10_up * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM10_up;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM10_down = except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM10_down * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM10_down;
 
-		  idFakeSF_tauid_2d_stat0_DM11_up				= except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM11_up			    * idSF_leg2_deep_vsJet_2d_stat0_DM11_up;
-		  idFakeSF_tauid_2d_stat0_DM11_down				= except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM11_down		    * idSF_leg2_deep_vsJet_2d_stat0_DM11_down;
-		  idFakeSF_tauid_2d_stat1_DM11_up				= except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM11_up			    * idSF_leg2_deep_vsJet_2d_stat1_DM11_up;
-		  idFakeSF_tauid_2d_stat1_DM11_down				= except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM11_down		    * idSF_leg2_deep_vsJet_2d_stat1_DM11_down;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM11_up	= except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM11_up   * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM11_up;
-		  idFakeSF_tauid_2d_systuncorrdmeras_DM11_down	= except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM11_down * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM11_down;
+		  dauSFs_tauid_2d_stat0_DM11_up = except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM11_up * idSF_leg2_deep_vsJet_2d_stat0_DM11_up;
+		  dauSFs_tauid_2d_stat0_DM11_down = except_VsJet * idSF_leg1_deep_vsJet_2d_stat0_DM11_down * idSF_leg2_deep_vsJet_2d_stat0_DM11_down;
+		  dauSFs_tauid_2d_stat1_DM11_up = except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM11_up * idSF_leg2_deep_vsJet_2d_stat1_DM11_up;
+		  dauSFs_tauid_2d_stat1_DM11_down = except_VsJet * idSF_leg1_deep_vsJet_2d_stat1_DM11_down * idSF_leg2_deep_vsJet_2d_stat1_DM11_down;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM11_up = except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM11_up * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM11_up;
+		  dauSFs_tauid_2d_systuncorrdmeras_DM11_down = except_VsJet * idSF_leg1_deep_vsJet_2d_systuncorrdmeras_DM11_down * idSF_leg2_deep_vsJet_2d_systuncorrdmeras_DM11_down;
 
-		  idFakeSF_tauid_2d_systcorrdmeras_up			= except_VsJet * idSF_leg1_deep_vsJet_2d_systcorrdmeras_up		   * idSF_leg2_deep_vsJet_2d_systcorrdmeras_up;
-		  idFakeSF_tauid_2d_systcorrdmeras_down			= except_VsJet * idSF_leg1_deep_vsJet_2d_systcorrdmeras_down	   * idSF_leg2_deep_vsJet_2d_systcorrdmeras_down;
-		  idFakeSF_tauid_2d_systcorrdmuncorreras_up		= except_VsJet * idSF_leg1_deep_vsJet_2d_systcorrdmuncorreras_up   * idSF_leg2_deep_vsJet_2d_systcorrdmuncorreras_up;
-		  idFakeSF_tauid_2d_systcorrdmuncorreras_down	= except_VsJet * idSF_leg1_deep_vsJet_2d_systcorrdmuncorreras_down * idSF_leg2_deep_vsJet_2d_systcorrdmuncorreras_down;
-		  idFakeSF_tauid_2d_systcorrerasgt140_up		= except_VsJet * idSF_leg1_deep_vsJet_2d_systcorrerasgt140_up      * idSF_leg2_deep_vsJet_2d_systcorrerasgt140_up;
-		  idFakeSF_tauid_2d_systcorrerasgt140_down   	= except_VsJet * idSF_leg1_deep_vsJet_2d_systcorrerasgt140_down    * idSF_leg2_deep_vsJet_2d_systcorrerasgt140_down;
-		  idFakeSF_tauid_2d_stat0gt140_up				= except_VsJet * idSF_leg1_deep_vsJet_2d_stat0gt140_up		       * idSF_leg2_deep_vsJet_2d_stat0gt140_up;
-		  idFakeSF_tauid_2d_stat0gt140_down				= except_VsJet * idSF_leg1_deep_vsJet_2d_stat0gt140_down		   * idSF_leg2_deep_vsJet_2d_stat0gt140_down;
-		  idFakeSF_tauid_2d_stat1gt140_up				= except_VsJet * idSF_leg1_deep_vsJet_2d_stat1gt140_up		       * idSF_leg2_deep_vsJet_2d_stat1gt140_up;
-		  idFakeSF_tauid_2d_stat1gt140_down				= except_VsJet * idSF_leg1_deep_vsJet_2d_stat1gt140_down		   * idSF_leg2_deep_vsJet_2d_stat1gt140_down;
-		  idFakeSF_tauid_2d_extrapgt140_up            	= except_VsJet * idSF_leg1_deep_vsJet_2d_extrapgt140_up            * idSF_leg2_deep_vsJet_2d_extrapgt140_up;
-		  idFakeSF_tauid_2d_extrapgt140_down          	= except_VsJet * idSF_leg1_deep_vsJet_2d_extrapgt140_down          * idSF_leg2_deep_vsJet_2d_extrapgt140_down;
+		  dauSFs_tauid_2d_systcorrdmeras_up = except_VsJet * idSF_leg1_deep_vsJet_2d_systcorrdmeras_up * idSF_leg2_deep_vsJet_2d_systcorrdmeras_up;
+		  dauSFs_tauid_2d_systcorrdmeras_down = except_VsJet * idSF_leg1_deep_vsJet_2d_systcorrdmeras_down * idSF_leg2_deep_vsJet_2d_systcorrdmeras_down;
+		  dauSFs_tauid_2d_systcorrdmuncorreras_up = except_VsJet * idSF_leg1_deep_vsJet_2d_systcorrdmuncorreras_up * idSF_leg2_deep_vsJet_2d_systcorrdmuncorreras_up;
+		  dauSFs_tauid_2d_systcorrdmuncorreras_down	= except_VsJet * idSF_leg1_deep_vsJet_2d_systcorrdmuncorreras_down * idSF_leg2_deep_vsJet_2d_systcorrdmuncorreras_down;
+		  dauSFs_tauid_2d_systcorrerasgt140_up = except_VsJet * idSF_leg1_deep_vsJet_2d_systcorrerasgt140_up * idSF_leg2_deep_vsJet_2d_systcorrerasgt140_up;
+		  dauSFs_tauid_2d_systcorrerasgt140_down = except_VsJet * idSF_leg1_deep_vsJet_2d_systcorrerasgt140_down * idSF_leg2_deep_vsJet_2d_systcorrerasgt140_down;
+		  dauSFs_tauid_2d_stat0gt140_up = except_VsJet * idSF_leg1_deep_vsJet_2d_stat0gt140_up * idSF_leg2_deep_vsJet_2d_stat0gt140_up;
+		  dauSFs_tauid_2d_stat0gt140_down = except_VsJet * idSF_leg1_deep_vsJet_2d_stat0gt140_down * idSF_leg2_deep_vsJet_2d_stat0gt140_down;
+		  dauSFs_tauid_2d_stat1gt140_up = except_VsJet * idSF_leg1_deep_vsJet_2d_stat1gt140_up * idSF_leg2_deep_vsJet_2d_stat1gt140_up;
+		  dauSFs_tauid_2d_stat1gt140_down = except_VsJet * idSF_leg1_deep_vsJet_2d_stat1gt140_down * idSF_leg2_deep_vsJet_2d_stat1gt140_down;
+		  dauSFs_tauid_2d_extrapgt140_up = except_VsJet * idSF_leg1_deep_vsJet_2d_extrapgt140_up * idSF_leg2_deep_vsJet_2d_extrapgt140_up;
+		  dauSFs_tauid_2d_extrapgt140_down = except_VsJet * idSF_leg1_deep_vsJet_2d_extrapgt140_down * idSF_leg2_deep_vsJet_2d_extrapgt140_down;
 
-		  idFakeSF_mutauFR_etaLt0p4_up      = except_vsMu * idSF_leg1_deep_vsMu_up[0]   * idSF_leg2_deep_vsMu_up[0];
-		  idFakeSF_mutauFR_eta0p4to0p8_up   = except_vsMu * idSF_leg1_deep_vsMu_up[1]   * idSF_leg2_deep_vsMu_up[1];
-		  idFakeSF_mutauFR_eta0p8to1p2_up   = except_vsMu * idSF_leg1_deep_vsMu_up[2]   * idSF_leg2_deep_vsMu_up[2];
-		  idFakeSF_mutauFR_eta1p2to1p7_up   = except_vsMu * idSF_leg1_deep_vsMu_up[3]   * idSF_leg2_deep_vsMu_up[3];
-		  idFakeSF_mutauFR_etaGt1p7_up      = except_vsMu * idSF_leg1_deep_vsMu_up[4]   * idSF_leg2_deep_vsMu_up[4];
-		  idFakeSF_mutauFR_etaLt0p4_down    = except_vsMu * idSF_leg1_deep_vsMu_down[0] * idSF_leg2_deep_vsMu_down[0];
-		  idFakeSF_mutauFR_eta0p4to0p8_down = except_vsMu * idSF_leg1_deep_vsMu_down[1] * idSF_leg2_deep_vsMu_down[1];
-		  idFakeSF_mutauFR_eta0p8to1p2_down = except_vsMu * idSF_leg1_deep_vsMu_down[2] * idSF_leg2_deep_vsMu_down[2];
-		  idFakeSF_mutauFR_eta1p2to1p7_down = except_vsMu * idSF_leg1_deep_vsMu_down[3] * idSF_leg2_deep_vsMu_down[3];
-		  idFakeSF_mutauFR_etaGt1p7_down    = except_vsMu * idSF_leg1_deep_vsMu_down[4] * idSF_leg2_deep_vsMu_down[4];
+		  dauSFs_mutauFR_etaLt0p4_up = except_vsMu * idSF_leg1_deep_vsMu_up[0] * idSF_leg2_deep_vsMu_up[0];
+		  dauSFs_mutauFR_eta0p4to0p8_up = except_vsMu * idSF_leg1_deep_vsMu_up[1] * idSF_leg2_deep_vsMu_up[1];
+		  dauSFs_mutauFR_eta0p8to1p2_up = except_vsMu * idSF_leg1_deep_vsMu_up[2] * idSF_leg2_deep_vsMu_up[2];
+		  dauSFs_mutauFR_eta1p2to1p7_up = except_vsMu * idSF_leg1_deep_vsMu_up[3] * idSF_leg2_deep_vsMu_up[3];
+		  dauSFs_mutauFR_etaGt1p7_up = except_vsMu * idSF_leg1_deep_vsMu_up[4] * idSF_leg2_deep_vsMu_up[4];
+		  dauSFs_mutauFR_etaLt0p4_down = except_vsMu * idSF_leg1_deep_vsMu_down[0] * idSF_leg2_deep_vsMu_down[0];
+		  dauSFs_mutauFR_eta0p4to0p8_down = except_vsMu * idSF_leg1_deep_vsMu_down[1] * idSF_leg2_deep_vsMu_down[1];
+		  dauSFs_mutauFR_eta0p8to1p2_down = except_vsMu * idSF_leg1_deep_vsMu_down[2] * idSF_leg2_deep_vsMu_down[2];
+		  dauSFs_mutauFR_eta1p2to1p7_down = except_vsMu * idSF_leg1_deep_vsMu_down[3] * idSF_leg2_deep_vsMu_down[3];
+		  dauSFs_mutauFR_etaGt1p7_down = except_vsMu * idSF_leg1_deep_vsMu_down[4] * idSF_leg2_deep_vsMu_down[4];
 
-		  idFakeSF_etauFR_barrel_up   = except_vsEle * idSF_leg1_deep_vsEle_up[0]   * idSF_leg2_deep_vsEle_up[0];
-		  idFakeSF_etauFR_endcap_up   = except_vsEle * idSF_leg1_deep_vsEle_up[1]   * idSF_leg2_deep_vsEle_up[1];
-		  idFakeSF_etauFR_barrel_down = except_vsEle * idSF_leg1_deep_vsEle_down[0] * idSF_leg2_deep_vsEle_down[0];
-		  idFakeSF_etauFR_endcap_down = except_vsEle * idSF_leg1_deep_vsEle_down[1] * idSF_leg2_deep_vsEle_down[1];
+		  dauSFs_etauFR_barrel_up = except_vsEle * idSF_leg1_deep_vsEle_up[0] * idSF_leg2_deep_vsEle_up[0];
+		  dauSFs_etauFR_endcap_up = except_vsEle * idSF_leg1_deep_vsEle_up[1] * idSF_leg2_deep_vsEle_up[1];
+		  dauSFs_etauFR_barrel_down = except_vsEle * idSF_leg1_deep_vsEle_down[0] * idSF_leg2_deep_vsEle_down[0];
+		  dauSFs_etauFR_endcap_down = except_vsEle * idSF_leg1_deep_vsEle_down[1] * idSF_leg2_deep_vsEle_down[1];
 
-		  idFakeSF_muID_up = idFakeSF_deep_2d;
-		  idFakeSF_muID_down = idFakeSF_deep_2d;
-		  idFakeSF_muIso_up = idFakeSF_deep_2d;
-		  idFakeSF_muIso_down = idFakeSF_deep_2d;
+		  dauSFs_muID_up = dauSFs;
+		  dauSFs_muID_down = dauSFs;
+		  dauSFs_muIso_up = dauSFs;
+		  dauSFs_muIso_down = dauSFs;
 
-		  idFakeSF_eleID_up = idFakeSF_deep_2d;
-		  idFakeSF_eleID_down = idFakeSF_deep_2d;
-		  idFakeSF_eleReco_up = idFakeSF_deep_2d;
-		  idFakeSF_eleReco_down = idFakeSF_deep_2d;
+		  dauSFs_eleID_up = dauSFs;
+		  dauSFs_eleID_down = dauSFs;
+		  dauSFs_eleReco_up = dauSFs;
+		  dauSFs_eleReco_down = dauSFs;
 		}
 	  else if(isMC and (pType == 3 or pType == 4))  // MuMu and EleEle channels
 		{
-		  idSF_deep_2d = idFakeSF_deep_2d = idSF_leg1 * idSF_leg2;
+		  idSF_deep_2d = dauSFs = idSF_leg1 * idSF_leg2;
 		}
 	  
 	  if (DEBUG) {
 		cout << "--- DEBUG idSF ---" << endl;
 		cout << "pairType  : "              << pType                   << endl;
-		cout << "totSF deep_2d: "           << idFakeSF_deep_2d        << endl;
+		cout << "totSF deep_2d: "           << dauSFs                  << endl;
 		cout << "idSF_leg1: "               << idSF_leg1               << endl;
 		cout << "idSF_leg1_deep_vsJet_2d: " << idSF_leg1_deep_vsJet_2d << endl;
 		cout << "idSF_leg1_deep_vsEle: "    << idSF_leg1_deep_vsEle    << endl;
@@ -3131,78 +3131,78 @@ int main (int argc, char** argv)
 	  }
 
 	  // Save the IDandISO SF (event per event)
-	  theSmallTree.m_IdSF_deep_2d				= idSF_deep_2d;
-	  theSmallTree.m_IdSF_leg1_deep_vsJet_2d	= idSF_leg1_deep_vsJet_2d;
-	  theSmallTree.m_IdSF_leg2_deep_vsJet_2d	= idSF_leg2_deep_vsJet_2d;
+	  theSmallTree.m_IdSF_deep_2d = idSF_deep_2d;
+	  theSmallTree.m_IdSF_leg1_deep_vsJet_2d = idSF_leg1_deep_vsJet_2d;
+	  theSmallTree.m_IdSF_leg2_deep_vsJet_2d = idSF_leg2_deep_vsJet_2d;
 	  
-	  theSmallTree.m_IdFakeSF_deep_2d = idFakeSF_deep_2d;
+	  theSmallTree.m_dauSFs = dauSFs;
 	  theSmallTree.m_FakeRateSF_deep  = fakeRateSF_deep;
 
-	  theSmallTree.m_idFakeSF_tauid_2d_stat0_DM0_up				 = idFakeSF_tauid_2d_stat0_DM0_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat0_DM0_down			 = idFakeSF_tauid_2d_stat0_DM0_down;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat1_DM0_up				 = idFakeSF_tauid_2d_stat1_DM0_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat1_DM0_down			 = idFakeSF_tauid_2d_stat1_DM0_down;
-	  theSmallTree.m_idFakeSF_tauid_2d_systuncorrdmeras_DM0_up	 = idFakeSF_tauid_2d_systuncorrdmeras_DM0_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_systuncorrdmeras_DM0_down = idFakeSF_tauid_2d_systuncorrdmeras_DM0_down;
+	  theSmallTree.m_dauSFs_tauid_2d_stat0_DM0_up = dauSFs_tauid_2d_stat0_DM0_up;
+	  theSmallTree.m_dauSFs_tauid_2d_stat0_DM0_down = dauSFs_tauid_2d_stat0_DM0_down;
+	  theSmallTree.m_dauSFs_tauid_2d_stat1_DM0_up = dauSFs_tauid_2d_stat1_DM0_up;
+	  theSmallTree.m_dauSFs_tauid_2d_stat1_DM0_down = dauSFs_tauid_2d_stat1_DM0_down;
+	  theSmallTree.m_dauSFs_tauid_2d_systuncorrdmeras_DM0_up = dauSFs_tauid_2d_systuncorrdmeras_DM0_up;
+	  theSmallTree.m_dauSFs_tauid_2d_systuncorrdmeras_DM0_down = dauSFs_tauid_2d_systuncorrdmeras_DM0_down;
 	  
-	  theSmallTree.m_idFakeSF_tauid_2d_stat0_DM1_up				 = idFakeSF_tauid_2d_stat0_DM1_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat0_DM1_down			 = idFakeSF_tauid_2d_stat0_DM1_down;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat1_DM1_up				 = idFakeSF_tauid_2d_stat1_DM1_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat1_DM1_down			 = idFakeSF_tauid_2d_stat1_DM1_down;
-	  theSmallTree.m_idFakeSF_tauid_2d_systuncorrdmeras_DM1_up	 = idFakeSF_tauid_2d_systuncorrdmeras_DM1_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_systuncorrdmeras_DM1_down = idFakeSF_tauid_2d_systuncorrdmeras_DM1_down;
+	  theSmallTree.m_dauSFs_tauid_2d_stat0_DM1_up = dauSFs_tauid_2d_stat0_DM1_up;
+	  theSmallTree.m_dauSFs_tauid_2d_stat0_DM1_down = dauSFs_tauid_2d_stat0_DM1_down;
+	  theSmallTree.m_dauSFs_tauid_2d_stat1_DM1_up = dauSFs_tauid_2d_stat1_DM1_up;
+	  theSmallTree.m_dauSFs_tauid_2d_stat1_DM1_down = dauSFs_tauid_2d_stat1_DM1_down;
+	  theSmallTree.m_dauSFs_tauid_2d_systuncorrdmeras_DM1_up = dauSFs_tauid_2d_systuncorrdmeras_DM1_up;
+	  theSmallTree.m_dauSFs_tauid_2d_systuncorrdmeras_DM1_down = dauSFs_tauid_2d_systuncorrdmeras_DM1_down;
 
-	  theSmallTree.m_idFakeSF_tauid_2d_stat0_DM10_up			  = idFakeSF_tauid_2d_stat0_DM10_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat0_DM10_down			  = idFakeSF_tauid_2d_stat0_DM10_down;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat1_DM10_up			  = idFakeSF_tauid_2d_stat1_DM10_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat1_DM10_down			  = idFakeSF_tauid_2d_stat1_DM10_down;
-	  theSmallTree.m_idFakeSF_tauid_2d_systuncorrdmeras_DM10_up	  = idFakeSF_tauid_2d_systuncorrdmeras_DM10_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_systuncorrdmeras_DM10_down = idFakeSF_tauid_2d_systuncorrdmeras_DM10_down;
+	  theSmallTree.m_dauSFs_tauid_2d_stat0_DM10_up = dauSFs_tauid_2d_stat0_DM10_up;
+	  theSmallTree.m_dauSFs_tauid_2d_stat0_DM10_down = dauSFs_tauid_2d_stat0_DM10_down;
+	  theSmallTree.m_dauSFs_tauid_2d_stat1_DM10_up = dauSFs_tauid_2d_stat1_DM10_up;
+	  theSmallTree.m_dauSFs_tauid_2d_stat1_DM10_down = dauSFs_tauid_2d_stat1_DM10_down;
+	  theSmallTree.m_dauSFs_tauid_2d_systuncorrdmeras_DM10_up = dauSFs_tauid_2d_systuncorrdmeras_DM10_up;
+	  theSmallTree.m_dauSFs_tauid_2d_systuncorrdmeras_DM10_down = dauSFs_tauid_2d_systuncorrdmeras_DM10_down;
 	  
-	  theSmallTree.m_idFakeSF_tauid_2d_stat0_DM11_up			  = idFakeSF_tauid_2d_stat0_DM11_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat0_DM11_down			  = idFakeSF_tauid_2d_stat0_DM11_down;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat1_DM11_up			  = idFakeSF_tauid_2d_stat1_DM11_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat1_DM11_down			  = idFakeSF_tauid_2d_stat1_DM11_down;
-	  theSmallTree.m_idFakeSF_tauid_2d_systuncorrdmeras_DM11_up	  = idFakeSF_tauid_2d_systuncorrdmeras_DM11_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_systuncorrdmeras_DM11_down = idFakeSF_tauid_2d_systuncorrdmeras_DM11_down;
+	  theSmallTree.m_dauSFs_tauid_2d_stat0_DM11_up = dauSFs_tauid_2d_stat0_DM11_up;
+	  theSmallTree.m_dauSFs_tauid_2d_stat0_DM11_down = dauSFs_tauid_2d_stat0_DM11_down;
+	  theSmallTree.m_dauSFs_tauid_2d_stat1_DM11_up = dauSFs_tauid_2d_stat1_DM11_up;
+	  theSmallTree.m_dauSFs_tauid_2d_stat1_DM11_down = dauSFs_tauid_2d_stat1_DM11_down;
+	  theSmallTree.m_dauSFs_tauid_2d_systuncorrdmeras_DM11_up = dauSFs_tauid_2d_systuncorrdmeras_DM11_up;
+	  theSmallTree.m_dauSFs_tauid_2d_systuncorrdmeras_DM11_down = dauSFs_tauid_2d_systuncorrdmeras_DM11_down;
 
-	  theSmallTree.m_idFakeSF_tauid_2d_systcorrdmeras_up			= idFakeSF_tauid_2d_systcorrdmeras_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_systcorrdmeras_down			= idFakeSF_tauid_2d_systcorrdmeras_down;
-	  theSmallTree.m_idFakeSF_tauid_2d_systcorrdmuncorreras_up		= idFakeSF_tauid_2d_systcorrdmuncorreras_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_systcorrdmuncorreras_down	= idFakeSF_tauid_2d_systcorrdmuncorreras_down;
-	  theSmallTree.m_idFakeSF_tauid_2d_systcorrerasgt140_up			= idFakeSF_tauid_2d_systcorrerasgt140_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_systcorrerasgt140_down		= idFakeSF_tauid_2d_systcorrerasgt140_down;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat0gt140_up				= idFakeSF_tauid_2d_stat0gt140_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat0gt140_down				= idFakeSF_tauid_2d_stat0gt140_down;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat1gt140_up				= idFakeSF_tauid_2d_stat1gt140_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_stat1gt140_down				= idFakeSF_tauid_2d_stat1gt140_down;
-	  theSmallTree.m_idFakeSF_tauid_2d_extrapgt140_up				= idFakeSF_tauid_2d_extrapgt140_up;
-	  theSmallTree.m_idFakeSF_tauid_2d_extrapgt140_down				= idFakeSF_tauid_2d_extrapgt140_down;
+	  theSmallTree.m_dauSFs_tauid_2d_systcorrdmeras_up = dauSFs_tauid_2d_systcorrdmeras_up;
+	  theSmallTree.m_dauSFs_tauid_2d_systcorrdmeras_down = dauSFs_tauid_2d_systcorrdmeras_down;
+	  theSmallTree.m_dauSFs_tauid_2d_systcorrdmuncorreras_up = dauSFs_tauid_2d_systcorrdmuncorreras_up;
+	  theSmallTree.m_dauSFs_tauid_2d_systcorrdmuncorreras_down = dauSFs_tauid_2d_systcorrdmuncorreras_down;
+	  theSmallTree.m_dauSFs_tauid_2d_systcorrerasgt140_up = dauSFs_tauid_2d_systcorrerasgt140_up;
+	  theSmallTree.m_dauSFs_tauid_2d_systcorrerasgt140_down = dauSFs_tauid_2d_systcorrerasgt140_down;
+	  theSmallTree.m_dauSFs_tauid_2d_stat0gt140_up = dauSFs_tauid_2d_stat0gt140_up;
+	  theSmallTree.m_dauSFs_tauid_2d_stat0gt140_down = dauSFs_tauid_2d_stat0gt140_down;
+	  theSmallTree.m_dauSFs_tauid_2d_stat1gt140_up = dauSFs_tauid_2d_stat1gt140_up;
+	  theSmallTree.m_dauSFs_tauid_2d_stat1gt140_down = dauSFs_tauid_2d_stat1gt140_down;
+	  theSmallTree.m_dauSFs_tauid_2d_extrapgt140_up = dauSFs_tauid_2d_extrapgt140_up;
+	  theSmallTree.m_dauSFs_tauid_2d_extrapgt140_down = dauSFs_tauid_2d_extrapgt140_down;
 	
-	  theSmallTree.m_idFakeSF_mutauFR_etaLt0p4_up		= idFakeSF_mutauFR_etaLt0p4_up;		
-	  theSmallTree.m_idFakeSF_mutauFR_eta0p4to0p8_up	= idFakeSF_mutauFR_eta0p4to0p8_up;	
-	  theSmallTree.m_idFakeSF_mutauFR_eta0p8to1p2_up	= idFakeSF_mutauFR_eta0p8to1p2_up;	
-	  theSmallTree.m_idFakeSF_mutauFR_eta1p2to1p7_up	= idFakeSF_mutauFR_eta1p2to1p7_up;	
-	  theSmallTree.m_idFakeSF_mutauFR_etaGt1p7_up		= idFakeSF_mutauFR_etaGt1p7_up;		
-	  theSmallTree.m_idFakeSF_mutauFR_etaLt0p4_down		= idFakeSF_mutauFR_etaLt0p4_down;	
-	  theSmallTree.m_idFakeSF_mutauFR_eta0p4to0p8_down	= idFakeSF_mutauFR_eta0p4to0p8_down;
-	  theSmallTree.m_idFakeSF_mutauFR_eta0p8to1p2_down	= idFakeSF_mutauFR_eta0p8to1p2_down;
-	  theSmallTree.m_idFakeSF_mutauFR_eta1p2to1p7_down	= idFakeSF_mutauFR_eta1p2to1p7_down;
-	  theSmallTree.m_idFakeSF_mutauFR_etaGt1p7_down		= idFakeSF_mutauFR_etaGt1p7_down;
-	  theSmallTree.m_idFakeSF_etauFR_barrel_up			= idFakeSF_etauFR_barrel_up;	
-	  theSmallTree.m_idFakeSF_etauFR_endcap_up			= idFakeSF_etauFR_endcap_up;		
-	  theSmallTree.m_idFakeSF_etauFR_barrel_down		= idFakeSF_etauFR_barrel_down;		
-	  theSmallTree.m_idFakeSF_etauFR_endcap_down		= idFakeSF_etauFR_endcap_down;
+	  theSmallTree.m_dauSFs_mutauFR_etaLt0p4_up = dauSFs_mutauFR_etaLt0p4_up;
+	  theSmallTree.m_dauSFs_mutauFR_eta0p4to0p8_up = dauSFs_mutauFR_eta0p4to0p8_up;
+	  theSmallTree.m_dauSFs_mutauFR_eta0p8to1p2_up = dauSFs_mutauFR_eta0p8to1p2_up;
+	  theSmallTree.m_dauSFs_mutauFR_eta1p2to1p7_up = dauSFs_mutauFR_eta1p2to1p7_up;
+	  theSmallTree.m_dauSFs_mutauFR_etaGt1p7_up = dauSFs_mutauFR_etaGt1p7_up;
+	  theSmallTree.m_dauSFs_mutauFR_etaLt0p4_down = dauSFs_mutauFR_etaLt0p4_down;
+	  theSmallTree.m_dauSFs_mutauFR_eta0p4to0p8_down = dauSFs_mutauFR_eta0p4to0p8_down;
+	  theSmallTree.m_dauSFs_mutauFR_eta0p8to1p2_down = dauSFs_mutauFR_eta0p8to1p2_down;
+	  theSmallTree.m_dauSFs_mutauFR_eta1p2to1p7_down = dauSFs_mutauFR_eta1p2to1p7_down;
+	  theSmallTree.m_dauSFs_mutauFR_etaGt1p7_down = dauSFs_mutauFR_etaGt1p7_down;
+	  theSmallTree.m_dauSFs_etauFR_barrel_up = dauSFs_etauFR_barrel_up;
+	  theSmallTree.m_dauSFs_etauFR_endcap_up = dauSFs_etauFR_endcap_up;
+	  theSmallTree.m_dauSFs_etauFR_barrel_down = dauSFs_etauFR_barrel_down;
+	  theSmallTree.m_dauSFs_etauFR_endcap_down = dauSFs_etauFR_endcap_down;
 
-	  theSmallTree.m_idFakeSF_muID_up		= idFakeSF_muID_up;
-	  theSmallTree.m_idFakeSF_muID_down		= idFakeSF_muID_down;
-	  theSmallTree.m_idFakeSF_muIso_up		= idFakeSF_muIso_up;
-	  theSmallTree.m_idFakeSF_muIso_down	= idFakeSF_muIso_down;
+	  theSmallTree.m_dauSFs_muID_up = dauSFs_muID_up;
+	  theSmallTree.m_dauSFs_muID_down = dauSFs_muID_down;
+	  theSmallTree.m_dauSFs_muIso_up = dauSFs_muIso_up;
+	  theSmallTree.m_dauSFs_muIso_down = dauSFs_muIso_down;
 
-	  theSmallTree.m_idFakeSF_eleID_up		= idFakeSF_eleID_up;
-	  theSmallTree.m_idFakeSF_eleID_down	= idFakeSF_eleID_down;
-	  theSmallTree.m_idFakeSF_eleReco_up	= idFakeSF_eleReco_up;
-	  theSmallTree.m_idFakeSF_eleReco_down	= idFakeSF_eleReco_down;
+	  theSmallTree.m_dauSFs_eleID_up = dauSFs_eleID_up;
+	  theSmallTree.m_dauSFs_eleID_down = dauSFs_eleID_down;
+	  theSmallTree.m_dauSFs_eleReco_up = dauSFs_eleReco_up;
+	  theSmallTree.m_dauSFs_eleReco_down = dauSFs_eleReco_down;
 	  
 	  //Jet faking Tau SF
 	  //derived from WJet sideband: http://camendol.web.cern.ch/camendol/HH2017/plotsHH2017MuTau/31Oct2018_DYNLO_ctrlWJets_SS/antiB_jets30_tau30_SStight/
@@ -4005,7 +4005,7 @@ int main (int argc, char** argv)
 	  theSmallTree.m_trigSF_stau_down      = isMC ? trigSF_stau_down      : 1.0;
 
 	  theSmallTree.m_totalWeight = (isMC? (59970./7.20811e+10) * theSmallTree.m_MC_weight * theSmallTree.m_PUReweight *
-									trigSF * theSmallTree.m_IdFakeSF_deep_2d: 1.0);
+									trigSF * theSmallTree.m_dauSFs: 1.0);
 
 	  //total weight used for sync: the denominator must be changed for each sample as h_eff->GetBinContent(1), the numerator is the luminosity
 
@@ -5396,7 +5396,7 @@ int main (int argc, char** argv)
 		  cout << " - Debug SFs -"			 << endl;
 		  cout << "	PU		   : "			 << theSmallTree.m_PUReweight		<< endl;
 		  cout << "	 IDandISO deep (2D): "	 << theSmallTree.m_IdSF_deep_2d		<< endl;
-		  cout << "	   w/ FakeRate: "		 << theSmallTree.m_IdFakeSF_deep_2d << endl;
+		  cout << "	   w/ FakeRate: "		 << theSmallTree.m_dauSFs << endl;
 		  cout << "	trig		   : "		 << theSmallTree.m_trigSF			<< endl;
 		  cout << "	bTag		   : "		 << theSmallTree.m_bTagweightM		<< endl;
 		  cout << "	prescale	   : "		 << theSmallTree.m_prescaleWeight	<< endl;
@@ -5408,7 +5408,7 @@ int main (int argc, char** argv)
 		  cout << "stitchWeight	 : "		 << stitchWeight << endl;
 		  cout << "HHweight		 : "		 << HHweight << endl;
 		  cout << "MC_weight	 : "		 << theSmallTree.m_MC_weight << endl;
-		  cout << "Yield weight deep (2D): " << theSmallTree.m_MC_weight * theSmallTree.m_PUReweight * theSmallTree.m_IdFakeSF_deep_2d * theSmallTree.m_trigSF << endl;
+		  cout << "Yield weight deep (2D): " << theSmallTree.m_MC_weight * theSmallTree.m_PUReweight * theSmallTree.m_dauSFs * theSmallTree.m_trigSF << endl;
 		  cout << "------------------------" << endl;
 		  cout << "--- FINAL DEBUG ---"      << endl;
 		  cout << "nbjetscand: "             << theSmallTree.m_nbjetscand << endl;

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -2616,18 +2616,18 @@ int main (int argc, char** argv)
 			}
 
 			else if (pType == 0) {
-			// use absolute value of eta for muons, because the SFs are given from 0 to 2.4
-			float leg1_muID_SF = myIDandISOScaleFactor[0]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
-			float leg1_muID_SFerr = myIDandISOScaleFactor[0]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
-			float leg1_muIso_SF = myIDandISOScaleFactor[2]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
-			float leg1_muIso_SFerr = myIDandISOScaleFactor[2]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
+				// use absolute value of eta for muons, because the SFs are given from 0 to 2.4
+				float leg1_muID_SF = myIDandISOScaleFactor[0]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
+				float leg1_muID_SFerr = myIDandISOScaleFactor[0]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
+				float leg1_muIso_SF = myIDandISOScaleFactor[2]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
+				float leg1_muIso_SFerr = myIDandISOScaleFactor[2]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
 
-			idSF_leg1 = leg1_muID_SF * leg1_muIso_SF;
-			idSF_leg1_muID_up = (leg1_muID_SF + leg1_muID_SFerr) * leg1_muIso_SF;
-			idSF_leg1_muID_down = (leg1_muID_SF - leg1_muID_SFerr) * leg1_muIso_SF;
+				idSF_leg1 = leg1_muID_SF * leg1_muIso_SF;
+				idSF_leg1_muID_up = (leg1_muID_SF + leg1_muID_SFerr) * leg1_muIso_SF;
+				idSF_leg1_muID_down = (leg1_muID_SF - leg1_muID_SFerr) * leg1_muIso_SF;
 
-			idSF_leg1_muIso_up = leg1_muID_SF * (leg1_muIso_SF + leg1_muIso_SFerr);
-			idSF_leg1_muIso_down = leg1_muID_SF * (leg1_muIso_SF - leg1_muIso_SFerr);
+				idSF_leg1_muIso_up = leg1_muID_SF * (leg1_muIso_SF + leg1_muIso_SFerr);
+				idSF_leg1_muIso_down = leg1_muID_SF * (leg1_muIso_SF - leg1_muIso_SFerr);
 			}
 
 			else if (pType == 1) {
@@ -2673,31 +2673,31 @@ int main (int argc, char** argv)
 			idSF_leg2_muIso_down = leg2_muID_SF * (leg2_muIso_SF - leg2_muIso_SFerr);
 		}
 		else if(pType == 4) { //EleEle
-				//TODO: should be super cluster eta (not available in bigntuples at the moment)
-				float leg1_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
-				float leg1_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
-				float leg1_eleReco_SF = myIDandISOScaleFactor[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
-				float leg1_eleReco_SFerr = myIDandISOScaleFactor[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+			//TODO: should be super cluster eta (not available in bigntuples at the moment)
+			float leg1_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+			float leg1_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+			float leg1_eleReco_SF = myIDandISOScaleFactor[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+			float leg1_eleReco_SFerr = myIDandISOScaleFactor[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
 
-				idSF_leg1 = leg1_eleID_SF;
-				idSF_leg1_eleID_up = leg1_eleID_SF + leg1_eleID_SFerr;
-				idSF_leg1_eleID_down = leg1_eleID_SF - leg1_eleID_SFerr;
+			idSF_leg1 = leg1_eleID_SF;
+			idSF_leg1_eleID_up = leg1_eleID_SF + leg1_eleID_SFerr;
+			idSF_leg1_eleID_down = leg1_eleID_SF - leg1_eleID_SFerr;
 
-				idSF_leg1_eleReco_up = leg1_eleID_SF * (leg1_eleReco_SF + leg1_eleReco_SFerr);
-				idSF_leg1_eleReco_down = leg1_eleID_SF * (leg1_eleReco_SF - leg1_eleReco_SFerr);
+			idSF_leg1_eleReco_up = leg1_eleID_SF * (leg1_eleReco_SF + leg1_eleReco_SFerr);
+			idSF_leg1_eleReco_down = leg1_eleID_SF * (leg1_eleReco_SF - leg1_eleReco_SFerr);
 
-				//TODO: should be super cluster eta (not available in bigntuples at the moment)
-				float leg2_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
-				float leg2_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
-				float leg2_eleReco_SF = myIDandISOScaleFactor[3]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
-				float leg2_eleReco_SFerr = myIDandISOScaleFactor[3]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
+			//TODO: should be super cluster eta (not available in bigntuples at the moment)
+			float leg2_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
+			float leg2_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
+			float leg2_eleReco_SF = myIDandISOScaleFactor[3]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
+			float leg2_eleReco_SFerr = myIDandISOScaleFactor[3]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
 
-				idSF_leg2 = leg2_eleID_SF;
-				idSF_leg2_eleID_up = leg2_eleID_SF + leg2_eleID_SFerr;
-				idSF_leg2_eleID_down = leg2_eleID_SF - leg2_eleID_SFerr;
+			idSF_leg2 = leg2_eleID_SF;
+			idSF_leg2_eleID_up = leg2_eleID_SF + leg2_eleID_SFerr;
+			idSF_leg2_eleID_down = leg2_eleID_SF - leg2_eleID_SFerr;
 
-				idSF_leg2_eleReco_up = leg2_eleID_SF * (leg2_eleReco_SF + leg2_eleReco_SFerr);
-				idSF_leg2_eleReco_down = leg2_eleID_SF * (leg2_eleReco_SF - leg2_eleReco_SFerr);
+			idSF_leg2_eleReco_up = leg2_eleID_SF * (leg2_eleReco_SF + leg2_eleReco_SFerr);
+			idSF_leg2_eleReco_down = leg2_eleID_SF * (leg2_eleReco_SF - leg2_eleReco_SFerr);
 		}
 	  }
 

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -2687,9 +2687,13 @@ int main (int argc, char** argv)
 			idSF_leg2_muIso_up = leg2_muID_SF * (leg2_muIso_SF + leg2_muIso_SFerr);
 			idSF_leg2_muIso_down = leg2_muID_SF * (leg2_muIso_SF - leg2_muIso_SFerr);
 
+			idSF_leg1_eleID_up = idSF_leg1;
+			idSF_leg1_eleID_down = idSF_leg1;
 			idSF_leg2_eleID_up = idSF_leg2;
 			idSF_leg2_eleID_down = idSF_leg2;
 
+			idSF_leg1_eleReco_up = idSF_leg1;
+			idSF_leg1_eleReco_down = idSF_leg1;
 			idSF_leg2_eleReco_up = idSF_leg2;
 			idSF_leg2_eleReco_down = idSF_leg2;
 
@@ -2739,17 +2743,21 @@ int main (int argc, char** argv)
 
 			idSF_leg2 = leg2_eleID_SF;
 
-			idSF_leg2_muID_up = idSF_leg2;
-			idSF_leg2_muID_down = idSF_leg2;
-
-			idSF_leg2_muIso_up = idSF_leg2;
-			idSF_leg2_muIso_down = idSF_leg2;
-
 			idSF_leg2_eleID_up = leg2_eleReco_SF * (leg2_eleID_SF + leg2_eleID_SFerr);
 			idSF_leg2_eleID_down = leg2_eleReco_SF * (leg2_eleID_SF - leg2_eleID_SFerr);
 
 			idSF_leg2_eleReco_up = (leg2_eleReco_SF + leg2_eleReco_SFerr) * leg2_eleID_SF;
 			idSF_leg2_eleReco_down = (leg2_eleReco_SF - leg2_eleReco_SFerr) * leg2_eleID_SF;
+
+			idSF_leg1_muID_up = idSF_leg1;
+			idSF_leg1_muID_down = idSF_leg1;
+			idSF_leg2_muID_up = idSF_leg2;
+			idSF_leg2_muID_down = idSF_leg2;
+
+			idSF_leg1_muIso_up = idSF_leg1;
+			idSF_leg1_muIso_down = idSF_leg1;
+			idSF_leg2_muIso_up = idSF_leg2;
+			idSF_leg2_muIso_down = idSF_leg2;
 
 			idSF_leg1_deep_vsJet_2d = idSF_leg1;
 			idSF_leg2_deep_vsJet_2d = idSF_leg2;
@@ -4988,7 +4996,6 @@ int main (int argc, char** argv)
 		  theSmallTree.m_btau_deltaRmax = *std::max_element(dRBTau.begin(), dRBTau.end());
 
 		  // loop over jets
-		  int genjets = 0;
 		  for (unsigned int iJet = 0; (iJet < theBigTree.jets_px->size ()) && (theSmallTree.m_njets < maxNjetsSaved); ++iJet)
 			{
 			  // PG filter jets at will
@@ -5036,7 +5043,6 @@ int main (int argc, char** argv)
 						{
 						  hasgj = true;
 						}
-					  genjets ++;
 					}
 				}
 

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -2680,11 +2680,11 @@ int main (int argc, char** argv)
 			float leg1_eleID_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
 
 			idSF_leg1 = leg1_eleID_SF;
-			idSF_leg1_eleID_up = leg1_eleID_SF + leg1_eleID_SFerr;
-			idSF_leg1_eleID_down = leg1_eleID_SF - leg1_eleID_SFerr;
+			idSF_leg1_eleID_up = leg1_eleReco_SF * (leg1_eleID_SF + leg1_eleID_SFerr);
+			idSF_leg1_eleID_down = leg1_eleReco_SF * (leg1_eleID_SF - leg1_eleID_SFerr);
 
-			idSF_leg1_eleReco_up = leg1_eleID_SF * (leg1_eleReco_SF + leg1_eleReco_SFerr);
-			idSF_leg1_eleReco_down = leg1_eleID_SF * (leg1_eleReco_SF - leg1_eleReco_SFerr);
+			idSF_leg1_eleReco_up = (leg1_eleReco_SF + leg1_eleReco_SFerr) * leg1_eleID_SF;
+			idSF_leg1_eleReco_down = (leg1_eleReco_SF - leg1_eleReco_SFerr) * leg1_eleID_SF;
 
 			//TODO: should be super cluster eta (not available in bigntuples at the moment)
 			float leg2_eleReco_SF = lepSFs[2]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
@@ -2693,11 +2693,11 @@ int main (int argc, char** argv)
 			float leg2_eleID_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
 
 			idSF_leg2 = leg2_eleID_SF;
-			idSF_leg2_eleID_up = leg2_eleID_SF + leg2_eleID_SFerr;
-			idSF_leg2_eleID_down = leg2_eleID_SF - leg2_eleID_SFerr;
+			idSF_leg2_eleID_up = leg2_eleReco_SF * (leg2_eleID_SF + leg2_eleID_SFerr);
+			idSF_leg2_eleID_down = leg2_eleReco_SF * (leg2_eleID_SF - leg2_eleID_SFerr);
 
-			idSF_leg2_eleReco_up = leg2_eleID_SF * (leg2_eleReco_SF + leg2_eleReco_SFerr);
-			idSF_leg2_eleReco_down = leg2_eleID_SF * (leg2_eleReco_SF - leg2_eleReco_SFerr);
+			idSF_leg2_eleReco_up = (leg2_eleReco_SF + leg2_eleReco_SFerr) * leg2_eleID_SF;
+			idSF_leg2_eleReco_down = (leg2_eleReco_SF - leg2_eleReco_SFerr) * leg2_eleID_SF;
 		}
 	  }
 

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -610,41 +610,41 @@ int main (int argc, char** argv)
   }
     
   // electron/muon IdAndIso SF
-  ScaleFactor * myIDandISOScaleFactor[3]; // [0: muID, 1: eleID, 2:muISO, 3:eleReco]
+  ScaleFactor * lepSFs[4]; // [0: muID, 1: eleID, 2:muISO, 3:eleReco]
   for (int i=0; i<4; i++) {
-    myIDandISOScaleFactor[i] = new ScaleFactor();
+    lepSFs[i] = new ScaleFactor();
   }
   if (PERIOD == "2018") {
-	myIDandISOScaleFactor[0]->init_ScaleFactor("weights/MuPogSF_UL/2018/Efficiencies_muon_generalTracks_Z_Run2018_UL_ID.root",
+	lepSFs[0]->init_ScaleFactor("weights/MuPogSF_UL/2018/Efficiencies_muon_generalTracks_Z_Run2018_UL_ID.root",
                                                "NUM_TightID_DEN_TrackerMuons_abseta_pt", true);
-	myIDandISOScaleFactor[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi.txt_Ele_wp80iso_EGM2D.root", false);
-	myIDandISOScaleFactor[2] -> init_ScaleFactor("weights/MuPogSF_UL/2018/Efficiencies_muon_generalTracks_Z_Run2018_UL_ISO.root",
+	lepSFs[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi.txt_Ele_wp80iso_EGM2D.root", false);
+	lepSFs[2] -> init_ScaleFactor("weights/MuPogSF_UL/2018/Efficiencies_muon_generalTracks_Z_Run2018_UL_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
-	myIDandISOScaleFactor[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi_ptAbove20.txt_EGM2D_UL2018.root", false);
+	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2018/egammaEffi_ptAbove20.txt_EGM2D_UL2018.root", false);
   }
   else if (PERIOD == "2017") {
-	myIDandISOScaleFactor[0] -> init_ScaleFactor("weights/MuPogSF_UL/2017/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.root",
+	lepSFs[0] -> init_ScaleFactor("weights/MuPogSF_UL/2017/Efficiencies_muon_generalTracks_Z_Run2017_UL_ID.root",
 												 "NUM_TightID_DEN_TrackerMuons_abseta_pt", true);
-	myIDandISOScaleFactor[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi.txt_EGM2D_MVA80iso_UL17.root", false);
-	myIDandISOScaleFactor[2] -> init_ScaleFactor("weights/MuPogSF_UL/2017/Efficiencies_muon_generalTracks_Z_Run2017_UL_ISO.root",
+	lepSFs[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi.txt_EGM2D_MVA80iso_UL17.root", false);
+	lepSFs[2] -> init_ScaleFactor("weights/MuPogSF_UL/2017/Efficiencies_muon_generalTracks_Z_Run2017_UL_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
-	myIDandISOScaleFactor[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi_ptAbove20.txt_EGM2D_UL2017.root", false);
+	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2017/egammaEffi_ptAbove20.txt_EGM2D_UL2017.root", false);
   }
   else if (PERIOD == "2016preVFP") {
-	myIDandISOScaleFactor[0] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ID.root",
+	lepSFs[0] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ID.root",
 												 "NUM_TightID_DEN_TrackerMuons_abseta_pt", true);
-	myIDandISOScaleFactor[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi.txt_Ele_wp80iso_preVFP_EGM2D.root",false);
-	myIDandISOScaleFactor[2] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ISO.root",
+	lepSFs[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi.txt_Ele_wp80iso_preVFP_EGM2D.root",false);
+	lepSFs[2] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_HIPM_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
-	myIDandISOScaleFactor[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptAbove20.txt_EGM2D_UL2016preVFP.root", false);
+	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptAbove20.txt_EGM2D_UL2016preVFP.root", false);
   }
   else if (PERIOD == "2016postVFP") {
-	myIDandISOScaleFactor[0] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_ID.root",
+	lepSFs[0] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_ID.root",
 												 "NUM_TightID_DEN_TrackerMuons_abseta_pt", true);
-	myIDandISOScaleFactor[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi.txt_Ele_wp80iso_postVFP_EGM2D.root", false);
-	myIDandISOScaleFactor[2] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_ISO.root",
+	lepSFs[1] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi.txt_Ele_wp80iso_postVFP_EGM2D.root", false);
+	lepSFs[2] -> init_ScaleFactor("weights/MuPogSF_UL/2016/Efficiencies_muon_generalTracks_Z_Run2016_UL_ISO.root",
 												 "NUM_TightRelIso_DEN_TightIDandIPCut_abseta_pt", true);
-	myIDandISOScaleFactor[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptAbove20.txt_EGM2D_UL2016postVFP.root", false);
+	lepSFs[3] -> init_EG_ScaleFactor("weights/EgammaPOGSF_UL/2016/egammaEffi_ptAbove20.txt_EGM2D_UL2016postVFP.root", false);
   }
   
   // tau IdAndIso SF
@@ -2617,10 +2617,10 @@ int main (int argc, char** argv)
 
 			else if (pType == 0) {
 				// use absolute value of eta for muons, because the SFs are given from 0 to 2.4
-				float leg1_muID_SF = myIDandISOScaleFactor[0]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
-				float leg1_muID_SFerr = myIDandISOScaleFactor[0]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
-				float leg1_muIso_SF = myIDandISOScaleFactor[2]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
-				float leg1_muIso_SFerr = myIDandISOScaleFactor[2]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
+				float leg1_muID_SF = lepSFs[0]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
+				float leg1_muID_SFerr = lepSFs[0]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
+				float leg1_muIso_SF = lepSFs[2]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
+				float leg1_muIso_SFerr = lepSFs[2]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
 
 				idSF_leg1 = leg1_muID_SF * leg1_muIso_SF;
 				idSF_leg1_muID_up = (leg1_muID_SF + leg1_muID_SFerr) * leg1_muIso_SF;
@@ -2632,10 +2632,10 @@ int main (int argc, char** argv)
 
 			else if (pType == 1) {
 				//TODO: should be super cluster eta (not available in bigntuples at the moment)
-				float leg1_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
-				float leg1_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
-				float leg1_eleReco_SF = myIDandISOScaleFactor[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
-				float leg1_eleReco_SFerr = myIDandISOScaleFactor[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+				float leg1_eleID_SF = lepSFs[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+				float leg1_eleID_SFerr = lepSFs[1]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+				float leg1_eleReco_SF = lepSFs[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+				float leg1_eleReco_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
 
 				idSF_leg1 = leg1_eleID_SF * leg1_eleReco_SF;
 				idSF_leg1_eleID_up = (leg1_eleID_SF + leg1_eleID_SFerr) * leg1_eleReco_SF;
@@ -2647,10 +2647,10 @@ int main (int argc, char** argv)
 		}
 		else if(pType == 3) { //MuMu
 			// use absolute value of eta for muons, because the SFs are given from 0 to 2.4
-			float leg1_muID_SF = myIDandISOScaleFactor[0]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
-			float leg1_muID_SFerr = myIDandISOScaleFactor[0]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
-			float leg1_muIso_SF = myIDandISOScaleFactor[2]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
-			float leg1_muIso_SFerr = myIDandISOScaleFactor[2]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
+			float leg1_muID_SF = lepSFs[0]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
+			float leg1_muID_SFerr = lepSFs[0]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
+			float leg1_muIso_SF = lepSFs[2]->get_ScaleFactor(leg1pt, fabs(leg1eta), pType);
+			float leg1_muIso_SFerr = lepSFs[2]->get_ScaleFactorError(leg1pt, fabs(leg1eta), pType);
 
 			idSF_leg1 = leg1_muID_SF * leg1_muIso_SF;
 			idSF_leg1_muID_up = (leg1_muID_SF + leg1_muID_SFerr) * leg1_muIso_SF;
@@ -2660,10 +2660,10 @@ int main (int argc, char** argv)
 			idSF_leg1_muIso_down = leg1_muID_SF * (leg1_muIso_SF - leg1_muIso_SFerr);
 
 			// use absolute value of eta for muons, because the SFs are given from 0 to 2.4
-			float leg2_muID_SF = myIDandISOScaleFactor[0]->get_ScaleFactor(leg2pt, fabs(leg2eta), pType);
-			float leg2_muID_SFerr = myIDandISOScaleFactor[0]->get_ScaleFactorError(leg2pt, fabs(leg2eta), pType);
-			float leg2_muIso_SF = myIDandISOScaleFactor[2]->get_ScaleFactor(leg2pt, fabs(leg2eta), pType);
-			float leg2_muIso_SFerr = myIDandISOScaleFactor[2]->get_ScaleFactorError(leg2pt, fabs(leg2eta), pType);
+			float leg2_muID_SF = lepSFs[0]->get_ScaleFactor(leg2pt, fabs(leg2eta), pType);
+			float leg2_muID_SFerr = lepSFs[0]->get_ScaleFactorError(leg2pt, fabs(leg2eta), pType);
+			float leg2_muIso_SF = lepSFs[2]->get_ScaleFactor(leg2pt, fabs(leg2eta), pType);
+			float leg2_muIso_SFerr = lepSFs[2]->get_ScaleFactorError(leg2pt, fabs(leg2eta), pType);
 
 			idSF_leg2 = leg2_muID_SF * leg2_muIso_SF;
 			idSF_leg2_muID_up = (leg2_muID_SF + leg2_muID_SFerr) * leg2_muIso_SF;
@@ -2674,10 +2674,10 @@ int main (int argc, char** argv)
 		}
 		else if(pType == 4) { //EleEle
 			//TODO: should be super cluster eta (not available in bigntuples at the moment)
-			float leg1_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
-			float leg1_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
-			float leg1_eleReco_SF = myIDandISOScaleFactor[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
-			float leg1_eleReco_SFerr = myIDandISOScaleFactor[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+			float leg1_eleID_SF = lepSFs[1]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+			float leg1_eleID_SFerr = lepSFs[1]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
+			float leg1_eleReco_SF = lepSFs[3]->get_direct_ScaleFactor(leg1pt, leg1eta, pType);
+			float leg1_eleReco_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg1pt, leg1eta, pType);
 
 			idSF_leg1 = leg1_eleID_SF;
 			idSF_leg1_eleID_up = leg1_eleID_SF + leg1_eleID_SFerr;
@@ -2687,10 +2687,10 @@ int main (int argc, char** argv)
 			idSF_leg1_eleReco_down = leg1_eleID_SF * (leg1_eleReco_SF - leg1_eleReco_SFerr);
 
 			//TODO: should be super cluster eta (not available in bigntuples at the moment)
-			float leg2_eleID_SF = myIDandISOScaleFactor[1]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
-			float leg2_eleID_SFerr = myIDandISOScaleFactor[1]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
-			float leg2_eleReco_SF = myIDandISOScaleFactor[3]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
-			float leg2_eleReco_SFerr = myIDandISOScaleFactor[3]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
+			float leg2_eleID_SF = lepSFs[1]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
+			float leg2_eleID_SFerr = lepSFs[1]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
+			float leg2_eleReco_SF = lepSFs[3]->get_direct_ScaleFactor(leg2pt, leg2eta, pType);
+			float leg2_eleReco_SFerr = lepSFs[3]->get_direct_ScaleFactorError(leg2pt, leg2eta, pType);
 
 			idSF_leg2 = leg2_eleID_SF;
 			idSF_leg2_eleID_up = leg2_eleID_SF + leg2_eleID_SFerr;


### PR DESCRIPTION
This PR adds the following:

- electron reco scale factors (+ the uncertainties)
- Id (+ Iso for muons) SF uncertainties
- a veto for electrons in the ecal barrel/endcap transition region (between 1.44 and 1.57, see [here](https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2#Recommended_MVA_Recipe_V2_for_re))

Technically the electron SFs and the veto should use the ECAL supercluster eta, but we don't have that in our current bigntuples ([scale factors](https://twiki.cern.ch/twiki/bin/view/CMS/EgammaIDRecipesRun2#Efficiencies_and_scale_factors))

The SF files are taken from from here: https://twiki.cern.ch/twiki/bin/view/CMS/EgammaUL2016To2018 but were already in our repo



