### PR TITLE
Add Tau dataset to all channels.

### DIFF
--- a/config/mainCfg_ETau_UL16.cfg
+++ b/config/mainCfg_ETau_UL16.cfg
@@ -1,7 +1,7 @@
 [general]
 lumi = 16800 # pb^-1 2016 postVFP
 
-data = DsingleEleF, DsingleEleG, DsingleEleH, DMETF, DMETG, DMETH
+data = DsingleEleF, DsingleEleG, DsingleEleH, DMETF, DMETG, DMETH, DTauF, DTauG, DTauH
 
 signals = GGF_Radion250, GGF_Radion260, GGF_Radion270, GGF_Radion280, GGF_Radion300, GGF_Radion320, GGF_Radion350, GGF_Radion400, GGF_Radion450, GGF_Radion500, GGF_Radion550, GGF_Radion600, GGF_Radion650, GGF_Radion700,GGF_Radion750, GGF_Radion800, GGF_Radion850, GGF_Radion900, GGF_Radion1000, GGF_Radion1250, GGF_Radion1500, GGF_Radion1750, GGF_Radion2000, GGF_Radion2500, GGF_Radion3000
 
@@ -19,7 +19,7 @@ cutCfg    = config/selectionCfg_ETau_UL16.cfg
 #pattern   = goodsystfiles  # use this only when running on systematics files
 
 [merge_plots]
-data_obs	= DsingleEleF, DsingleEleG, DsingleEleH, DMETF, DMETG, DMETH
+data_obs	= DsingleEleF, DsingleEleG, DsingleEleH, DMETF, DMETG, DMETH, DTauF, DTauG, DTauH
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf
@@ -39,7 +39,7 @@ other		= EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, TW
 #VVV		= WWW, WWZ, WZZ, ZZZ
 
 # For limits
-data_obs	= DsingleEleF, DsingleEleG, DsingleEleH, DMETF, DMETG, DMETH
+data_obs	= DsingleEleF, DsingleEleG, DsingleEleH, DMETF, DMETG, DMETH, DTauF, DTauG, DTauH
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf

--- a/config/mainCfg_ETau_UL16APV.cfg
+++ b/config/mainCfg_ETau_UL16APV.cfg
@@ -1,7 +1,7 @@
 [general]
 lumi = 19500 # pb^-1 2016 preVFP
 
-data = DsingleEleB, DsingleEleC, DsingleEleD, DsingleEleE, DsingleEleF, DMETB, DMETC, DMETD, DMETE, DMETF
+data = DsingleEleB, DsingleEleC, DsingleEleD, DsingleEleE, DsingleEleF, DMETB, DMETC, DMETD, DMETE, DMETF, DTauB, DTauC, DTauD, DTauE, DTauF
 
 signals = GGF_Radion250, GGF_Radion260, GGF_Radion270, GGF_Radion280, GGF_Radion300, GGF_Radion320, GGF_Radion350, GGF_Radion400, GGF_Radion450, GGF_Radion500, GGF_Radion550, GGF_Radion600, GGF_Radion650, GGF_Radion700,GGF_Radion750, GGF_Radion800, GGF_Radion850, GGF_Radion900, GGF_Radion1000, GGF_Radion1250, GGF_Radion1500, GGF_Radion1750, GGF_Radion2000, GGF_Radion2500, GGF_Radion3000
 
@@ -19,7 +19,7 @@ cutCfg    = config/selectionCfg_ETau_UL16APV.cfg
 #pattern   = goodsystfiles  # use this only when running on systematics files
 
 [merge_plots]
-data_obs	= DsingleEleB, DsingleEleC, DsingleEleD, DsingleEleE, DsingleEleF, DMETB, DMETC, DMETD, DMETE, DMETF
+data_obs	= DsingleEleB, DsingleEleC, DsingleEleD, DsingleEleE, DsingleEleF, DMETB, DMETC, DMETD, DMETE, DMETF, DTauB, DTauC, DTauD, DTauE, DTauF
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf
@@ -39,7 +39,7 @@ other		= EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, TW
 #VVV     = WWW, WWZ, WZZ, ZZZ
 
 # For limits
