### PR TITLE
Limit SC eta from -2.499 to 2.499

### DIFF
--- a/test/skimNtuple_HHbtag.cpp
+++ b/test/skimNtuple_HHbtag.cpp
@@ -2714,10 +2714,10 @@ int main (int argc, char** argv)
 
 	  float leg1pt  = tlv_firstLepton.Pt();
 	  float leg1eta = TMath::Abs(tlv_firstLepton.Eta());
-	  float leg1eta_SC = theBigTree.daughters_SCeta->at(firstDaughterIndex); // needed for electron SFs and eta gap veto
+	  float leg1eta_SC = std::max(-2.499f, std::min(theBigTree.daughters_SCeta->at(firstDaughterIndex), 2.499f)); // needed for electron SFs and eta gap veto
 	  float leg2pt  = tlv_secondLepton.Pt();
 	  float leg2eta = TMath::Abs(tlv_secondLepton.Eta());
-	  float leg2eta_SC = theBigTree.daughters_SCeta->at(secondDaughterIndex); // needed for electron SFs and eta gap veto
+	  float leg2eta_SC = std::max(-2.499f, std::min(theBigTree.daughters_SCeta->at(secondDaughterIndex), 2.499f)); // needed for electron SFs and eta gap veto
 
 	  // the first tau only makes sense in the TauTau channel
 	  int tau1DM  = static_cast<int>(theSmallTree.m_dau1_decayMode);


### PR DESCRIPTION
This PR fixes a minor issue with the SC eta. Since we cut on the eta of the track, but use the eta of the super cluster for the SFs, in very rare cases the SC could be outside of the SF range (-2.5 to 2.5). I now limited the SC eta from -2.499 to 2.499