### PR TITLE
bugfix: store the corrected lepton energies

### DIFF
--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -2361,7 +2361,7 @@ int main (int argc, char** argv)
 	  
 	  theSmallTree.m_dau1_eta = tlv_firstLepton.Eta () ;
 	  theSmallTree.m_dau1_phi = tlv_firstLepton.Phi () ;
-	  theSmallTree.m_dau1_e = theBigTree.daughters_e->at (firstDaughterIndex) ;
+	  theSmallTree.m_dau1_e = tlv_firstLepton.E();
 	  theSmallTree.m_dau1_dxy = theBigTree.dxy->at(firstDaughterIndex) ;
 	  theSmallTree.m_dau1_dz  = theBigTree.dz->at(firstDaughterIndex) ;
 	  theSmallTree.m_dau1_flav = theBigTree.daughters_charge->at (firstDaughterIndex) * (theBigTree.particleType->at (firstDaughterIndex) + 1) ;
@@ -2415,7 +2415,7 @@ int main (int argc, char** argv)
 
 	  theSmallTree.m_dau2_eta = tlv_secondLepton.Eta () ;
 	  theSmallTree.m_dau2_phi = tlv_secondLepton.Phi () ;
-	  theSmallTree.m_dau2_e = theBigTree.daughters_e->at (secondDaughterIndex) ;
+	  theSmallTree.m_dau2_e = tlv_secondLepton.E();
 	  theSmallTree.m_dau2_dxy = theBigTree.dxy->at(secondDaughterIndex) ;
 	  theSmallTree.m_dau2_dz  = theBigTree.dz->at(secondDaughterIndex) ;
 	  theSmallTree.m_dau2_flav = theBigTree.daughters_charge->at (secondDaughterIndex) * (theBigTree.particleType->at (secondDaughterIndex) + 1) ;


### PR DESCRIPTION
This PR fixes that for the nominal energies of dau1 and dau2 the uncorrected values from the bigtree were used, while for the up and down shift of the different uncertainty sources as well as pt (nominal + shifts) the corrected (ees/eer, therefore only affecting electrons) values were used

https://github.com/LLRCMS/KLUBAnalysis/pull/385