-data_obs = DsingleEleB, DsingleEleC, DsingleEleD, DsingleEleE, DsingleEleF, DMETB, DMETC, DMETD, DMETE, DMETF
+data_obs = DsingleEleB, DsingleEleC, DsingleEleD, DsingleEleE, DsingleEleF, DMETB, DMETC, DMETD, DMETE, DMETF, DTauB, DTauC, DTauD, DTauE, DTauF
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf

--- a/config/mainCfg_ETau_UL17.cfg
+++ b/config/mainCfg_ETau_UL17.cfg
@@ -1,7 +1,7 @@
 [general]
 lumi = 41529 # pb^-1 full 2017
 
-data = EGamma_Run2017B, EGamma_Run2017C, EGamma_Run2017D, EGamma_Run2017E, EGamma_Run2017F, MET_Run2017B, MET_Run2017C, MET_Run2017D, MET_Run2017E, MET_Run2017F
+data = EGamma_Run2017B, EGamma_Run2017C, EGamma_Run2017D, EGamma_Run2017E, EGamma_Run2017F, MET_Run2017B, MET_Run2017C, MET_Run2017D, MET_Run2017E, MET_Run2017F, Tau_Run2017B, Tau_Run2017C, Tau_Run2017D, Tau_Run2017E, Tau_Run2017F
 
 signals = GGF_Radion250, GGF_Radion260, GGF_Radion270, GGF_Radion280, GGF_Radion300, GGF_Radion320, GGF_Radion350, GGF_Radion400, GGF_Radion450, GGF_Radion500, GGF_Radion550, GGF_Radion600, GGF_Radion650, GGF_Radion700, GGF_Radion750, GGF_Radion800, GGF_Radion850, GGF_Radion900, GGF_Radion1000, GGF_Radion1250, GGF_Radion1500, GGF_Radion1750, GGF_Radion2000, GGF_Radion2500, GGF_Radion3000
 
@@ -19,7 +19,7 @@ cutCfg    = config/selectionCfg_ETau_UL17.cfg
 #pattern  = goodsystfiles  # use this only when running on systematics files
 
 [merge_plots]
-data_obs    = EGamma_Run2017B, EGamma_Run2017C, EGamma_Run2017D, EGamma_Run2017E, EGamma_Run2017F, MET_Run2017B, MET_Run2017C, MET_Run2017D, MET_Run2017E, MET_Run2017F 
+data_obs    = EGamma_Run2017B, EGamma_Run2017C, EGamma_Run2017D, EGamma_Run2017E, EGamma_Run2017F, MET_Run2017B, MET_Run2017C, MET_Run2017D, MET_Run2017E, MET_Run2017F, Tau_Run2017B, Tau_Run2017C, Tau_Run2017D, Tau_Run2017E, Tau_Run2017F
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf
@@ -27,7 +27,7 @@ H           = ZH_HTauTau, ZH_HBB_ZLL, ZH_HBB_ZQQ, WplusHTauTau, WminusHTauTau, t
 other		= EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, TWantitop, singleTop_top, singleTop_antitop, TTWW, TTWZ, TTZZ, TTWJetsToQQ, WWW, WWZ, WZZ, ZZZ, WW, WZ, ZZ, TTWJetsToLNu, TTZToQQ, TTZToLLNuNu
 
 [merge_limits]
-data_obs    = EGamma_Run2017B, EGamma_Run2017C, EGamma_Run2017D, EGamma_Run2017E, EGamma_Run2017F, MET_Run2017B, MET_Run2017C, MET_Run2017D, MET_Run2017E, MET_Run2017F 
+data_obs    = EGamma_Run2017B, EGamma_Run2017C, EGamma_Run2017D, EGamma_Run2017E, EGamma_Run2017F, MET_Run2017B, MET_Run2017C, MET_Run2017D, MET_Run2017E, MET_Run2017F, Tau_Run2017B, Tau_Run2017C, Tau_Run2017D, Tau_Run2017E, Tau_Run2017F 
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf

