### PR TITLE
Apply PFJetID to AK8 Puppi jets

### DIFF
--- a/interface/bigTree.h
+++ b/interface/bigTree.h
@@ -262,6 +262,7 @@ class bigTree {
   std::vector<float>   *bParticleNetAK4JetTags_probg;
   std::vector<float>   *pfCombinedMVAV2BJetTags;
   std::vector<int>     *PFjetID;
+  std::vector<int>     *PFjetID_AK8Puppi;
   std::vector<float>   *jetRawf;
   std::vector<float>   *jets_JER;
 
@@ -657,6 +658,7 @@ class bigTree {
   TBranch        *b_bParticleNetAK4JetTags_probg;
   TBranch        *b_pfCombinedMVAV2BJetTags; //!
   TBranch        *b_PFjetID;   //!
+  TBranch        *b_PFjetID_AK8Puppi;   //!
   TBranch        *b_jetRawf;   //!
   TBranch        *b_jets_JER ; //!
   TBranch        *b_ak8jets_px;
@@ -922,6 +924,7 @@ class bigTree {
     bParticleNetAK4JetTags_probg = 0;
     pfCombinedMVAV2BJetTags = 0;
     PFjetID = 0;
+    PFjetID_AK8Puppi = 0;
     jetRawf = 0;
     jets_JER = 0;
     ak8jets_px = 0;
@@ -1139,6 +1142,7 @@ class bigTree {
     fChain->SetBranchAddress("bParticleNetAK4JetTags_probg", &bParticleNetAK4JetTags_probg, &b_bParticleNetAK4JetTags_probg);
     fChain->SetBranchAddress("pfCombinedMVAV2BJetTags", &pfCombinedMVAV2BJetTags, &b_pfCombinedMVAV2BJetTags);
     fChain->SetBranchAddress("PFjetID", &PFjetID, &b_PFjetID);
+    fChain->SetBranchAddress("PFjetID_AK8Puppi", &PFjetID_AK8Puppi, &b_PFjetID_AK8Puppi);
     fChain->SetBranchAddress("jetRawf", &jetRawf, &b_jetRawf);
     fChain->SetBranchAddress("jets_JER", &jets_JER, &b_jets_JER);
     fChain->SetBranchAddress("ak8jets_px",                                 &ak8jets_px, &b_ak8jets_px);

--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -5377,8 +5377,9 @@ int main (int argc, char** argv)
 			tlv_fj *= smears_AK8[ifj];
 		  }
 		  
-		  if (tlv_fj.Pt() < 250 or theBigTree.ak8jets_SoftDropMass->at(ifj) < 30 or
-			  tlv_fj.DeltaR(tlv_firstLepton) < 0.8 or tlv_fj.DeltaR(tlv_secondLepton) < 0.8) {
+		  if(tlv_fj.Pt() < 250 or theBigTree.ak8jets_SoftDropMass->at(ifj) < 30 or
+			tlv_fj.DeltaR(tlv_firstLepton) < 0.8 or tlv_fj.DeltaR(tlv_secondLepton) < 0.8 or
+			theBigTree.PFjetID_AK8Puppi->at(ifj) < PFjetID_WP) { // 0: don't pass PF Jet ID; 1: tight, 2: tightLepVeto
 			continue;
 		  }
 			    


### PR DESCRIPTION
This PR adds a check for the AK8 jet ID that we recently added to our big nutples