### PR TITLE
Fix data samples handling - boosted corrections 

### DIFF
--- a/interface/smallTree_HHbtag.h
+++ b/interface/smallTree_HHbtag.h
@@ -772,14 +772,14 @@ struct smallTree
       m_HHbregrsvfit_phi = -1.;
       m_HHbregrsvfit_m   = -1.;
       m_fatjet_particleNetMDJetTags_HP_SF = 1.;
-      m_fatjet_particleNetMDJetTags_HP_SF_up = 1.;
-      m_fatjet_particleNetMDJetTags_HP_SF_down = 1.;
+      m_fatjet_particleNetMDJetTags_HP_SF_up = 0.;
+      m_fatjet_particleNetMDJetTags_HP_SF_down = 0.;
       m_fatjet_particleNetMDJetTags_MP_SF = 1.;
-      m_fatjet_particleNetMDJetTags_MP_SF_up = 1.;
-      m_fatjet_particleNetMDJetTags_MP_SF_down = 1.;
+      m_fatjet_particleNetMDJetTags_MP_SF_up = 0.;
+      m_fatjet_particleNetMDJetTags_MP_SF_down = 0.;
       m_fatjet_particleNetMDJetTags_LP_SF = 1.;
-      m_fatjet_particleNetMDJetTags_LP_SF_up = 1.;
-      m_fatjet_particleNetMDJetTags_LP_SF_down = 1.;
+      m_fatjet_particleNetMDJetTags_LP_SF_up = 0.;
+      m_fatjet_particleNetMDJetTags_LP_SF_down = 0.;
 
       m_subjetjet1_pt = -1. ;
       m_subjetjet1_eta  = -1. ;


### PR DESCRIPTION
In the previous version of the code, data samples were not handled. An if(isMC) condition has been added for the gen matching, and boosted corrections are now stored only for MC samples. For data samples, the default value of 1 is used instead. I have initialized the up and down variations to 0.

This version of the code has been tested on a couple of Tau samples using the code from PR #403, and it works fine