--- a/config/mainCfg_ETau_UL18.cfg
+++ b/config/mainCfg_ETau_UL18.cfg
@@ -2,7 +2,7 @@
 lumi = 59741 # pb^-1
 lumi_fb = 60.0 # fb^-1
 
-data = DsingleEleA, DsingleEleB, DsingleEleC, DsingleEleD, DMETA, DMETB, DMETC, DMETD
+data = DsingleEleA, DsingleEleB, DsingleEleC, DsingleEleD, DMETA, DMETB, DMETC, DMETD, DTauA, DTauB, DTauC, DTauD
 
 signals = GGF_Radion250, GGF_Radion260, GGF_Radion270, GGF_Radion280, GGF_Radion300, GGF_Radion320, GGF_Radion350, GGF_Radion400, GGF_Radion450, GGF_Radion500, GGF_Radion550, GGF_Radion600, GGF_Radion650, GGF_Radion700, GGF_Radion750, GGF_Radion800, GGF_Radion850, GGF_Radion900, GGF_Radion1000, GGF_Radion1250, GGF_Radion1500, GGF_Radion1750, GGF_Radion2000, GGF_Radion2500, GGF_Radion3000
 
@@ -19,7 +19,7 @@ sampleCfg = config/sampleCfg_UL18.cfg
 cutCfg    = config/selectionCfg_ETau_UL18.cfg
 
 [merge_plots]
-data_obs	= DsingleEleA, DsingleEleB, DsingleEleC, DsingleEleD, DMETA, DMETB, DMETC, DMETD
+data_obs	= DsingleEleA, DsingleEleB, DsingleEleC, DsingleEleD, DMETA, DMETB, DMETC, DMETD, DTauA, DTauB, DTauC, DTauD
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf
@@ -27,7 +27,7 @@ H           = ZH_HTauTau, ZH_HBB_ZLL, ZH_HBB_ZQQ, WplusHTauTau, WminusHTauTau, t
 other		= EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, TWantitop, singleTop_top, singleTop_antitop, TTWW, TTWZ, TTZZ, TTWJetsToQQ, WWW_1, WWW_2, WWZ_1, WWZ_2, WZZ_1, WZZ_2, ZZZ_1, ZZZ_2, WW, WZ, ZZ, TTWJetsToLNu, TTZToQQ, TTZToLLNuNu
 
 [merge_limits]
-data_obs	= DsingleEleA, DsingleEleB, DsingleEleC, DsingleEleD, DMETA, DMETB, DMETC, DMETD
+data_obs	= DsingleEleA, DsingleEleB, DsingleEleC, DsingleEleD, DMETA, DMETB, DMETC, DMETD, DTauA, DTauB, DTauC, DTauD
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf

--- a/config/mainCfg_MuTau_UL16.cfg
+++ b/config/mainCfg_MuTau_UL16.cfg
@@ -1,7 +1,7 @@
 [general]
 lumi = 16800 # pb^-1 2016 postVFP
 
-data = DsingleMuF, DsingleMuG, DsingleMuH, DMETF, DMETG, DMETH
+data = DsingleMuF, DsingleMuG, DsingleMuH, DMETF, DMETG, DMETH, DTauF, DTauG, DTauH
 
 signals = GGF_Radion250, GGF_Radion260, GGF_Radion270, GGF_Radion280, GGF_Radion300, GGF_Radion320, GGF_Radion350, GGF_Radion400, GGF_Radion450, GGF_Radion500, GGF_Radion550, GGF_Radion600, GGF_Radion650, GGF_Radion700,GGF_Radion750, GGF_Radion800, GGF_Radion850, GGF_Radion900, GGF_Radion1000, GGF_Radion1250, GGF_Radion1500, GGF_Radion1750, GGF_Radion2000, GGF_Radion2500, GGF_Radion3000
 
@@ -19,7 +19,7 @@ cutCfg    = config/selectionCfg_MuTau_UL16.cfg
 #pattern   = goodsystfiles  # use this only when running on systematics files
 
 [merge_plots]
-data_obs	= DsingleMuF, DsingleMuG, DsingleMuH, DMETF, DMETG, DMETH
+data_obs	= DsingleMuF, DsingleMuG, DsingleMuH, DMETF, DMETG, DMETH, DTauF, DTauG, DTauH
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf
@@ -39,7 +39,7 @@ other		= EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, TW
 #VVV     = WWW, WWZ, WZZ, ZZZ
 
 # For limits
-data_obs    = DsingleMuF, DsingleMuG, DsingleMuH, DMETF, DMETG, DMETH
+data_obs    = DsingleMuF, DsingleMuG, DsingleMuH, DMETF, DMETG, DMETH, DTauF, DTauG, DTauH
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf

--- a/config/mainCfg_MuTau_UL16APV.cfg
+++ b/config/mainCfg_MuTau_UL16APV.cfg
@@ -1,7 +1,7 @@
 [general]
 lumi = 19500 # pb^-1 2016 preVFP
 
-data = DsingleMuB, DsingleMuC, DsingleMuD, DsingleMuE, DsingleMuF, DMETB, DMETC, DMETD, DMETE, DMETF
+data = DsingleMuB, DsingleMuC, DsingleMuD, DsingleMuE, DsingleMuF, DMETB, DMETC, DMETD, DMETE, DMETF, DTauB, DTauC, DTauD, DTauE, DTauF
 
 signals = GGF_Radion250, GGF_Radion260, GGF_Radion270, GGF_Radion280, GGF_Radion300, GGF_Radion320, GGF_Radion350, GGF_Radion400, GGF_Radion450, GGF_Radion500, GGF_Radion550, GGF_Radion600, GGF_Radion650, GGF_Radion700,GGF_Radion750, GGF_Radion800, GGF_Radion850, GGF_Radion900, GGF_Radion1000, GGF_Radion1250, GGF_Radion1500, GGF_Radion1750, GGF_Radion2000, GGF_Radion2500, GGF_Radion3000
 
@@ -19,7 +19,7 @@ cutCfg    = config/selectionCfg_MuTau_UL16APV.cfg
 #pattern   = goodsystfiles  # use this only when running on systematics files
 
 [merge_plots]
-data_obs	= DsingleMuB, DsingleMuC, DsingleMuD, DsingleMuE, DsingleMuF, DMETB, DMETC, DMETD, DMETE, DMETF
+data_obs	= DsingleMuB, DsingleMuC, DsingleMuD, DsingleMuE, DsingleMuF, DMETB, DMETC, DMETD, DMETE, DMETF, DTauB, DTauC, DTauD, DTauE, DTauF
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf
@@ -39,7 +39,7 @@ other		= EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, TW
 #VVV     = WWW, WWZ, WZZ, ZZZ
 
 # For limits
-data_obs = DsingleMuB, DsingleMuC, DsingleMuD, DsingleMuE, DsingleMuF, DMETB, DMETC, DMETD, DMETE, DMETF
+data_obs = DsingleMuB, DsingleMuC, DsingleMuD, DsingleMuE, DsingleMuF, DMETB, DMETC, DMETD, DMETE, DMETF, DTauB, DTauC, DTauD, DTauE, DTauF
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf

--- a/config/mainCfg_MuTau_UL17.cfg
+++ b/config/mainCfg_MuTau_UL17.cfg
@@ -1,7 +1,7 @@
 [general]
 lumi = 41529 # pb^-1 full 2017
 
-data = SingleMuon_Run2017B, SingleMuon_Run2017C, SingleMuon_Run2017D, SingleMuon_Run2017E, SingleMuon_Run2017F, MET_Run2017B, MET_Run2017C, MET_Run2017D, MET_Run2017E, MET_Run2017F 
+data = SingleMuon_Run2017B, SingleMuon_Run2017C, SingleMuon_Run2017D, SingleMuon_Run2017E, SingleMuon_Run2017F, MET_Run2017B, MET_Run2017C, MET_Run2017D, MET_Run2017E, MET_Run2017F, Tau_Run2017B, Tau_Run2017C, Tau_Run2017D, Tau_Run2017E, Tau_Run2017F
 
 signals = GGF_Radion250, GGF_Radion260, GGF_Radion270, GGF_Radion280, GGF_Radion300, GGF_Radion320, GGF_Radion350, GGF_Radion400, GGF_Radion450, GGF_Radion500, GGF_Radion550, GGF_Radion600, GGF_Radion650, GGF_Radion700, GGF_Radion750, GGF_Radion800, GGF_Radion850, GGF_Radion900, GGF_Radion1000, GGF_Radion1250, GGF_Radion1500, GGF_Radion1750, GGF_Radion2000, GGF_Radion2500, GGF_Radion3000
 
@@ -19,7 +19,7 @@ cutCfg    = config/selectionCfg_MuTau_UL17.cfg
 #pattern  = goodsystfiles  # use this only when running on systematics files
 
 [merge_plots]
-data_obs    = SingleMuon_Run2017B, SingleMuon_Run2017C, SingleMuon_Run2017D, SingleMuon_Run2017E, SingleMuon_Run2017F, MET_Run2017B, MET_Run2017C, MET_Run2017D, MET_Run2017E, MET_Run2017F
+data_obs    = SingleMuon_Run2017B, SingleMuon_Run2017C, SingleMuon_Run2017D, SingleMuon_Run2017E, SingleMuon_Run2017F, MET_Run2017B, MET_Run2017C, MET_Run2017D, MET_Run2017E, MET_Run2017F, Tau_Run2017B, Tau_Run2017C, Tau_Run2017D, Tau_Run2017E, Tau_Run2017F
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf
@@ -27,7 +27,7 @@ H           = ZH_HTauTau, ZH_HBB_ZLL, ZH_HBB_ZQQ, WplusHTauTau, WminusHTauTau, t
 other		= EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, TWantitop, singleTop_top, singleTop_antitop, TTWW, TTWZ, TTZZ, TTWJetsToQQ, WWW, WWZ, WZZ, ZZZ, WW, WZ, ZZ, TTWJetsToLNu, TTZToQQ, TTZToLLNuNu
 
 [merge_limits]
-data_obs    = SingleMuon_Run2017B, SingleMuon_Run2017C, SingleMuon_Run2017D, SingleMuon_Run2017E, SingleMuon_Run2017F, MET_Run2017B, MET_Run2017C, MET_Run2017D, MET_Run2017E, MET_Run2017F 
+data_obs    = SingleMuon_Run2017B, SingleMuon_Run2017C, SingleMuon_Run2017D, SingleMuon_Run2017E, SingleMuon_Run2017F, MET_Run2017B, MET_Run2017C, MET_Run2017D, MET_Run2017E, MET_Run2017F, Tau_Run2017B, Tau_Run2017C, Tau_Run2017D, Tau_Run2017E, Tau_Run2017F
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf

--- a/config/mainCfg_MuTau_UL18.cfg
+++ b/config/mainCfg_MuTau_UL18.cfg
@@ -2,7 +2,7 @@
 lumi = 59741 # pb^-1
 lumi_fb = 60.0 # fb^-1
 
-data = DsingleMuA, DsingleMuB, DsingleMuC, DsingleMuD, DMETA, DMETB, DMETC, DMETD
+data = DsingleMuA, DsingleMuB, DsingleMuC, DsingleMuD, DMETA, DMETB, DMETC, DMETD, DTauA, DTauB, DTauC, DTauD
 
 signals = GGF_Radion250, GGF_Radion260, GGF_Radion270, GGF_Radion280, GGF_Radion300, GGF_Radion320, GGF_Radion350, GGF_Radion400, GGF_Radion450, GGF_Radion500, GGF_Radion550, GGF_Radion600, GGF_Radion650, GGF_Radion700, GGF_Radion750, GGF_Radion800, GGF_Radion850, GGF_Radion900, GGF_Radion1000, GGF_Radion1250, GGF_Radion1500, GGF_Radion1750, GGF_Radion2000, GGF_Radion2500, GGF_Radion3000
 
@@ -19,7 +19,7 @@ sampleCfg = config/sampleCfg_UL18.cfg
 cutCfg    = config/selectionCfg_MuTau_UL18.cfg
 
 [merge_plots]
-data_obs    = DsingleMuA, DsingleMuB, DsingleMuC, DsingleMuD, DMETA, DMETB, DMETC, DMETD
+data_obs    = DsingleMuA, DsingleMuB, DsingleMuC, DsingleMuD, DMETA, DMETB, DMETC, DMETD, DTauA, DTauB, DTauC, DTauD
 TT			= TTfullyHad, TTfullyLep, TTsemiLep
 W			= WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY      	= DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf
@@ -27,7 +27,7 @@ H           = ZH_HTauTau, ZH_HBB_ZLL, ZH_HBB_ZQQ, WplusHTauTau, WminusHTauTau, t
 other		= EWKWMinus2Jets_WToLNu, EWKWPlus2Jets_WToLNu, EWKZ2Jets_ZToLL, TWtop, TWantitop, singleTop_top, singleTop_antitop, TTWW, TTWZ, TTZZ, TTWJetsToQQ, WWW_1, WWW_2, WWZ_1, WWZ_2, WZZ_1, WZZ_2, ZZZ_1, ZZZ_2, WW, WZ, ZZ, TTWJetsToLNu, TTZToQQ, TTZToLLNuNu
 
 [merge_limits]
-data_obs = DsingleMuA, DsingleMuB, DsingleMuC, DsingleMuD, DMETA, DMETB, DMETC, DMETD
+data_obs = DsingleMuA, DsingleMuB, DsingleMuC, DsingleMuD, DMETA, DMETB, DMETC, DMETD, DTauA, DTauB, DTauC, DTauD
 TT       = TTfullyHad, TTfullyLep, TTsemiLep
 W        = WJets_HT_0_70, WJets_HT_70_100, WJets_HT_100_200, WJets_HT_200_400, WJets_HT_400_600, WJets_HT_600_800, WJets_HT_800_1200, WJets_HT_1200_2500, WJets_HT_2500_Inf
 DY       = DY_NLO_incl_stitch, DY_NLO_0J, DY_NLO_1J, DY_NLO_2J, DY_NLO_Pt0To50, DY_NLO_Pt50To100, DY_NLO_Pt100To250, DY_NLO_Pt250To400, DY_NLO_Pt400To650, DY_NLO_Pt650ToInf

--- a/interface/smallTree_HHbtag.h
+++ b/interface/smallTree_HHbtag.h
@@ -210,6 +210,9 @@ struct smallTree
       m_lumi = -1. ;
       m_triggerbit = -1. ;
       m_pass_triggerbit = -1. ;
+	  m_legacyAccept = -1;
+	  m_metAccept = -1;
+	  m_singletauAccept = -1;
       m_cross_monitoring_trig = false ;
       m_rho = -1. ;
 
@@ -1215,6 +1218,9 @@ struct smallTree
 
       m_smallT->Branch ("triggerbit", &m_triggerbit, "triggerbit/L") ;
       m_smallT->Branch ("pass_triggerbit", &m_pass_triggerbit, "pass_triggerbit/I") ;
+	  m_smallT->Branch ("legacyAccept", &m_legacyAccept, "legacyAccept/I") ;
+	  m_smallT->Branch ("metAccept", &m_metAccept, "metAccept/I") ;
+	  m_smallT->Branch ("singletauAccept", &m_singletauAccept, "singletauAccept/I") ;
       m_smallT->Branch ("cross_monitoring_trig", &m_cross_monitoring_trig, "cross_monitoring_trig/O") ;
       m_smallT->Branch ("rho", &m_rho, "rho/F") ;
 
@@ -2177,6 +2183,9 @@ struct smallTree
   Int_t m_lumi ;
   Long64_t m_triggerbit ;
   int m_pass_triggerbit ;
+  int m_legacyAccept ;
+  int m_metAccept ;
+  int m_singletauAccept ;
   Bool_t m_cross_monitoring_trig ;
   Float_t m_rho ;
 

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -1971,7 +1971,7 @@ int main (int argc, char** argv)
 		  bool metAccept       = passMETTrg    and trgRegions["met"]; 
 		  bool singletauAccept = passSingleTau and trgRegions["tau"];
 		  if (!isMC) {
-			legacyAccept    = legacyAccept    and !isMETDataset and (!isTauDataset or pType!=2);
+			legacyAccept    = legacyAccept    and !isMETDataset and (!isTauDataset or pType==2);
 			metAccept       = metAccept       and isMETDataset;
 			singletauAccept = singletauAccept and !isMETDataset and isTauDataset;
 		  }

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -217,7 +217,7 @@ int main (int argc, char** argv)
 
   int datasetType = atoi(argv[33]);
   bool isMETDataset = datasetType == DataType::kMET;
-  bool isTauDataset = datasetType == DataType::kSingleTau; // currently not used
+  bool isTauDataset = datasetType == DataType::kSingleTau;
   cout << "** INFO: isMETDataset  : " << isMETDataset << endl;
   cout << "** INFO: isTauDataset  : " << isTauDataset << endl;
   if (isMC) {
@@ -1971,9 +1971,9 @@ int main (int argc, char** argv)
 		  bool metAccept       = passMETTrg    and trgRegions["met"]; 
 		  bool singletauAccept = passSingleTau and trgRegions["tau"];
 		  if (!isMC) {
-			legacyAccept    = legacyAccept    and !isMETDataset;
+			legacyAccept    = legacyAccept    and !isMETDataset and (!isTauDataset or pType!=2);
 			metAccept       = metAccept       and isMETDataset;
-			singletauAccept = singletauAccept and !isMETDataset;
+			singletauAccept = singletauAccept and !isMETDataset and isTauDataset;
 		  }
 		  bool triggerAccept = legacyAccept or metAccept or singletauAccept;
 
@@ -2010,6 +2010,7 @@ int main (int argc, char** argv)
 		  if (!triggerAccept) continue;
 		  
 		  theSmallTree.m_pass_triggerbit = pass_triggerbit;
+
 		  ec.Increment ("Trigger", EvtW); // for data, EvtW is 1.0
 		  if (isHHsignal && pairType == genHHDecMode) {
 			ecHHsig[genHHDecMode].Increment ("Trigger", EvtW);
@@ -2018,6 +2019,10 @@ int main (int argc, char** argv)
 		  theSmallTree.m_isLeptrigger = passTrg;
 		  theSmallTree.m_isMETtrigger = passMETTrg;
 		  theSmallTree.m_isSingleTautrigger = passSingleTau;
+
+		  theSmallTree.m_legacyAccept = legacyAccept;
+		  theSmallTree.m_metAccept = metAccept;
+		  theSmallTree.m_singletauAccept = singletauAccept;
 		} // end if applyTriggers
 
       // ----------------------------------------------------------


### PR DESCRIPTION
- We want to finally introduce the Tau PD to the etau and mutau channels. This has to be done carefully, as event duplication is bound to happen if no specific checks are made. For the tautau channel (```pType==2```) we do not care, since the channel already uses the Tau PD, and duplication is not possible. For the remaining channels, we have to guarantee that only events belonging to the Tau PD are assigned to the singleTau trigger region, and that only events belong to the EGamma or Mu PDs are assigned to the legacy trigger region. The former is guaranteed by construction, given the different pT cuts. The latter is not guaranteed by default, and is enforced in this PR.

- We added some variables to enable some possible debugging later on.

Please have a look, and let me know if the logic seems correct.